### PR TITLE
[Feature] 커뮤니티 게시글 CRUD 로직 구현 (이미지 업로드는 S3 추가 후 추후 구현 예정)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/community/application/command/CreatePostCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/CreatePostCommand.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.community.application.command;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record CreatePostCommand(
+        Long authorId,
+        PostTagType category,
+        String title,
+        String content,
+        Long countryId,
+        Long lectureId,
+        List<String> freeTags,
+        List<MultipartFile> images
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/DeletePostCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/DeletePostCommand.java
@@ -1,0 +1,6 @@
+package com.kidmily.algoga_server.community.application.command;
+
+public record DeletePostCommand(
+        Long postId,
+        Long requesterId
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/UpdatePostCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/UpdatePostCommand.java
@@ -1,0 +1,16 @@
+package com.kidmily.algoga_server.community.application.command;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+
+import java.util.List;
+
+public record UpdatePostCommand(
+        Long postId,
+        Long requesterId,
+        PostTagType category,
+        String title,
+        String content,
+        Long countryId,
+        Long lectureId,
+        List<String> freeTags
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostCommandService.java
@@ -1,0 +1,101 @@
+package com.kidmily.algoga_server.community.application.service;
+
+import com.kidmily.algoga_server.community.application.command.CreatePostCommand;
+import com.kidmily.algoga_server.community.application.command.DeletePostCommand;
+import com.kidmily.algoga_server.community.application.command.UpdatePostCommand;
+import com.kidmily.algoga_server.community.application.usecase.PostCommandUseCase;
+import com.kidmily.algoga_server.community.domain.model.Post;
+import com.kidmily.algoga_server.community.domain.repository.PostRepository;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostCommandService implements PostCommandUseCase {
+
+    private final PostRepository postRepository;
+
+
+    @Override
+    public Long handle(CreatePostCommand command) {
+
+        // 받은 정보 확인 로그
+        log.info("[PostCommandService] 게시글 작성 요청 수신 - authorId: {}, category: {}, title: {}, freeTagsCount: {}",
+                command.authorId(),
+                command.category(),
+                command.title(),
+                command.freeTags() == null ? 0 : command.freeTags().size());
+
+        Post newPost = Post.create(
+
+                command.authorId(),
+                command.category(),
+                command.title(),
+                command.content(),
+                command.countryId(),
+                command.lectureId(),
+                command.freeTags(),
+                List.of()  // 이미지는 S3 구현 후 추가
+        );
+
+
+        Post savedPost = postRepository.save(newPost);
+
+        log.info("[PostCommandService] 게시글 작성 완료 - postId: {}", savedPost.getId());
+
+        return savedPost.getId();
+    }
+
+    @Override
+    public Long handle(UpdatePostCommand command) {
+        log.info("[PostCommandService] 게시글 수정 요청 수신 - postId: {}, requesterId: {}",
+                command.postId(), command.requesterId());
+
+        Post post = postRepository.findById(command.postId())
+                .orElseThrow(() -> {
+                    log.warn("[PostCommandService] 게시글을 찾을 수 없음 - postId: {}", command.postId());
+                    return new BusinessException(PostErrorCode.POST_NOT_FOUND);
+                });
+
+        post.update(
+                command.requesterId(),
+                command.category(),
+                command.title(),
+                command.content(),
+                command.countryId(),
+                command.lectureId(),
+                command.freeTags(),
+                List.of()
+        );
+
+        Post updatedPost = postRepository.update(post);  // save → update
+
+        log.info("[PostCommandService] 게시글 수정 완료 - postId: {}", updatedPost.getId());
+        return updatedPost.getId();
+    }
+
+    @Override
+    public void handle(DeletePostCommand command) {
+        log.info("[PostCommandService] 게시글 삭제 요청 수신 - postId: {}, requesterId: {}",
+                command.postId(), command.requesterId());
+
+        Post post = postRepository.findById(command.postId())
+                .orElseThrow(() -> {
+                    log.warn("[PostCommandService] 게시글을 찾을 수 없음 - postId: {}", command.postId());
+                    return new BusinessException(PostErrorCode.POST_NOT_FOUND);
+                });
+
+        post.delete(command.requesterId());
+        postRepository.delete(post);
+
+        log.info("[PostCommandService] 게시글 삭제 완료 - postId: {}", command.postId());
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
@@ -1,0 +1,88 @@
+package com.kidmily.algoga_server.community.application.service;
+
+import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
+import com.kidmily.algoga_server.community.domain.model.Post;
+import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
+import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
+import com.kidmily.algoga_server.community.domain.repository.PostRepository;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataCommentRepository;
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataLikeDislikeRepository;
+import com.kidmily.algoga_server.community.presentation.api.response.CommentResponse;
+import com.kidmily.algoga_server.community.presentation.api.response.PostResponse;
+import com.kidmily.algoga_server.community.presentation.api.response.TagResponse;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostQueryService implements PostQueryUseCase {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final LikeDislikeRepository likeDislikeRepository;
+
+    @Override
+    @Transactional
+    public PostResponse getPost(Long postId) {
+        log.info("[PostQueryService] 게시글 단건 조회 요청 - postId: {}", postId);
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    log.warn("[PostQueryService] 게시글을 찾을 수 없음 - postId: {}", postId);
+                    return new BusinessException(PostErrorCode.POST_NOT_FOUND);
+                });
+
+        // 조회수 증가
+        post.increaseViewCount();
+        postRepository.update(post);
+
+        // 좋아요/싫어요 수 카운트
+        Long likeCount = likeDislikeRepository.countLikes(TargetType.POST, postId);
+        Long dislikeCount = likeDislikeRepository.countDislikes(TargetType.POST, postId);
+
+
+        List<CommentResponse> comments = commentRepository
+                .findActiveCommentsByPostId(postId)
+                .stream()
+                .map(c -> new CommentResponse(c.getCommentId(), c.getUserId(), c.getContent(), c.getCreatedAt()))
+                .toList();
+
+        // 💡 [수정] 태그 변환 로직을 메서드 안쪽으로 이동시켰습니다.
+        Stream<TagResponse> categoryStream = post.getCategory() != null ?
+                Stream.of(TagResponse.fromCategory(post.getCategory())) : Stream.empty();
+
+        Stream<TagResponse> freeTagStream = post.getFreeTags() != null ?
+                post.getFreeTags().stream().map(TagResponse::fromFreeTag) : Stream.empty();
+
+        List<TagResponse> tags = Stream.concat(categoryStream, freeTagStream).toList();
+
+        return new PostResponse(
+                post.getId(),
+                post.getAuthorId(),
+                tags,
+                post.getTitle(),
+                post.getContent(),
+                post.getCountryId(),
+                post.getLectureId(),
+                post.getImageUrls(),
+                post.getViewCount(),
+                likeCount,
+                dislikeCount,
+                (long) comments.size(),
+                comments,
+                post.getCreatedAt()
+        );
+    }
+
+
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostCommandUseCase.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.community.application.usecase;
+
+import com.kidmily.algoga_server.community.application.command.CreatePostCommand;
+import com.kidmily.algoga_server.community.application.command.DeletePostCommand;
+import com.kidmily.algoga_server.community.application.command.UpdatePostCommand;
+import com.kidmily.algoga_server.example.application.command.CreateExampleCommand;
+
+// 외부 계층(컨트롤러)가 바라보는 인터페이스
+public interface PostCommandUseCase {
+    Long handle(CreatePostCommand command);
+    Long handle(UpdatePostCommand command);
+    void handle(DeletePostCommand command);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostQueryUseCase.java
@@ -1,0 +1,7 @@
+package com.kidmily.algoga_server.community.application.usecase;
+
+import com.kidmily.algoga_server.community.presentation.api.response.PostResponse;
+
+public interface PostQueryUseCase {
+    PostResponse getPost(Long postId);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
@@ -1,0 +1,170 @@
+package com.kidmily.algoga_server.community.domain.model;
+
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    private static final int MAX_IMAGE_COUNT = 10;
+    private static final int MAX_FREE_TAG_COUNT = 10;
+
+    private Long id;
+    private Long authorId;
+    private PostTagType category;
+    private String title;
+    private String content;
+    private Long countryId;
+    private Long lectureId;
+    private List<String> freeTags;
+    private List<String> imageUrls;
+    private LocalDateTime createdAt;
+    private Boolean isDeleted;
+    private Integer viewCount;
+
+    // 1. 생성 시점의 생성자
+    private Post(Long authorId, PostTagType category, String title, String content,
+                 Long countryId, Long lectureId, List<String> freeTags, List<String> imageUrls) {
+        validateCategory(category);
+        validateTitle(title);
+        validateContent(content);
+        validateFreeTags(freeTags);
+        validateImages(imageUrls);
+
+        this.authorId = authorId;
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.countryId = countryId;
+        this.lectureId = lectureId;
+        this.freeTags = freeTags;
+        this.imageUrls = imageUrls;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // DB 조회 후 재구성용 생성자
+    private Post(Long id, Long authorId, PostTagType category, String title, String content,
+                 Long countryId, Long lectureId, List<String> freeTags, List<String> imageUrls,
+                 LocalDateTime createdAt, Integer viewCount, Boolean isDeleted) {
+        this.id = id;
+        this.authorId = authorId;
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.countryId = countryId;
+        this.lectureId = lectureId;
+        this.freeTags = freeTags;
+        this.imageUrls = imageUrls;
+        this.createdAt = createdAt;
+        this.viewCount = viewCount;
+        this.isDeleted = isDeleted;
+    }
+
+    // 2. 정적 팩토리 메서드
+    // 게시글 생성
+    public static Post create(Long authorId, PostTagType category, String title, String content,
+                              Long countryId, Long lectureId, List<String> freeTags, List<String> imageUrls) {
+
+
+        return new Post(authorId, category, title, content, countryId, lectureId, freeTags, imageUrls);
+    }
+
+    // 게시글 수정
+    public void update(Long requesterId, PostTagType category, String title, String content,
+                       Long countryId, Long lectureId, List<String> freeTags, List<String> imageUrls) {
+        // 권한 검증
+        validateOwnerForUpdate(requesterId);
+
+        // 비즈니스 규칙 검증
+        validateCategory(category);
+        validateTitle(title);
+        validateContent(content);
+        validateFreeTags(freeTags);
+        validateImages(imageUrls);
+
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.countryId = countryId;
+        this.lectureId = lectureId;
+        this.freeTags = freeTags;
+        this.imageUrls = imageUrls;
+    }
+
+    // 조회수 증가
+    public void increaseViewCount() {
+        this.viewCount = (this.viewCount == null ? 0 : this.viewCount) + 1;
+    }
+
+    private void validateOwnerForUpdate(Long requesterId) {
+        if (!this.authorId.equals(requesterId)) {
+            throw new BusinessException(PostErrorCode.POST_UPDATE_FORBIDDEN);
+        }
+    }
+
+    private void validateOwnerForDelete(Long requesterId) {
+        if (!this.authorId.equals(requesterId)) {
+            throw new BusinessException(PostErrorCode.POST_DELETE_FORBIDDEN);
+        }
+    }
+
+    // 게시글 삭제
+    public void delete(Long requesterId) {
+        validateOwnerForDelete(requesterId);
+        this.isDeleted = true;
+    }
+
+
+    public static Post reconstitute(Long id, Long authorId, PostTagType category, String title, String content,
+                                    Long countryId, Long lectureId, List<String> freeTags, List<String> imageUrls,
+                                    LocalDateTime createdAt, Integer viewCount, Boolean isDeleted) {
+        return new Post(id, authorId, category, title, content, countryId, lectureId,
+                freeTags, imageUrls, createdAt, viewCount, isDeleted);
+    }
+
+    // 3. 도메인 규칙 검증 메서드 (상단 import에 맞게 BusinessException으로 일관성 유지)
+    private void validateCategory(PostTagType category) {
+        if (category == null) {
+            throw new BusinessException(PostErrorCode.POST_CATEGORY_INVALID);
+        }
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new BusinessException(PostErrorCode.POST_TITLE_BLANK);
+        }
+    }
+
+    private void validateContent(String content) {
+        if (content == null || content.trim().isEmpty()) {
+            throw new BusinessException(PostErrorCode.POST_CONTENT_BLANK);
+        }
+    }
+
+    private void validateFreeTags(List<String> freeTags) {
+        if (freeTags != null && freeTags.size() > MAX_FREE_TAG_COUNT) {
+            throw new BusinessException(PostErrorCode.POST_FREE_TAG_LIMIT_EXCEEDED);
+        }
+        // 중복 검증
+        if (freeTags != null) {
+            long distinctCount = freeTags.stream().distinct().count();
+            if (distinctCount != freeTags.size()) {
+                throw new BusinessException(PostErrorCode.POST_FREE_TAG_DUPLICATED);
+            }
+        }
+    }
+
+    private void validateImages(List<String> imageUrls) {
+        if (imageUrls != null && imageUrls.size() > MAX_IMAGE_COUNT) {
+            throw new BusinessException(PostErrorCode.POST_IMAGE_COUNT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/CommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.community.domain.repository;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.CommentJpaEntity;
+
+import java.util.List;
+
+public interface CommentRepository {
+    List<CommentJpaEntity> findActiveCommentsByPostId(Long postId);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/LikeDislikeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/LikeDislikeRepository.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.community.domain.repository;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+
+public interface LikeDislikeRepository {
+    Long countLikes(TargetType targetType, Long targetId);
+    Long countDislikes(TargetType targetType, Long targetId);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.community.domain.repository;
+
+import com.kidmily.algoga_server.community.domain.model.Post;
+
+import java.util.Optional;
+
+// Application, Domain 계층이 사용할 레포지토리 포트(Port)
+public interface PostRepository {
+    Post save(Post post);
+    Optional<Post> findById(Long id);
+    Post update(Post post);
+    void delete(Post post);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
@@ -1,0 +1,36 @@
+package com.kidmily.algoga_server.community.exception;
+
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorCode implements BaseErrorCode {
+
+    // 400 - 입력값 검증
+    POST_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "POST_001", "유효하지 않은 카테고리입니다."),
+    POST_CATEGORY_BLANK(HttpStatus.BAD_REQUEST, "POST_00X", "카테고리는 필수입니다."),
+    POST_FREE_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "POST_002", "자유 태그는 최대 10개까지 등록 가능합니다."),
+    POST_COURSE_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "POST_003", "수강강의 태그는 최대 10개까지 등록 가능합니다."),
+    POST_FREE_TAG_DUPLICATED(HttpStatus.BAD_REQUEST, "POST_00X", "자유 태그에 중복된 값이 있습니다."),
+    POST_TITLE_BLANK(HttpStatus.BAD_REQUEST, "POST_007", "제목은 필수입니다."),
+    POST_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "POST_008", "본문은 필수입니다."),
+
+    // 401 - 인증
+    POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_004", "게시글 작성 권한이 없습니다."),
+
+    // 413 - 이미지
+    POST_IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_005", "이미지는 최대 10장까지 업로드 가능합니다."),
+    POST_IMAGE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_006", "이미지 한 장의 크기는 최대 10MB입니다."),
+
+    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_00X", "게시글을 수정할 권한이 없습니다."),
+    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_00X", "게시글을 삭제할 권한이 없습니다."),
+
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_00X", "게시글을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/PostMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/PostMapper.java
@@ -1,0 +1,100 @@
+package com.kidmily.algoga_server.community.infrastructure.mapper;
+import com.kidmily.algoga_server.community.domain.model.Post;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostImage;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTag;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+import java.util.List;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface PostMapper {
+
+    // toJpaEntity는 필드 구조가 달라 자동 매핑 불가 → default로 직접 구현
+    default PostJpaEntity toJpaEntity(Post post) {
+        if (post == null) return null;
+
+        PostJpaEntity jpaEntity = PostJpaEntity.builder()
+                .authorId(post.getAuthorId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .countryId(post.getCountryId())
+                .lectureId(post.getLectureId())
+                .build();
+
+        // 카테고리 태그 추가
+        if (post.getCategory() != null) {
+            PostTag categoryTag = PostTag.builder()
+                    .post(jpaEntity)
+                    .tagType(post.getCategory())
+                    .tagName(post.getCategory().name())
+                    .build();
+            jpaEntity.getPostTags().add(categoryTag);
+        }
+
+        // 자유 태그 추가
+        if (post.getFreeTags() != null) {
+            post.getFreeTags().forEach(tagName -> {
+                PostTag freeTag = PostTag.builder()
+                        .post(jpaEntity)
+                        .tagType(PostTagType.FREE)
+                        .tagName(tagName)
+                        .build();
+                jpaEntity.getPostTags().add(freeTag);
+            });
+        }
+
+        // 이미지 추가
+        if (post.getImageUrls() != null) {
+            for (int i = 0; i < post.getImageUrls().size(); i++) {
+                PostImage image = PostImage.builder()
+                        .post(jpaEntity)
+                        .imageUrl(post.getImageUrls().get(i))
+                        .orderNum(i)
+                        .build();
+                jpaEntity.getPostImages().add(image);
+            }
+        }
+
+        return jpaEntity;
+    }
+
+    // toDomain도 reconstitute 사용으로 default
+    default Post toDomain(PostJpaEntity jpaEntity) {
+        if (jpaEntity == null) {
+            return null;
+        }
+
+        PostTagType category = jpaEntity.getPostTags().stream()
+                .filter(tag -> tag.getTagType() != PostTagType.FREE)
+                .map(PostTag::getTagType)
+                .findFirst()
+                .orElse(null);
+
+        List<String> freeTags = jpaEntity.getPostTags().stream()
+                .filter(tag -> tag.getTagType() == PostTagType.FREE)
+                .map(PostTag::getTagName)
+                .toList();
+
+        List<String> imageUrls = jpaEntity.getPostImages().stream()
+                .map(PostImage::getImageUrl)
+                .toList();
+
+        return Post.reconstitute(
+                jpaEntity.getPostId(),
+                jpaEntity.getAuthorId(),
+                category,
+                jpaEntity.getTitle(),
+                jpaEntity.getContent(),
+                jpaEntity.getCountryId(),
+                jpaEntity.getLectureId(),
+                freeTags,
+                imageUrls,
+                jpaEntity.getCreatedAt(),
+                jpaEntity.getViewCount(),
+                jpaEntity.getIsDeleted()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence;
+
+import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.CommentJpaEntity;
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryAdapter implements CommentRepository {
+
+    private final SpringDataCommentRepository springDataRepository;
+
+    @Override
+    public List<CommentJpaEntity> findActiveCommentsByPostId(Long postId) {
+        return springDataRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/LikeDislikeRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/LikeDislikeRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence;
+
+import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataLikeDislikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeDislikeRepositoryAdapter implements LikeDislikeRepository {
+
+    private final SpringDataLikeDislikeRepository springDataRepository;
+
+    @Override
+    public Long countLikes(TargetType targetType, Long targetId) {
+        return springDataRepository.countByTargetTypeAndTargetIdAndLike(targetType, targetId, true);
+    }
+
+    @Override
+    public Long countDislikes(TargetType targetType, Long targetId) {
+        return springDataRepository.countByTargetTypeAndTargetIdAndLike(targetType, targetId, false);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
@@ -1,0 +1,89 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence;
+
+import com.kidmily.algoga_server.community.domain.model.Post;
+import com.kidmily.algoga_server.community.domain.repository.PostRepository;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.infrastructure.mapper.PostMapper;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTag;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataPostRepository;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryAdapter implements PostRepository {
+
+    private final SpringDataPostRepository springDataRepository;
+    private final PostMapper postMapper;
+
+    @Override
+    public Post save(Post post) {
+        // MapStruct를 통한 Domain -> JPA Entity 매핑
+        PostJpaEntity jpaEntity = postMapper.toJpaEntity(post);
+
+        // DB 저장
+        PostJpaEntity savedEntity = springDataRepository.save(jpaEntity);
+
+        // MapStruct를 통한 JPA Entity -> Domain Entity 매핑
+        return postMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<Post> findById(Long id) {
+        return springDataRepository.findById(id)
+                .map(postMapper::toDomain);
+    }
+
+    @Override
+    public Post update(Post post) {
+        // 기존 엔티티 조회
+        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId())
+                .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+
+        // 기존 태그/이미지 전부 삭제 (orphanRemoval이 처리)
+        jpaEntity.getPostTags().clear();
+        jpaEntity.getPostImages().clear();
+
+        // 필드 업데이트
+        jpaEntity.update(
+                post.getCategory(),
+                post.getTitle(),
+                post.getContent(),
+                post.getCountryId(),
+                post.getLectureId()
+        );
+
+        // 새 태그 추가
+        if (post.getCategory() != null) {
+            jpaEntity.getPostTags().add(PostTag.builder()
+                    .post(jpaEntity)
+                    .tagType(post.getCategory())
+                    .tagName(post.getCategory().name())
+                    .build());
+        }
+        if (post.getFreeTags() != null) {
+            post.getFreeTags().forEach(tagName ->
+                    jpaEntity.getPostTags().add(PostTag.builder()
+                            .post(jpaEntity)
+                            .tagType(PostTagType.FREE)
+                            .tagName(tagName)
+                            .build()));
+        }
+
+        PostJpaEntity savedEntity = springDataRepository.save(jpaEntity);
+        return postMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public void delete(Post post) {
+        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId())
+                .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+        jpaEntity.softDelete();  // PostJpaEntity에 이미 있음
+        springDataRepository.save(jpaEntity);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/CommentJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/CommentJpaEntity.java
@@ -1,0 +1,57 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CommentJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "parent_id")
+    private Long parentId;  // 대댓글 처리
+
+    @Column(name = "content", nullable = false, length = 500)
+    private String content;
+
+    @Column(name = "is_deleted")
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/LikeDislikeJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/LikeDislikeJpaEntity.java
@@ -1,0 +1,41 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "likes_dislikes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LikeDislikeJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long likeId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private TargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "is_like", nullable = false)
+    private Boolean isLike;  // true: 좋아요, false: 싫어요
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostImage.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostImage.java
@@ -1,0 +1,29 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "post_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long postImageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PostJpaEntity post;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "order_num")
+    private Integer orderNum;
+}
+

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
@@ -1,0 +1,91 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+
+
+public class PostJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long postId;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+//    private User user;
+
+    @Column(name = "user_id")
+    private Long authorId;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "country_id")
+    private Long countryId;
+
+    @Column(name = "lecture_id")
+    private Long lectureId;
+
+    @Column(name = "view_count")
+    @Builder.Default
+    private Integer viewCount = 0;
+
+    @Column(name = "is_deleted")
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PostImage> postImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PostTag> postTags = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void update(PostTagType category, String title, String content,
+                       Long countryId, Long lectureId) {
+        this.title = title;
+        this.content = content;
+        this.countryId = countryId;
+        this.lectureId = lectureId;
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+
+}
+

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTag.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTag.java
@@ -1,0 +1,30 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "post_tags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_tag_id")
+    private Long postTagId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PostJpaEntity post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tag_type", length = 50)
+    private PostTagType tagType;
+
+    @Column(name = "tag_name", length = 100)
+    private String tagName;
+
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTagType.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTagType.java
@@ -1,0 +1,20 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostTagType {
+
+    TRAVEL_REVIEW("여행후기"),
+    TIP_INFO("팁&정보"),
+    QUESTION("질문"),
+    COMPANION("동행 구해요"),
+    COUNTRY("나라"),
+    LECTURE("수강강의"),
+    FREE("자유");
+
+    // 한글 명칭을 저장할 변수 (final로 안전하게 보호)
+    private final String description;
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/TargetType.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/TargetType.java
@@ -1,0 +1,6 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+
+public enum TargetType {
+    POST,
+    COMMENT
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataCommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataCommentRepository.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.CommentJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpringDataCommentRepository extends JpaRepository<CommentJpaEntity, Long> {
+    Long countByPostIdAndIsDeletedFalse(Long postId);
+
+    List<CommentJpaEntity> findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataLikeDislikeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataLikeDislikeRepository.java
@@ -1,0 +1,17 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.LikeDislikeJpaEntity;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SpringDataLikeDislikeRepository extends JpaRepository<LikeDislikeJpaEntity, Long> {
+    @Query("SELECT COUNT(l) FROM LikeDislikeJpaEntity l " +
+            "WHERE l.targetType = :targetType AND l.targetId = :targetId AND l.isLike = :isLike")
+    Long countByTargetTypeAndTargetIdAndLike(
+            @Param("targetType") TargetType targetType,
+            @Param("targetId") Long targetId,
+            @Param("isLike") Boolean isLike
+    );
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
@@ -1,0 +1,7 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataPostRepository extends JpaRepository<PostJpaEntity, Long> {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.community.presentation.advice;
+
+import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.kidmily.algoga_server.community.presentation.api")
+public class CommunityExceptionAdvice implements CommonExceptionAdvice {
+
+    @Override
+    public Logger getLogger() {
+        return log;
+    }
+
+    // 커뮤니티 도메인에서만 발생하는 특수 예외가 있다면 이곳에 추가
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
@@ -1,0 +1,141 @@
+package com.kidmily.algoga_server.community.presentation.api;
+
+import com.kidmily.algoga_server.community.application.command.CreatePostCommand;
+import com.kidmily.algoga_server.community.application.command.DeletePostCommand;
+import com.kidmily.algoga_server.community.application.command.UpdatePostCommand;
+import com.kidmily.algoga_server.community.application.usecase.PostCommandUseCase;
+import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.presentation.api.request.CreatePostRequest;
+import com.kidmily.algoga_server.community.presentation.api.request.UpdatePostRequest;
+import com.kidmily.algoga_server.community.presentation.api.response.CreatePostResponse;
+import com.kidmily.algoga_server.community.presentation.api.response.PostResponse;
+import com.kidmily.algoga_server.community.presentation.api.response.UpdatePostResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+@Tag(name = "Community", description = "커뮤니티 도메인 API")
+public class CommunityController {
+
+    private final PostCommandUseCase postCommandUseCase;
+    private final PostQueryUseCase postQueryUseCase;
+
+    @PostMapping
+    @Operation(summary = "게시글 작성", description = "나라, 자유, 수강강의 태그 및 최대 10장의 사진을 포함해 게시글을 등록합니다.")
+
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {
+            "INVALID_REQUEST",
+            "UNAUTHORIZED"
+    })
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "POST_CATEGORY_INVALID",
+            "POST_FREE_TAG_LIMIT_EXCEEDED",
+            "POST_COURSE_TAG_LIMIT_EXCEEDED",
+            "POST_IMAGE_COUNT_EXCEEDED",
+            "POST_IMAGE_SIZE_EXCEEDED"
+    })
+
+    public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
+            @Valid @RequestBody CreatePostRequest request
+    ) {
+        long currentUserId = 1L;
+        CreatePostCommand command = new CreatePostCommand(
+                currentUserId,
+                request.category(),
+                request.title(),
+                request.content(),
+                request.countryId(),
+                request.lectureId(),         // freeTags 앞으로
+                request.freeTags() == null ? List.of() : request.freeTags(),
+                List.of()
+        );
+                Long createdId = postCommandUseCase.handle(command);
+        CreatePostResponse responseData = new CreatePostResponse(createdId);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("POST_CREATED", "게시글 작성에 성공했습니다.", responseData));
+    }
+
+    @PutMapping("/{postId}")
+    @Operation(summary = "게시글 수정", description = "본인 게시글의 제목, 내용, 카테고리, 태그를 수정합니다.")
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {
+            "INVALID_REQUEST",
+            "UNAUTHORIZED"
+    })
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "POST_NOT_FOUND",
+            "POST_FORBIDDEN",
+            "POST_CATEGORY_INVALID",
+            "POST_FREE_TAG_LIMIT_EXCEEDED"
+    })
+    public ResponseEntity<ApiResponse<UpdatePostResponse>> updatePost(
+            @Parameter(description = "게시글 ID", example = "1")
+            @PathVariable Long postId,
+            @Valid @RequestBody UpdatePostRequest request
+    ) {
+        long currentUserId = 1L;  // TODO: Spring Security 적용 후 교체
+
+        UpdatePostCommand command = new UpdatePostCommand(
+                postId,
+                currentUserId,
+                request.category(),
+                request.title(),
+                request.content(),
+                request.countryId(),
+                request.lectureId(),
+                request.freeTags() == null ? List.of() : request.freeTags()
+        );
+        postCommandUseCase.handle(command);
+        UpdatePostResponse responseData = new UpdatePostResponse(postId);
+
+        return ResponseEntity.ok(ApiResponse.success("POST_UPDATED", "게시글 수정에 성공했습니다.", responseData));
+    }
+
+    @DeleteMapping("/{postId}")
+    @Operation(summary = "게시글 삭제", description = "본인 게시글을 Soft Delete 처리합니다. 연관 댓글도 함께 삭제됩니다.")
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {
+            "UNAUTHORIZED"
+    })
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "POST_NOT_FOUND",
+            "POST_FORBIDDEN"
+    })
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @Parameter(description = "게시글 ID", example = "1")
+            @PathVariable Long postId
+    ) {
+        long currentUserId = 1L;  // TODO: Spring Security 적용 후 교체
+
+        DeletePostCommand command = new DeletePostCommand(postId, currentUserId);
+        postCommandUseCase.handle(command);
+
+        return ResponseEntity.ok(ApiResponse.success("POST_DELETED", "게시글이 삭제되었습니다.", null));
+    }
+
+    // 게시글 상세 조회
+    @GetMapping("/{postId}")
+    @Operation(summary = "게시글 단건 조회", description = "게시글 ID로 상세 정보를 조회합니다. 조회수가 +1 증가합니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {"POST_NOT_FOUND"})
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(
+            @Parameter(description = "게시글 ID", example = "1")
+            @PathVariable Long postId
+    ) {
+        PostResponse responseData = postQueryUseCase.getPost(postId);
+        return ResponseEntity.ok(ApiResponse.success("POST_FOUND", "게시글 조회에 성공했습니다.", responseData));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreatePostRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreatePostRequest.java
@@ -1,0 +1,40 @@
+package com.kidmily.algoga_server.community.presentation.api.request;
+
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "게시물 생성 요청")
+public record CreatePostRequest(
+
+
+        @Schema(description = "카테고리 태그", example = "TRAVEL_REVIEW",
+                allowableValues = {"TRAVEL_REVIEW", "TIP_INFO", "QUESTION", "COMPANION", "COUNTRY", "LECTURE", "FREE"})
+        @NotNull(message = "카테고리는 필수입니다.")
+        PostTagType category,
+
+        @Schema(description = "제목", example = "도쿄 여행 추천 강의 후기")
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+
+        @Schema(description = "본문", example = "일본 여행 준비하면서 들은 강의인데 도움이 많이 됐어요.")
+        @NotBlank(message = "본문은 필수입니다.")
+        String content,
+
+        @Schema(description = "나라 ID (선택)", example = "1")
+        Long countryId,
+
+        @Schema(description = "수강 강의 ID (선택)", example = "3")
+        Long lectureId,
+
+        @Schema(description = "자유 태그 목록 (최대 10개)", example = "[\"도쿄\", \"맛집\", \"여행\"]")
+        @Size(max = 10, message = "자유 태그는 최대 10개입니다.")
+        List<String> freeTags
+
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/UpdatePostRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/UpdatePostRequest.java
@@ -1,0 +1,36 @@
+package com.kidmily.algoga_server.community.presentation.api.request;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+// 사진은 S3 추가 후 구현 에정
+@Schema(description = "게시글 수정 요청")
+public record UpdatePostRequest(
+
+        @Schema(description = "카테고리 태그", example = "TRAVEL_REVIEW")
+        @NotNull(message = "카테고리는 필수입니다.")
+        PostTagType category,
+
+        @Schema(description = "제목", example = "도쿄 여행 후기 (수정)")
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+
+        @Schema(description = "본문", example = "수정한 내용입니다.")
+        @NotBlank(message = "본문은 필수입니다.")
+        String content,
+
+        @Schema(description = "나라 ID (선택)", example = "1")
+        Long countryId,
+
+        @Schema(description = "수강 강의 ID (선택)", example = "3")
+        Long lectureId,
+
+        @Schema(description = "자유 태그 목록 (최대 10개)", example = "[\"도쿄\", \"맛집\"]")
+        @Size(max = 10, message = "자유 태그는 최대 10개입니다.")
+        List<String> freeTags
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CommentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CommentResponse.java
@@ -1,0 +1,19 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        @Schema(description = "댓글 ID", example = "1")
+        Long commentId,
+
+        @Schema(description = "작성자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "내용", example = "와 야경 진짜 예쁘네요!")
+        String content,
+
+        @Schema(description = "작성일시")
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CreatePostResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CreatePostResponse.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시글 작성 응답")
+public record CreatePostResponse(
+        @Schema(description = "생성된 게시글 고유 식별자(ID)", example = "1")
+        Long postId
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/PostResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/PostResponse.java
@@ -1,0 +1,54 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "게시글 상세 조회 응답")
+public record PostResponse(
+
+        @Schema(description = "게시글 ID", example = "1")
+        Long postId,
+
+        @Schema(description = "작성자 ID", example = "1")
+        Long authorId,
+
+        @Schema(description = "태그 목록")
+        List<TagResponse> tags,
+
+        @Schema(description = "제목", example = "도쿄 3박 4일 완벽 여행 후기")
+        String title,
+
+        @Schema(description = "본문", example = "알고가 강의 덕분에 완벽한 도쿄 여행을 다녀왔습니다!")
+        String content,
+
+        @Schema(description = "나라 ID", example = "1")
+        Long countryId,
+
+        @Schema(description = "수강 강의 ID", example = "3")
+        Long lectureId,
+
+        @Schema(description = "이미지 URL 목록")
+        List<String> imageUrls,
+
+        @Schema(description = "조회수", example = "234")
+        Integer viewCount,
+
+        @Schema(description = "좋아요 수", example = "234")
+        Long likeCount,
+
+        @Schema(description = "싫어요 수", example = "1")
+        Long dislikeCount,
+
+        @Schema(description = "댓글 수", example = "45")
+        Long commentCount,
+
+        @Schema(description = "댓글 목록")
+        List<CommentResponse> comments,
+
+        @Schema(description = "작성일시")
+        LocalDateTime createdAt
+
+
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/TagResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/TagResponse.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "태그 응답")
+public record TagResponse(
+        @Schema(description = "태그 타입", example = "TRAVEL_REVIEW")
+        PostTagType tagType,
+        @Schema(description = "태그 이름", example = "여행후기")
+        String tagName
+) {
+        // getDescription()을 사용해 한글명이 매핑되도록 교정!
+        public static TagResponse fromCategory(PostTagType category) {
+                return new TagResponse(category, category.getDescription());
+        }
+
+        public static TagResponse fromFreeTag(String freeTag) {
+                return new TagResponse(PostTagType.FREE, freeTag);
+        }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/UpdatePostResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/UpdatePostResponse.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시글 수정 응답")
+public record UpdatePostResponse(
+        @Schema(description = "수정된 게시글 ID", example = "1")
+        Long postId
+) {}


### PR DESCRIPTION
## 설명
커뮤니티 게시글 CRUD API 구현

- 게시글 작성 `POST /api/v1/posts`
- 게시글 수정 `PUT /api/v1/posts/{postId}`
- 게시글 삭제 `DELETE /api/v1/posts/{postId}` (Soft Delete)
- 게시글 상세 조회 `GET /api/v1/posts/{postId}`

이미지는 S3 추가 후 구현 예정임. 현재는 빈 리스트로 보내줌

## 🔗 Issue
Closes #32

---
## 확인할 사항
- [ ] 게시글 작성 시 카테고리 태그, 자유 태그, 나라/강의 ID가 정상적으로 저장되는지 확인
- [ ] 게시글 수정 시 기존 태그가 삭제되고 새 태그로 교체되는지 확인
- [ ] 게시글 삭제 시 `is_deleted = true`로 Soft Delete 처리되는지 확인
- [ ] 단건 조회 시 태그 목록, 댓글 수, 좋아요/싫어요 수, 조회수가 정상 반환되는지 확인
- [ ] 타인 게시글 수정/삭제 시도 시 403 Forbidden 반환되는지 확인
- [ ] Swagger 문서에서 요청/응답 예시 정상 표시되는지 확인
