### PR TITLE
[Feature] 콘텐츠 매니저 강의 관리 CRUD API 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/common/api/response/PageResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/global/common/api/response/PageResponse.java
@@ -1,0 +1,44 @@
+package com.kidmily.algoga_server.global.common.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Schema(description = "페이지 응답")
+public record PageResponse<T>(
+
+        @Schema(description = "현재 페이지 데이터")
+        List<T> content,
+
+        @Schema(description = "현재 페이지 번호", example = "0")
+        int page,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int size,
+
+        @Schema(description = "전체 데이터 개수", example = "35")
+        long totalElements,
+
+        @Schema(description = "전체 페이지 수", example = "4")
+        int totalPages,
+
+        @Schema(description = "첫 페이지 여부", example = "true")
+        boolean first,
+
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        boolean last
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.lms.application.command;
+
+public record UpdateCourseCommand(
+        String title,
+        String description,
+        String thumbnailUrl,
+        String fileUrl
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
@@ -1,25 +1,36 @@
 package com.kidmily.algoga_server.lms.application.service;
 
 import com.kidmily.algoga_server.lms.application.command.CreateCourseCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateCourseCommand;
 import com.kidmily.algoga_server.lms.application.usecase.AdminContentUseCase;
 import com.kidmily.algoga_server.lms.domain.model.Course;
 import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.MapRepository;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional // 에러가 나면 모든 DB 작업을 롤백(취소)해줍니다.
+@Transactional
 public class AdminContentService implements AdminContentUseCase {
 
-    // Spring Data JPA가 아니라, 우리가 만든 순수 인터페이스(Port)를 바라봅니다.
     private final CourseRepository courseRepository;
+    private final MapRepository mapRepository;
 
     @Override
     public Long createCourse(CreateCourseCommand command) {
+        log.info("[Course Command] 강의 생성 요청. countryId={}, managerId={}, title={}",
+                command.countryId(), command.managerId(), command.title());
 
-        // 1. 도메인 객체 생성 (비즈니스 규칙 검증은 Course.create 안에서 일어남)
+        validateCountry(command.countryId(), "강의 생성");
+
         Course newCourse = Course.create(
                 command.countryId(),
                 command.managerId(),
@@ -29,10 +40,83 @@ public class AdminContentService implements AdminContentUseCase {
                 command.fileUrl()
         );
 
-        // 2. 레포지토리를 통해 저장 (내부적으로 어댑터가 JpaEntity로 통역해서 DB에 넣음)
         Course savedCourse = courseRepository.save(newCourse);
 
-        // 3. 생성된 강의의 ID 반환
+        log.info("[Course Command] 강의 생성 완료. courseId={}", savedCourse.getId());
+
         return savedCourse.getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Course> getCourses(Pageable pageable) {
+        log.info("[Course Query] 어드민 강의 목록 조회 요청. page={}, size={}",
+                pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<Course> courses = courseRepository.findAllByDeletedFalse(pageable);
+
+        log.info("[Course Query] 어드민 강의 목록 조회 완료. totalElements={}, totalPages={}",
+                courses.getTotalElements(), courses.getTotalPages());
+
+        return courses;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Course getCourse(Long courseId) {
+        log.info("[Course Query] 어드민 강의 상세 조회 요청. courseId={}", courseId);
+
+        Course course = courseRepository.findByIdAndDeletedFalse(courseId)
+                .orElseThrow(() -> {
+                    log.warn("[Course Query] 강의 상세 조회 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
+                    return new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+                });
+
+        log.info("[Course Query] 어드민 강의 상세 조회 완료. courseId={}", course.getId());
+
+        return course;
+    }
+
+    @Override
+    public Course updateCourse(Long courseId, UpdateCourseCommand command) {
+        log.info("[Course Command] 강의 수정 요청. courseId={}, title={}",
+                courseId, command.title());
+
+        Course updatedCourse = courseRepository.updateBasicInfo(
+                courseId,
+                command.title(),
+                command.description(),
+                command.thumbnailUrl(),
+                command.fileUrl()
+        ).orElseThrow(() -> {
+            log.warn("[Course Command] 강의 수정 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
+            return new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+        });
+
+        log.info("[Course Command] 강의 수정 완료. courseId={}", updatedCourse.getId());
+
+        return updatedCourse;
+    }
+
+    @Override
+    public void deleteCourse(Long courseId) {
+        log.info("[Course Command] 강의 삭제 요청. courseId={}", courseId);
+
+        boolean deleted = courseRepository.softDelete(courseId);
+
+        if (!deleted) {
+            log.warn("[Course Command] 강의 삭제 실패. 존재하지 않거나 이미 삭제된 강의입니다. courseId={}", courseId);
+            throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+        }
+
+        log.info("[Course Command] 강의 삭제 완료. courseId={}", courseId);
+    }
+
+    private void validateCountry(Long countryId, String action) {
+        if (mapRepository.findActiveCountryById(countryId).isEmpty()) {
+            log.warn("[Course Command] {} 실패. 존재하지 않는 국가입니다. countryId={}",
+                    action, countryId);
+            throw new LmsException(LmsErrorCode.COUNTRY_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminContentUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminContentUseCase.java
@@ -1,10 +1,20 @@
 package com.kidmily.algoga_server.lms.application.usecase;
 
 import com.kidmily.algoga_server.lms.application.command.CreateCourseCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateCourseCommand;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface AdminContentUseCase {
 
-    // 강의 생성 유스케이스
     Long createCourse(CreateCourseCommand command);
 
+    Page<Course> getCourses(Pageable pageable);
+
+    Course getCourse(Long courseId);
+
+    Course updateCourse(Long courseId, UpdateCourseCommand command);
+
+    void deleteCourse(Long courseId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/Course.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/Course.java
@@ -4,17 +4,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Course {
+
     private Long id;
     private Long countryId;
     private Long managerId;
     private String title;
     private String description;
     private String thumbnailUrl;
-    private String fileUrl; // ✨ DB 스키마에 맞춰 추가됨
+    private String fileUrl;
     private String status;
+    private boolean deleted;
     private List<Chapter> chapters;
 
-    private Course(Long id, Long countryId, Long managerId, String title, String description, String thumbnailUrl, String fileUrl, String status, List<Chapter> chapters) {
+    private Course(
+            Long id,
+            Long countryId,
+            Long managerId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl,
+            String status,
+            boolean deleted,
+            List<Chapter> chapters
+    ) {
         this.id = id;
         this.countryId = countryId;
         this.managerId = managerId;
@@ -23,17 +36,81 @@ public class Course {
         this.thumbnailUrl = thumbnailUrl;
         this.fileUrl = fileUrl;
         this.status = status;
+        this.deleted = deleted;
         this.chapters = chapters != null ? chapters : new ArrayList<>();
     }
 
-    // 어드민 강의 생성
-    public static Course create(Long countryId, Long managerId, String title, String description, String thumbnailUrl, String fileUrl) {
-        return new Course(null, countryId, managerId, title, description, thumbnailUrl, fileUrl, "DRAFT", new ArrayList<>());
+    public static Course create(
+            Long countryId,
+            Long managerId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl
+    ) {
+        return new Course(
+                null,
+                countryId,
+                managerId,
+                title,
+                description,
+                thumbnailUrl,
+                fileUrl,
+                "DRAFT",
+                false,
+                new ArrayList<>()
+        );
     }
 
-    // DB에서 조회
-    public static Course withId(Long id, Long countryId, Long managerId, String title, String description, String thumbnailUrl, String fileUrl, String status, List<Chapter> chapters) {
-        return new Course(id, countryId, managerId, title, description, thumbnailUrl, fileUrl, status, chapters);
+    public static Course withId(
+            Long id,
+            Long countryId,
+            Long managerId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl,
+            String status,
+            List<Chapter> chapters
+    ) {
+        return new Course(
+                id,
+                countryId,
+                managerId,
+                title,
+                description,
+                thumbnailUrl,
+                fileUrl,
+                status,
+                false,
+                chapters
+        );
+    }
+
+    public static Course withId(
+            Long id,
+            Long countryId,
+            Long managerId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl,
+            String status,
+            boolean deleted,
+            List<Chapter> chapters
+    ) {
+        return new Course(
+                id,
+                countryId,
+                managerId,
+                title,
+                description,
+                thumbnailUrl,
+                fileUrl,
+                status,
+                deleted,
+                chapters
+        );
     }
 
     public void addChapter(String title, String videoUrl, int durationSeconds) {
@@ -48,14 +125,43 @@ public class Course {
         this.status = "PUBLISHED";
     }
 
-    // Getters
-    public Long getId() { return id; }
-    public Long getCountryId() { return countryId; }
-    public Long getManagerId() { return managerId; }
-    public String getTitle() { return title; }
-    public String getDescription() { return description; }
-    public String getThumbnailUrl() { return thumbnailUrl; }
-    public String getFileUrl() { return fileUrl; }
-    public String getStatus() { return status; }
-    public List<Chapter> getChapters() { return chapters; }
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCountryId() {
+        return countryId;
+    }
+
+    public Long getManagerId() {
+        return managerId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getThumbnailUrl() {
+        return thumbnailUrl;
+    }
+
+    public String getFileUrl() {
+        return fileUrl;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public List<Chapter> getChapters() {
+        return chapters;
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
@@ -1,6 +1,8 @@
 package com.kidmily.algoga_server.lms.domain.repository;
 
 import com.kidmily.algoga_server.lms.domain.model.Course;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
@@ -11,6 +13,20 @@ public interface CourseRepository {
     Course save(Course course);
 
     Optional<Course> findById(Long id);
+
+    Optional<Course> findByIdAndDeletedFalse(Long id);
+
+    Page<Course> findAllByDeletedFalse(Pageable pageable);
+
+    Optional<Course> updateBasicInfo(
+            Long courseId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl
+    );
+
+    boolean softDelete(Long courseId);
 
     List<Course> findPublishedByCountryId(Long countryId);
 

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/mapper/CourseMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/mapper/CourseMapper.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 @Component
 public class CourseMapper {
 
-    // 1. Domain -> DB Entity 변환 (저장할 때)
     public CourseJpaEntity toEntity(Course course) {
         CourseJpaEntity courseEntity = new CourseJpaEntity(
                 course.getCountryId(),
@@ -24,7 +23,6 @@ public class CourseMapper {
                 course.getStatus()
         );
 
-        // 챕터들도 순회하면서 Entity로 변환하여 추가
         if (course.getChapters() != null) {
             course.getChapters().forEach(chapter -> {
                 ChapterJpaEntity chapterEntity = new ChapterJpaEntity(
@@ -36,10 +34,10 @@ public class CourseMapper {
                 courseEntity.getChapters().add(chapterEntity);
             });
         }
+
         return courseEntity;
     }
 
-    // 2. DB Entity -> Domain 변환 (조회할 때)
     public Course toDomain(CourseJpaEntity entity) {
         List<Chapter> chapters = entity.getChapters().stream()
                 .map(chEntity -> Chapter.withId(
@@ -48,7 +46,8 @@ public class CourseMapper {
                         chEntity.getVideoUrl(),
                         chEntity.getDurationSeconds(),
                         chEntity.getOrderNum()
-                )).collect(Collectors.toList());
+                ))
+                .collect(Collectors.toList());
 
         return Course.withId(
                 entity.getId(),
@@ -57,8 +56,9 @@ public class CourseMapper {
                 entity.getTitle(),
                 entity.getDescription(),
                 entity.getThumbnailUrl(),
-                entity.getFileUrl(),   // ✨ 누락되었던 파라미터 매핑
+                entity.getFileUrl(),
                 entity.getStatus(),
+                entity.isDeleted(),
                 chapters
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
@@ -5,6 +5,8 @@ import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
 import com.kidmily.algoga_server.lms.infrastructure.mapper.CourseMapper;
 import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.CourseJpaEntity;
 import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.SpringDataCourseRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
@@ -42,8 +44,46 @@ public class CourseRepositoryAdapter implements CourseRepository {
     }
 
     @Override
+    public Optional<Course> findByIdAndDeletedFalse(Long id) {
+        return springDataCourseRepository.findByIdAndDeletedFalse(id)
+                .map(courseMapper::toDomain);
+    }
+
+    @Override
+    public Page<Course> findAllByDeletedFalse(Pageable pageable) {
+        return springDataCourseRepository.findByDeletedFalseOrderByIdDesc(pageable)
+                .map(courseMapper::toDomain);
+    }
+
+    @Override
+    public Optional<Course> updateBasicInfo(
+            Long courseId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl
+    ) {
+        return springDataCourseRepository.findByIdAndDeletedFalse(courseId)
+                .map(entity -> {
+                    entity.updateBasicInfo(title, description, thumbnailUrl, fileUrl);
+                    return courseMapper.toDomain(entity);
+                });
+    }
+
+    @Override
+    public boolean softDelete(Long courseId) {
+        return springDataCourseRepository.findByIdAndDeletedFalse(courseId)
+                .map(entity -> {
+                    entity.softDelete();
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    @Override
     public List<Course> findPublishedByCountryId(Long countryId) {
-        return springDataCourseRepository.findByCountryIdAndStatusOrderByIdDesc(countryId, PUBLISHED)
+        return springDataCourseRepository
+                .findByCountryIdAndStatusAndDeletedFalseOrderByIdDesc(countryId, PUBLISHED)
                 .stream()
                 .map(courseMapper::toDomain)
                 .toList();
@@ -51,7 +91,8 @@ public class CourseRepositoryAdapter implements CourseRepository {
 
     @Override
     public long countPublishedByCountryId(Long countryId) {
-        return springDataCourseRepository.countByCountryIdAndStatus(countryId, PUBLISHED);
+        return springDataCourseRepository
+                .countByCountryIdAndStatusAndDeletedFalse(countryId, PUBLISHED);
     }
 
     @Override

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseJpaEntity.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,17 +16,21 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseJpaEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "lecture_id")
     private Long id;
 
-    @Column(name = "country_id")
+    @Column(name = "country_id", nullable = false)
     private Long countryId;
 
-    @Column(name = "manager_id")
+    @Column(name = "manager_id", nullable = false)
     private Long managerId;
 
+    @Column(nullable = false, length = 255)
     private String title;
+
     @Lob
     @Column(name = "description", nullable = false)
     private String description;
@@ -33,13 +41,33 @@ public class CourseJpaEntity {
     @Column(name = "file_url", length = 500)
     private String fileUrl;
 
+    @Column(nullable = false, length = 30)
     private String status;
+
+    @Column(name = "is_deleted")
+    private boolean deleted = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "lecture_id")
     private List<ChapterJpaEntity> chapters = new ArrayList<>();
 
-    public CourseJpaEntity(Long countryId, Long managerId, String title, String description, String thumbnailUrl, String fileUrl, String status) {
+    public CourseJpaEntity(
+            Long countryId,
+            Long managerId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl,
+            String status
+    ) {
         this.countryId = countryId;
         this.managerId = managerId;
         this.title = title;
@@ -47,5 +75,28 @@ public class CourseJpaEntity {
         this.thumbnailUrl = thumbnailUrl;
         this.fileUrl = fileUrl;
         this.status = status;
+        this.deleted = false;
+    }
+
+    public void updateBasicInfo(
+            String title,
+            String description,
+            String thumbnailUrl,
+            String fileUrl
+    ) {
+        this.title = title;
+        this.description = description;
+
+        if (thumbnailUrl != null) {
+            this.thumbnailUrl = thumbnailUrl;
+        }
+
+        if (fileUrl != null) {
+            this.fileUrl = fileUrl;
+        }
+    }
+
+    public void softDelete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseRepository.java
@@ -1,23 +1,37 @@
 package com.kidmily.algoga_server.lms.infrastructure.persistence.repository;
 
 import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.CourseJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntity, Long> {
 
-    List<CourseJpaEntity> findByCountryIdAndStatusOrderByIdDesc(Long countryId, String status);
+    Optional<CourseJpaEntity> findByIdAndDeletedFalse(Long id);
 
-    long countByCountryIdAndStatus(Long countryId, String status);
+    Page<CourseJpaEntity> findByDeletedFalseOrderByIdDesc(Pageable pageable);
+
+    List<CourseJpaEntity> findByCountryIdAndStatusAndDeletedFalseOrderByIdDesc(
+            Long countryId,
+            String status
+    );
+
+    long countByCountryIdAndStatusAndDeletedFalse(
+            Long countryId,
+            String status
+    );
 
     @Query("""
             SELECT c.countryId, COUNT(c.id)
             FROM CourseJpaEntity c
             WHERE c.countryId IN :countryIds
               AND c.status = :status
+              AND c.deleted = false
             GROUP BY c.countryId
             """)
     List<Object[]> countByCountryIdsAndStatus(

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
@@ -1,17 +1,33 @@
 package com.kidmily.algoga_server.lms.presentation.api.admin;
 
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.common.api.response.PageResponse;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
 import com.kidmily.algoga_server.lms.application.command.CreateCourseCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateCourseCommand;
 import com.kidmily.algoga_server.lms.application.usecase.AdminContentUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.infrastructure.document.LocalFileStorageManager;
 import com.kidmily.algoga_server.lms.presentation.request.admin.CreateCourseRequest;
+import com.kidmily.algoga_server.lms.presentation.request.admin.UpdateCourseRequest;
+import com.kidmily.algoga_server.lms.presentation.response.AdminCourseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "Admin Course", description = "콘텐츠 매니저 강의 관리 API")
 @RestController
 @RequestMapping("/api/admin/courses")
 @RequiredArgsConstructor
@@ -20,20 +36,28 @@ public class AdminCourseController {
     private final AdminContentUseCase adminContentUseCase;
     private final LocalFileStorageManager fileStorageManager;
 
-    // consumes 속성으로 파일 업로드(MULTIPART_FORM_DATA)를 지원한다고 명시
+    @Operation(
+            summary = "어드민 강의 생성",
+            description = "콘텐츠 매니저가 강의 기본 정보와 썸네일, 선택 첨부파일을 등록합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COUNTRY_NOT_FOUND", "FILE_UPLOAD_FAILED"})
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createCourse(
-            @RequestPart(value = "request") CreateCourseRequest request,
-            @RequestPart(value = "thumbnail") MultipartFile thumbnailFile,
-            @RequestPart(value = "file", required = false) MultipartFile attachedFile // 첨부파일은 선택사항
-    ) {
-        Long currentManagerId = 1L; // 임시 어드민 ID
+            @Parameter(description = "강의 생성 요청 JSON")
+            @Valid @RequestPart(value = "request") CreateCourseRequest request,
 
-        // 1. 넘어온 파일들을 인텔리제이 폴더에 물리적으로 저장하고 URL을 얻어옵니다.
+            @Parameter(description = "강의 썸네일 이미지 파일", example = "osaka.png")
+            @RequestPart(value = "thumbnail") MultipartFile thumbnailFile,
+
+            @Parameter(description = "강의 첨부파일. 선택값입니다.", example = "osaka-guide.pdf")
+            @RequestPart(value = "file", required = false) MultipartFile attachedFile
+    ) {
+        Long currentManagerId = 1L;
+
         String thumbnailUrl = fileStorageManager.uploadFile(thumbnailFile, "thumbnails");
         String fileUrl = fileStorageManager.uploadFile(attachedFile, "documents");
 
-        // 2. 알아낸 URL을 Command 상자에 합쳐서 서비스로 넘깁니다. (클린 아키텍처)
         CreateCourseCommand command = new CreateCourseCommand(
                 request.countryId(),
                 currentManagerId,
@@ -43,7 +67,6 @@ public class AdminCourseController {
                 fileUrl
         );
 
-        // 3. 서비스 호출
         Long savedCourseId = adminContentUseCase.createCourse(command);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -52,5 +75,128 @@ public class AdminCourseController {
                         "강의 생성에 성공했습니다.",
                         savedCourseId
                 ));
+    }
+
+    // global.common.api.response.PageResponse 추가하기 전.
+//    @Operation(
+//            summary = "어드민 강의 목록 조회",
+//            description = "삭제되지 않은 강의 목록을 최신순으로 조회합니다."
+//    )
+//    @GetMapping
+//    public ResponseEntity<ApiResponse<Page<AdminCourseResponse>>> getCourses(
+//            @ParameterObject Pageable pageable
+//    ) {
+//        Page<AdminCourseResponse> response = adminContentUseCase.getCourses(pageable)
+//                .map(AdminCourseResponse::from);
+//
+//        return ResponseEntity.ok(
+//                ApiResponse.success(
+//                        "ADMIN_COURSES_FOUND",
+//                        "어드민 강의 목록 조회에 성공했습니다.",
+//                        response
+//                )
+//        );
+//    }
+
+    @Operation(
+            summary = "어드민 강의 목록 조회",
+            description = "삭제되지 않은 강의 목록을 최신순으로 조회합니다."
+    )
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<AdminCourseResponse>>> getCourses(
+            @ParameterObject Pageable pageable
+    ) {
+        Page<AdminCourseResponse> response = adminContentUseCase.getCourses(pageable)
+                .map(AdminCourseResponse::from);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_COURSES_FOUND",
+                        "어드민 강의 목록 조회에 성공했습니다.",
+                        PageResponse.from(response)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "어드민 강의 상세 조회",
+            description = "강의 ID를 기준으로 삭제되지 않은 강의 상세 정보를 조회합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @GetMapping("/{courseId}")
+    public ResponseEntity<ApiResponse<AdminCourseResponse>> getCourse(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId
+    ) {
+        Course course = adminContentUseCase.getCourse(courseId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_COURSE_FOUND",
+                        "어드민 강의 상세 조회에 성공했습니다.",
+                        AdminCourseResponse.from(course)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "어드민 강의 수정",
+            description = "강의 제목, 설명, 썸네일, 첨부파일을 수정합니다. 파일을 보내지 않으면 기존 파일 경로를 유지합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "FILE_UPLOAD_FAILED"})
+    @PutMapping(value = "/{courseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<AdminCourseResponse>> updateCourse(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "강의 수정 요청 JSON")
+            @Valid @RequestPart(value = "request") UpdateCourseRequest request,
+
+            @Parameter(description = "변경할 썸네일 이미지 파일. 선택값입니다.", example = "osaka-new.png")
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnailFile,
+
+            @Parameter(description = "변경할 첨부파일. 선택값입니다.", example = "osaka-guide-new.pdf")
+            @RequestPart(value = "file", required = false) MultipartFile attachedFile
+    ) {
+        String thumbnailUrl = fileStorageManager.uploadFile(thumbnailFile, "thumbnails");
+        String fileUrl = fileStorageManager.uploadFile(attachedFile, "documents");
+
+        UpdateCourseCommand command = new UpdateCourseCommand(
+                request.title(),
+                request.description(),
+                thumbnailUrl,
+                fileUrl
+        );
+
+        Course updatedCourse = adminContentUseCase.updateCourse(courseId, command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COURSE_UPDATED",
+                        "강의 수정에 성공했습니다.",
+                        AdminCourseResponse.from(updatedCourse)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "어드민 강의 삭제",
+            description = "강의를 실제 삭제하지 않고 Soft Delete 처리합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @DeleteMapping("/{courseId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCourse(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId
+    ) {
+        adminContentUseCase.deleteCourse(courseId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COURSE_DELETED",
+                        "강의 삭제에 성공했습니다."
+                )
+        );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateCourseRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateCourseRequest.java
@@ -1,16 +1,21 @@
 package com.kidmily.algoga_server.lms.presentation.request.admin;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "어드민 강의 생성 요청")
 public record CreateCourseRequest(
 
+        @Schema(description = "국가 ID", example = "1")
         @NotNull(message = "국가 ID는 필수입니다.")
         Long countryId,
 
+        @Schema(description = "강의 제목", example = "오사카 여행 준비 마스터")
         @NotBlank(message = "강의 제목은 필수입니다.")
         String title,
 
+        @Schema(description = "강의 설명", example = "환전부터 교통패스까지 오사카 여행 준비에 필요한 내용을 학습합니다.")
         @NotBlank(message = "강의 설명은 필수입니다.")
         String description
 ) {

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateCourseRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateCourseRequest.java
@@ -1,0 +1,17 @@
+package com.kidmily.algoga_server.lms.presentation.request.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "어드민 강의 수정 요청")
+public record UpdateCourseRequest(
+
+        @Schema(description = "수정할 강의 제목", example = "오사카 여행 준비 마스터 개정판")
+        @NotBlank(message = "강의 제목은 필수입니다.")
+        String title,
+
+        @Schema(description = "수정할 강의 설명", example = "오사카 여행 전 반드시 알아야 하는 교통, 환전, 입국 정보를 학습합니다.")
+        @NotBlank(message = "강의 설명은 필수입니다.")
+        String description
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/request.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/request.http
@@ -8,7 +8,7 @@ Content-Type: application/json
 
 {
   "countryId": 1,
-  "title": "상해 핵심 가이드",
+  "title": "체코 핵심 가이드",
   "description": "이 강의는 request.http 파일을 통해 생성된 강의입니다."
 }
 
@@ -26,6 +26,7 @@ Content-Type: application/pdf
 
 --boundary--
 
+### ----------------------------------------------------------
 ### 지도 - 대륙 목록 조회
 GET http://localhost:15000/api/v1/maps/continents
 
@@ -49,5 +50,48 @@ GET http://localhost:15000/api/v1/maps/continents/WRONG/countries
 ### 국가별 강의 목록 조회 - 존재하지 않는 국가
 GET http://localhost:15000/api/v1/courses/countries/9999
 
+### ----------------------------------------------------------
+### 어드민 - 강의 목록 조회
+GET http://localhost:15000/api/admin/courses?page=0&size=10
 
+
+### 어드민 - 강의 상세 조회
+GET http://localhost:15000/api/admin/courses/2
+
+
+### 어드민 - 강의 수정
+PUT http://localhost:15000/api/admin/courses/2
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"; filename="request.json"
+Content-Type: application/json
+
+{
+  "title": "오사카 여행 준비 마스터 수정본",
+  "description": "오사카 여행 전 필요한 교통, 환전, 입국 정보를 수정 반영한 강의입니다."
+}
+
+--boundary
+Content-Disposition: form-data; name="thumbnail"; filename="sample_image.png"
+Content-Type: image/png
+
+< ./sample_image.png
+
+--boundary
+Content-Disposition: form-data; name="file"; filename="sample_doc.pdf"
+Content-Type: application/pdf
+
+< ./sample_doc.pdf
+
+--boundary--
+
+
+### 어드민 - 강의 삭제
+DELETE http://localhost:15000/api/admin/courses/2
+
+
+### 어드민 - 존재하지 않는 강의 상세 조회
+GET http://localhost:15000/api/admin/courses/9999
+### ----------------------------------------------------------
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseResponse.java
@@ -1,0 +1,46 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "어드민 강의 응답")
+public record AdminCourseResponse(
+
+        @Schema(description = "강의 ID", example = "1")
+        Long courseId,
+
+        @Schema(description = "국가 ID", example = "1")
+        Long countryId,
+
+        @Schema(description = "콘텐츠 매니저 ID", example = "1")
+        Long managerId,
+
+        @Schema(description = "강의 제목", example = "오사카 여행 준비 마스터")
+        String title,
+
+        @Schema(description = "강의 설명", example = "환전부터 교통패스까지 오사카 여행 준비에 필요한 내용을 학습합니다.")
+        String description,
+
+        @Schema(description = "썸네일 파일 경로", example = "thumbnails/550e8400-e29b-41d4-a716-446655440000.png")
+        String thumbnailUrl,
+
+        @Schema(description = "첨부파일 경로", example = "documents/550e8400-e29b-41d4-a716-446655440000.pdf")
+        String fileUrl,
+
+        @Schema(description = "강의 상태", example = "DRAFT")
+        String status
+) {
+
+    public static AdminCourseResponse from(Course course) {
+        return new AdminCourseResponse(
+                course.getId(),
+                course.getCountryId(),
+                course.getManagerId(),
+                course.getTitle(),
+                course.getDescription(),
+                course.getThumbnailUrl(),
+                course.getFileUrl(),
+                course.getStatus()
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ spring:
     password: algoga
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     properties:
@@ -28,7 +29,12 @@ logging:
     org.hibernate.SQL: debug
 
 springdoc:
-  default-produces-media-type: application/json
+  default-produces-media-type: application/json # API 응답(Response) 기본 미디어 타입
+
+jwt:
+  secret-key: algoga-project-secret-key-must-be-long-enough-for-security # 32바이트 이상 임의의 문자열
+  access-token-expiration: 1800000 # 30분 (밀리초)
+  refresh-token-expiration: 604800000 # 7일 (밀리초)
 
 app:
   file:


### PR DESCRIPTION
## 설명
콘텐츠 매니저가 백오피스에서 강의를 관리할 수 있도록 강의 CRUD API 구현

- 어드민 강의 목록 조회 API 구현
- 어드민 강의 상세 조회 API 구현
- 어드민 강의 수정 API 구현
- 어드민 강의 삭제 API 구현
- 강의 삭제 시 실제 삭제가 아닌 Soft Delete 처리
- 삭제된 강의는 목록/상세/수정/삭제 대상에서 제외
- 강의 목록 조회 응답에 `PageResponse<T>` 적용
  :  `PageImpl` 직접 응답으로 인한 직렬화 WARN 제거
  :  프론트에서 사용할 페이징 필드 구조 고정
- 어드민 강의 생성/조회/수정/삭제 서비스 로그 추가
  :  정상 요청/응답 흐름은 `log.info`
  :  존재하지 않거나 삭제된 강의 접근은 `log.warn`
- Controller, RequestDTO, ResponseDTO에 Swagger 어노테이션 및 example 추가
- 로컬 파일 업로드 방식 유지
  :  썸네일: `uploads/thumbnails`
  :  첨부파일: `uploads/documents`
- `application.yaml` 설정 정리
  :  multipart 파일 업로드 용량 설정
  :  local file upload root 설정
  : `spring.jpa.open-in-view=false` 설정

## 🔗 Issue
Closes #37 

---
## API 응답 구조
강의 목록 조회 API는 공통 응답인 `ApiResponse`의 `data` 안에 `PageResponse<AdminCourseResponse>` 형태 응답.

프론트에서 사용할 주요 필드는 아래와 같습니다.
- `data.content`: 강의 목록
- `data.page`: 현재 페이지 번호
- `data.size`: 페이지 크기
- `data.totalElements`: 전체 강의 개수
- `data.totalPages`: 전체 페이지 수
- `data.first`: 첫 페이지 여부
- `data.last`: 마지막 페이지 여부

강의 단건 응답에서는 아래 데이터를 제공합니다.
- `courseId`
- `countryId`
- `managerId`
- `title`
- `description`
- `thumbnailUrl`
- `fileUrl`
- `status`

---

## 확인할 사항
- [ ] `POST /api/admin/courses` 요청 시 강의가 정상 생성되는지 확인
- [ ] `GET /api/admin/courses?page=0&size=10` 요청 시 강의 목록과 페이징 정보가 정상 반환되는지 확인
- [ ] `GET /api/admin/courses/{courseId}` 요청 시 강의 상세 정보가 정상 반환되는지 확인
- [ ] `PUT /api/admin/courses/{courseId}` 요청 시 강의 제목/설명/파일 정보가 정상 수정되는지 확인
- [ ] `DELETE /api/admin/courses/{courseId}` 요청 시 강의가 Soft Delete 처리되는지 확인
- [ ] 삭제된 강의가 목록 조회 및 상세 조회에서 제외되는지 확인
- [ ] 존재하지 않는 강의 ID 요청 시 `404 LMS_001` 응답이 반환되는지 확인
- [ ] 서비스 계층에서 `log.info`, `log.warn` 로그가 정상 출력되는지 확인
- [ ] Swagger에서 Controller, RequestDTO, ResponseDTO 설명 및 example이 노출되는지 확인
- [ ] request.http 또는 Postman으로 주요 API req/res 결과 확인