### PR TITLE
[Feature] 콘텐츠 매니저 챕터 관리 CRUD API 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateChapterCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateChapterCommand.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.lms.application.command;
+
+public record CreateChapterCommand(
+        Long courseId,
+        String title,
+        String videoUrl,
+        int durationSeconds,
+        int chapterOrder
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateChapterCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateChapterCommand.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.lms.application.command;
+
+public record UpdateChapterCommand(
+        String title,
+        String videoUrl,
+        int durationSeconds,
+        int chapterOrder
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminChapterService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminChapterService.java
@@ -1,0 +1,137 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.command.CreateChapterCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateChapterCommand;
+import com.kidmily.algoga_server.lms.application.usecase.AdminChapterUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminChapterService implements AdminChapterUseCase {
+
+    private final ChapterRepository chapterRepository;
+    private final CourseRepository courseRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Chapter> getChapters(Long courseId) {
+        log.info("[Chapter Query] 어드민 챕터 목록 조회 요청. courseId={}", courseId);
+
+        validateCourse(courseId, "챕터 목록 조회");
+
+        List<Chapter> chapters = chapterRepository.findByCourseId(courseId);
+
+        log.info("[Chapter Query] 어드민 챕터 목록 조회 완료. courseId={}, count={}",
+                courseId, chapters.size());
+
+        return chapters;
+    }
+
+    @Override
+    public Chapter createChapter(CreateChapterCommand command) {
+        log.info("[Chapter Command] 챕터 등록 요청. courseId={}, title={}, chapterOrder={}",
+                command.courseId(), command.title(), command.chapterOrder());
+
+        validateCourse(command.courseId(), "챕터 등록");
+        validateChapterOrder(command.chapterOrder());
+
+        if (command.videoUrl() == null) {
+            log.warn("[Chapter Command] 챕터 등록 실패. 영상 파일이 없습니다. courseId={}",
+                    command.courseId());
+            throw new LmsException(LmsErrorCode.CHAPTER_VIDEO_REQUIRED);
+        }
+
+        Chapter chapter = Chapter.create(
+                command.courseId(),
+                command.title(),
+                command.videoUrl(),
+                command.durationSeconds(),
+                command.chapterOrder()
+        );
+
+        Chapter savedChapter = chapterRepository.save(chapter);
+
+        log.info("[Chapter Command] 챕터 등록 완료. courseId={}, chapterId={}",
+                savedChapter.getCourseId(), savedChapter.getId());
+
+        return savedChapter;
+    }
+
+    @Override
+    public Chapter updateChapter(
+            Long courseId,
+            Long chapterId,
+            UpdateChapterCommand command
+    ) {
+        log.info("[Chapter Command] 챕터 수정 요청. courseId={}, chapterId={}, title={}, chapterOrder={}",
+                courseId, chapterId, command.title(), command.chapterOrder());
+
+        validateCourse(courseId, "챕터 수정");
+        validateChapterOrder(command.chapterOrder());
+
+        Chapter updatedChapter = chapterRepository.updateBasicInfo(
+                chapterId,
+                courseId,
+                command.title(),
+                command.videoUrl(),
+                command.durationSeconds(),
+                command.chapterOrder()
+        ).orElseThrow(() -> {
+            log.warn("[Chapter Command] 챕터 수정 실패. 존재하지 않거나 삭제된 챕터입니다. courseId={}, chapterId={}",
+                    courseId, chapterId);
+            return new LmsException(LmsErrorCode.CHAPTER_NOT_FOUND);
+        });
+
+        log.info("[Chapter Command] 챕터 수정 완료. courseId={}, chapterId={}",
+                courseId, updatedChapter.getId());
+
+        return updatedChapter;
+    }
+
+    @Override
+    public void deleteChapter(Long courseId, Long chapterId) {
+        log.info("[Chapter Command] 챕터 삭제 요청. courseId={}, chapterId={}",
+                courseId, chapterId);
+
+        validateCourse(courseId, "챕터 삭제");
+
+        boolean deleted = chapterRepository.softDelete(chapterId, courseId);
+
+        if (!deleted) {
+            log.warn("[Chapter Command] 챕터 삭제 실패. 존재하지 않거나 이미 삭제된 챕터입니다. courseId={}, chapterId={}",
+                    courseId, chapterId);
+            throw new LmsException(LmsErrorCode.CHAPTER_NOT_FOUND);
+        }
+
+        log.info("[Chapter Command] 챕터 삭제 완료. courseId={}, chapterId={}",
+                courseId, chapterId);
+    }
+
+    private void validateCourse(Long courseId, String action) {
+        if (courseRepository.findByIdAndDeletedFalse(courseId).isEmpty()) {
+            log.warn("[Chapter Command] {} 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}",
+                    action, courseId);
+            throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+        }
+    }
+
+    private void validateChapterOrder(int chapterOrder) {
+        if (chapterOrder < 1) {
+            log.warn("[Chapter Command] 유효하지 않은 챕터 순서입니다. chapterOrder={}",
+                    chapterOrder);
+            throw new LmsException(LmsErrorCode.INVALID_CHAPTER_ORDER);
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminChapterUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminChapterUseCase.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.lms.application.usecase;
+
+import com.kidmily.algoga_server.lms.application.command.CreateChapterCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateChapterCommand;
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+
+import java.util.List;
+
+public interface AdminChapterUseCase {
+
+    List<Chapter> getChapters(Long courseId);
+
+    Chapter createChapter(CreateChapterCommand command);
+
+    Chapter updateChapter(Long courseId, Long chapterId, UpdateChapterCommand command);
+
+    void deleteChapter(Long courseId, Long chapterId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/Chapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/Chapter.java
@@ -1,34 +1,131 @@
 package com.kidmily.algoga_server.lms.domain.model;
 
 public class Chapter {
-    private Long id;
-    private String title;
-    private String videoUrl;
-    private int durationSeconds; // 진도율 조작 방지용
-    private int chapterOrder;
 
-    private Chapter(Long id, String title, String videoUrl, int durationSeconds, int chapterOrder) {
+    private final Long id;
+    private final Long courseId;
+    private final String title;
+    private final String videoUrl;
+    private final int durationSeconds;
+    private final int chapterOrder;
+    private final boolean deleted;
+
+    private Chapter(
+            Long id,
+            Long courseId,
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder,
+            boolean deleted
+    ) {
         this.id = id;
+        this.courseId = courseId;
         this.title = title;
         this.videoUrl = videoUrl;
         this.durationSeconds = durationSeconds;
         this.chapterOrder = chapterOrder;
+        this.deleted = deleted;
     }
 
-    // 어드민이 새 챕터를 만들 때
-    public static Chapter create(String title, String videoUrl, int durationSeconds, int chapterOrder) {
-        return new Chapter(null, title, videoUrl, durationSeconds, chapterOrder);
+    public static Chapter create(
+            Long courseId,
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder
+    ) {
+        return new Chapter(
+                null,
+                courseId,
+                title,
+                videoUrl,
+                durationSeconds,
+                chapterOrder,
+                false
+        );
     }
 
-    // DB에서 불러올 때
-    public static Chapter withId(Long id, String title, String videoUrl, int durationSeconds, int chapterOrder) {
-        return new Chapter(id, title, videoUrl, durationSeconds, chapterOrder);
+    public static Chapter create(
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder
+    ) {
+        return new Chapter(
+                null,
+                null,
+                title,
+                videoUrl,
+                durationSeconds,
+                chapterOrder,
+                false
+        );
     }
 
-    // Getters
-    public Long getId() { return id; }
-    public String getTitle() { return title; }
-    public String getVideoUrl() { return videoUrl; }
-    public int getDurationSeconds() { return durationSeconds; }
-    public int getChapterOrder() { return chapterOrder; }
+    public static Chapter withId(
+            Long id,
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder
+    ) {
+        return new Chapter(
+                id,
+                null,
+                title,
+                videoUrl,
+                durationSeconds,
+                chapterOrder,
+                false
+        );
+    }
+
+    public static Chapter withId(
+            Long id,
+            Long courseId,
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder,
+            boolean deleted
+    ) {
+        return new Chapter(
+                id,
+                courseId,
+                title,
+                videoUrl,
+                durationSeconds,
+                chapterOrder,
+                deleted
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCourseId() {
+        return courseId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getVideoUrl() {
+        return videoUrl;
+    }
+
+    public int getDurationSeconds() {
+        return durationSeconds;
+    }
+
+    public int getChapterOrder() {
+        return chapterOrder;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/ChapterRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/ChapterRepository.java
@@ -1,0 +1,26 @@
+package com.kidmily.algoga_server.lms.domain.repository;
+
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChapterRepository {
+
+    Chapter save(Chapter chapter);
+
+    List<Chapter> findByCourseId(Long courseId);
+
+    Optional<Chapter> findByIdAndCourseId(Long chapterId, Long courseId);
+
+    Optional<Chapter> updateBasicInfo(
+            Long chapterId,
+            Long courseId,
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder
+    );
+
+    boolean softDelete(Long chapterId, Long courseId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
@@ -16,7 +16,10 @@ public enum LmsErrorCode implements BaseErrorCode {
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_005", "파일을 찾을 수 없습니다."),
     COUNTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_006", "해당 국가를 찾을 수 없습니다."),
     CONTINENT_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_007", "해당 대륙의 국가를 찾을 수 없습니다."),
-    INVALID_CONTINENT_CODE(HttpStatus.BAD_REQUEST, "LMS_008", "유효하지 않은 대륙 코드입니다.");
+    INVALID_CONTINENT_CODE(HttpStatus.BAD_REQUEST, "LMS_008", "유효하지 않은 대륙 코드입니다."),
+    CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_009", "해당 챕터를 찾을 수 없습니다."),
+    CHAPTER_VIDEO_REQUIRED(HttpStatus.BAD_REQUEST, "LMS_010", "챕터 영상 파일은 필수입니다."),
+    INVALID_CHAPTER_ORDER(HttpStatus.BAD_REQUEST, "LMS_011", "유효하지 않은 챕터 순서입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/ChapterRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/ChapterRepositoryAdapter.java
@@ -1,0 +1,91 @@
+package com.kidmily.algoga_server.lms.infrastructure.persistence.adapter;
+
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.ChapterJpaEntity;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.SpringDataChapterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ChapterRepositoryAdapter implements ChapterRepository {
+
+    private final SpringDataChapterRepository springDataChapterRepository;
+
+    @Override
+    public Chapter save(Chapter chapter) {
+        ChapterJpaEntity entity = new ChapterJpaEntity(
+                chapter.getCourseId(),
+                chapter.getTitle(),
+                chapter.getVideoUrl(),
+                chapter.getDurationSeconds(),
+                chapter.getChapterOrder()
+        );
+
+        ChapterJpaEntity savedEntity = springDataChapterRepository.save(entity);
+
+        return toDomain(savedEntity);
+    }
+
+    @Override
+    public List<Chapter> findByCourseId(Long courseId) {
+        return springDataChapterRepository.findByCourseIdAndDeletedFalseOrderByOrderNumAsc(courseId)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<Chapter> findByIdAndCourseId(Long chapterId, Long courseId) {
+        return springDataChapterRepository.findByIdAndCourseIdAndDeletedFalse(chapterId, courseId)
+                .map(this::toDomain);
+    }
+
+    @Override
+    public Optional<Chapter> updateBasicInfo(
+            Long chapterId,
+            Long courseId,
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder
+    ) {
+        return springDataChapterRepository.findByIdAndCourseIdAndDeletedFalse(chapterId, courseId)
+                .map(entity -> {
+                    entity.updateBasicInfo(
+                            title,
+                            videoUrl,
+                            durationSeconds,
+                            chapterOrder
+                    );
+
+                    return toDomain(entity);
+                });
+    }
+
+    @Override
+    public boolean softDelete(Long chapterId, Long courseId) {
+        return springDataChapterRepository.findByIdAndCourseIdAndDeletedFalse(chapterId, courseId)
+                .map(entity -> {
+                    entity.softDelete();
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    private Chapter toDomain(ChapterJpaEntity entity) {
+        return Chapter.withId(
+                entity.getId(),
+                entity.getCourseId(),
+                entity.getTitle(),
+                entity.getVideoUrl(),
+                entity.getDurationSeconds(),
+                entity.getOrderNum(),
+                entity.isDeleted()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/ChapterJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/ChapterJpaEntity.java
@@ -10,26 +10,75 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChapterJpaEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "chapter_id") // 명시적 매핑
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chapter_id")
     private Long id;
 
+    @Column(name = "lecture_id")
+    private Long courseId;
+
+    @Column(nullable = false, length = 255)
     private String title;
 
     @Column(name = "video_url", nullable = false, length = 500)
     private String videoUrl;
 
-    @Column(name = "duration_seconds")
+    @Column(name = "duration_seconds", nullable = false)
     private int durationSeconds;
 
-    @Column(name = "order_num")
+    @Column(name = "order_num", nullable = false)
     private int orderNum;
 
-    // 생성자도 동일하게 맞추는 것이 좋습니다.
-    public ChapterJpaEntity(String title, String videoUrl, int durationSeconds, int orderNum) {
+    @Column(name = "is_deleted")
+    private boolean deleted = false;
+
+    public ChapterJpaEntity(
+            Long courseId,
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int orderNum
+    ) {
+        this.courseId = courseId;
         this.title = title;
         this.videoUrl = videoUrl;
         this.durationSeconds = durationSeconds;
         this.orderNum = orderNum;
+        this.deleted = false;
+    }
+
+    public ChapterJpaEntity(
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int orderNum
+    ) {
+        this.title = title;
+        this.videoUrl = videoUrl;
+        this.durationSeconds = durationSeconds;
+        this.orderNum = orderNum;
+        this.deleted = false;
+    }
+
+    public void updateBasicInfo(
+            String title,
+            String videoUrl,
+            int durationSeconds,
+            int orderNum
+    ) {
+        this.title = title;
+
+        if (videoUrl != null) {
+            this.videoUrl = videoUrl;
+        }
+
+        this.durationSeconds = durationSeconds;
+        this.orderNum = orderNum;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataChapterRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataChapterRepository.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.lms.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.ChapterJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringDataChapterRepository extends JpaRepository<ChapterJpaEntity, Long> {
+
+    List<ChapterJpaEntity> findByCourseIdAndDeletedFalseOrderByOrderNumAsc(Long courseId);
+
+    Optional<ChapterJpaEntity> findByIdAndCourseIdAndDeletedFalse(Long id, Long courseId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
@@ -1,0 +1,164 @@
+package com.kidmily.algoga_server.lms.presentation.api.admin;
+
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
+import com.kidmily.algoga_server.lms.application.command.CreateChapterCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateChapterCommand;
+import com.kidmily.algoga_server.lms.application.usecase.AdminChapterUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.infrastructure.document.LocalFileStorageManager;
+import com.kidmily.algoga_server.lms.presentation.request.admin.CreateChapterRequest;
+import com.kidmily.algoga_server.lms.presentation.request.admin.UpdateChapterRequest;
+import com.kidmily.algoga_server.lms.presentation.response.AdminChapterResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "챕터 관리", description = "콘텐츠 매니저 챕터 관리 API")
+@RestController
+@RequestMapping("/api/v1/courses/{courseId}/chapters")
+@RequiredArgsConstructor
+public class AdminChapterController {
+
+    private final AdminChapterUseCase adminChapterUseCase;
+    private final LocalFileStorageManager fileStorageManager;
+
+    @Operation(
+            summary = "챕터 목록 조회",
+            description = "특정 강의에 등록된 챕터 목록을 노출 순서대로 조회합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminChapterResponse>>> getChapters(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId
+    ) {
+        List<AdminChapterResponse> response = adminChapterUseCase.getChapters(courseId)
+                .stream()
+                .map(AdminChapterResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_CHAPTERS_FOUND",
+                        "챕터 목록 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "챕터 등록",
+            description = "특정 강의에 챕터 영상과 기본 정보를 등록합니다. 영상 파일은 필수입니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "FILE_UPLOAD_FAILED", "CHAPTER_VIDEO_REQUIRED", "INVALID_CHAPTER_ORDER"})
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<AdminChapterResponse>> createChapter(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "챕터 등록 요청 JSON")
+            @Valid @RequestPart(value = "request") CreateChapterRequest request,
+
+            @Parameter(description = "챕터 영상 파일", example = "chapter-video.mp4")
+            @RequestPart(value = "video") MultipartFile videoFile
+    ) {
+        String videoUrl = fileStorageManager.uploadFile(videoFile, "videos");
+
+        CreateChapterCommand command = new CreateChapterCommand(
+                courseId,
+                request.title(),
+                videoUrl,
+                request.durationSeconds(),
+                request.chapterOrder()
+        );
+
+        Chapter savedChapter = adminChapterUseCase.createChapter(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        "CHAPTER_CREATED",
+                        "챕터 등록에 성공했습니다.",
+                        AdminChapterResponse.from(savedChapter)
+                ));
+    }
+
+    @Operation(
+            summary = "챕터 수정",
+            description = "특정 강의의 챕터 제목, 영상, 재생 시간, 노출 순서를 수정합니다. 영상 파일을 보내지 않으면 기존 영상 경로를 유지합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "CHAPTER_NOT_FOUND", "FILE_UPLOAD_FAILED", "INVALID_CHAPTER_ORDER"})
+    @PutMapping(value = "/{chapterId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<AdminChapterResponse>> updateChapter(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "챕터 ID", example = "1")
+            @PathVariable Long chapterId,
+
+            @Parameter(description = "챕터 수정 요청 JSON")
+            @Valid @RequestPart(value = "request") UpdateChapterRequest request,
+
+            @Parameter(description = "변경할 챕터 영상 파일. 선택값입니다.", example = "chapter-video-new.mp4")
+            @RequestPart(value = "video", required = false) MultipartFile videoFile
+    ) {
+        String videoUrl = fileStorageManager.uploadFile(videoFile, "videos");
+
+        UpdateChapterCommand command = new UpdateChapterCommand(
+                request.title(),
+                videoUrl,
+                request.durationSeconds(),
+                request.chapterOrder()
+        );
+
+        Chapter updatedChapter = adminChapterUseCase.updateChapter(
+                courseId,
+                chapterId,
+                command
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "CHAPTER_UPDATED",
+                        "챕터 수정에 성공했습니다.",
+                        AdminChapterResponse.from(updatedChapter)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "챕터 삭제",
+            description = "특정 강의의 챕터를 실제 삭제하지 않고 Soft Delete 처리합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "CHAPTER_NOT_FOUND"})
+    @DeleteMapping("/{chapterId}")
+    public ResponseEntity<ApiResponse<Void>> deleteChapter(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "챕터 ID", example = "1")
+            @PathVariable Long chapterId
+    ) {
+        adminChapterUseCase.deleteChapter(courseId, chapterId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "CHAPTER_DELETED",
+                        "챕터 삭제에 성공했습니다."
+                )
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
@@ -29,7 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Admin Course", description = "콘텐츠 매니저 강의 관리 API")
 @RestController
-@RequestMapping("/api/admin/courses")
+@RequestMapping("/api/v1/courses")
 @RequiredArgsConstructor
 public class AdminCourseController {
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateChapterRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateChapterRequest.java
@@ -1,0 +1,25 @@
+package com.kidmily.algoga_server.lms.presentation.request.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "어드민 챕터 등록 요청")
+public record CreateChapterRequest(
+
+        @Schema(description = "챕터 제목", example = "오사카 입국 준비")
+        @NotBlank(message = "챕터 제목은 필수입니다.")
+        String title,
+
+        @Schema(description = "영상 재생 시간. 초 단위", example = "600")
+        @NotNull(message = "영상 재생 시간은 필수입니다.")
+        @Min(value = 1, message = "영상 재생 시간은 1초 이상이어야 합니다.")
+        Integer durationSeconds,
+
+        @Schema(description = "챕터 노출 순서", example = "1")
+        @NotNull(message = "챕터 순서는 필수입니다.")
+        @Min(value = 1, message = "챕터 순서는 1 이상이어야 합니다.")
+        Integer chapterOrder
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateChapterRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateChapterRequest.java
@@ -1,0 +1,25 @@
+package com.kidmily.algoga_server.lms.presentation.request.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "어드민 챕터 수정 요청")
+public record UpdateChapterRequest(
+
+        @Schema(description = "수정할 챕터 제목", example = "오사카 입국 준비 개정판")
+        @NotBlank(message = "챕터 제목은 필수입니다.")
+        String title,
+
+        @Schema(description = "수정할 영상 재생 시간. 초 단위", example = "720")
+        @NotNull(message = "영상 재생 시간은 필수입니다.")
+        @Min(value = 1, message = "영상 재생 시간은 1초 이상이어야 합니다.")
+        Integer durationSeconds,
+
+        @Schema(description = "수정할 챕터 노출 순서", example = "1")
+        @NotNull(message = "챕터 순서는 필수입니다.")
+        @Min(value = 1, message = "챕터 순서는 1 이상이어야 합니다.")
+        Integer chapterOrder
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/request.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/request.http
@@ -1,5 +1,5 @@
 ### 어드민: 로컬 파일 첨부하여 강의 생성
-POST http://localhost:15000/api/admin/courses
+POST http://localhost:15000/api/v1/courses
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -52,15 +52,15 @@ GET http://localhost:15000/api/v1/courses/countries/9999
 
 ### ----------------------------------------------------------
 ### 어드민 - 강의 목록 조회
-GET http://localhost:15000/api/admin/courses?page=0&size=10
+GET http://localhost:15000/api/v1/courses?page=0&size=10
 
 
 ### 어드민 - 강의 상세 조회
-GET http://localhost:15000/api/admin/courses/2
+GET http://localhost:15000/api/v1/courses/2
 
 
 ### 어드민 - 강의 수정
-PUT http://localhost:15000/api/admin/courses/2
+PUT http://localhost:15000/api/v1/courses/2
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -88,10 +88,91 @@ Content-Type: application/pdf
 
 
 ### 어드민 - 강의 삭제
-DELETE http://localhost:15000/api/admin/courses/2
+DELETE http://localhost:15000/api/v1/courses/2
 
 
 ### 어드민 - 존재하지 않는 강의 상세 조회
-GET http://localhost:15000/api/admin/courses/9999
+GET http://localhost:15000/api/v1/courses/9999
 ### ----------------------------------------------------------
 
+### 챕터 관리 - 챕터 목록 조회
+GET http://localhost:15000/api/v1/courses/3/chapters
+
+
+### 챕터 관리 - 챕터 등록
+POST http://localhost:15000/api/v1/courses/3/chapters
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"; filename="request.json"
+Content-Type: application/json
+
+{
+  "title": "1강. 여행 전 필수 준비",
+  "durationSeconds": 600,
+  "chapterOrder": 1
+}
+
+--boundary
+Content-Disposition: form-data; name="video"; filename="sample_video.mp4"
+Content-Type: video/mp4
+
+< ./sample_video.mp4
+
+--boundary--
+
+
+### 챕터 관리 - 챕터 목록 조회
+GET http://localhost:15000/api/v1/courses/3/chapters
+
+
+### 챕터 관리 - 챕터 수정
+### 아래 1을 실제 챕터 등록 응답의 data.chapterId로 바꿔줘
+PUT http://localhost:15000/api/v1/courses/3/chapters/4
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"; filename="request.json"
+Content-Type: application/json
+
+{
+  "title": "1강. 여행 전 필수 준비 수정본",
+  "durationSeconds": 720,
+  "chapterOrder": 1
+}
+
+--boundary
+Content-Disposition: form-data; name="video"; filename="sample_video.mp4"
+Content-Type: video/mp4
+
+< ./sample_video.mp4
+
+--boundary--
+
+
+### 챕터 관리 - 챕터 삭제
+### 아래 1을 실제 챕터 ID로 바꿔줘
+DELETE http://localhost:15000/api/v1/courses/3/chapters/4
+
+
+### 예외 케이스 테스트
+GET http://localhost:15000/api/v1/courses/9999/chapters
+
+### 챕터 관리 - 존재하지 않는 챕터 수정
+PUT http://localhost:15000/api/v1/courses/3/chapters/9999
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"; filename="request.json"
+Content-Type: application/json
+
+{
+  "title": "없는 챕터 수정",
+  "durationSeconds": 720,
+  "chapterOrder": 1
+}
+
+--boundary--
+
+### 삭제 후 목록 조회
+GET http://localhost:15000/api/v1/courses/3/chapters

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminChapterResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminChapterResponse.java
@@ -1,0 +1,38 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "어드민 챕터 응답")
+public record AdminChapterResponse(
+
+        @Schema(description = "챕터 ID", example = "1")
+        Long chapterId,
+
+        @Schema(description = "강의 ID", example = "1")
+        Long courseId,
+
+        @Schema(description = "챕터 제목", example = "오사카 입국 준비")
+        String title,
+
+        @Schema(description = "챕터 영상 파일 경로", example = "videos/550e8400-e29b-41d4-a716-446655440000.mp4")
+        String videoUrl,
+
+        @Schema(description = "영상 재생 시간. 초 단위", example = "600")
+        int durationSeconds,
+
+        @Schema(description = "챕터 노출 순서", example = "1")
+        int chapterOrder
+) {
+
+    public static AdminChapterResponse from(Chapter chapter) {
+        return new AdminChapterResponse(
+                chapter.getId(),
+                chapter.getCourseId(),
+                chapter.getTitle(),
+                chapter.getVideoUrl(),
+                chapter.getDurationSeconds(),
+                chapter.getChapterOrder()
+        );
+    }
+}


### PR DESCRIPTION
## 설명
콘텐츠 매니저가 특정 강의에 포함되는 챕터를 관리할 수 있도록 챕터 CRUD API를 구현했습니다.

- 특정 강의의 챕터 목록 조회 API 구현 / 
- 특정 강의에 챕터 등록 API 구현 / 특정 강의의 챕터 수정 API 구현 / 특정 강의의 챕터 삭제 API 구현
- 챕터 삭제 시 실제 삭제가 아닌 Soft Delete 처리 & 삭제된 챕터는 목록/수정/삭제 대상에서 제외
- 챕터 영상 파일 로컬 저장 처리 : 저장 경로: `uploads/videos` ,  DB 저장 경로 예시: `videos/{uuid}.mp4`
- 존재하지 않는 강의 ID 요청 시 `LMS_001` 예외 처리, 존재하지 않는 챕터 ID 요청 시 `LMS_009` 예외 처리
- 챕터 영상 필수 누락 시 `LMS_010` 예외 처리, 유효하지 않은 챕터 순서 요청 시 `LMS_011` 예외 처리
- Service 계층 로그 추가 : 정상 요청/처리 흐름은 `log.info`, 예상 가능한 예외 상황은 `log.warn` , Controller, RequestDTO, ResponseDTO에 Swagger 어노테이션 및 example 추가
- `request.http` 챕터 관리 테스트 케이스 추가

## 🔗 Issue
Closes #48 

---
## API 응답 구조
챕터 목록 조회 API는 공통 응답인 `ApiResponse`의 `data` 안에 `List<AdminChapterResponse>` 형태로 응답합니다.
프론트에서 사용할 주요 필드는 아래와 같습니다.
- `chapterId`: 챕터 ID
- `courseId`: 강의 ID
- `title`: 챕터 제목
- `videoUrl`: 챕터 영상 파일 경로
- `durationSeconds`: 영상 재생 시간(초)
- `chapterOrder`: 챕터 노출 순서

예시 응답:
```json
{
  "timestamp": "2026-05-24T14:20:59.262080200Z",
  "status": 200,
  "code": "ADMIN_CHAPTERS_FOUND",
  "message": "챕터 목록 조회에 성공했습니다.",
  "data": [
    {
      "chapterId": 4,
      "courseId": 3,
      "title": "1강. 여행 전 필수 준비",
      "videoUrl": "videos/ec0c1ee6-c465-4f4c-9fa5-6de5d96e4a8c.mp4",
      "durationSeconds": 600,
      "chapterOrder": 1
    }
  ]
}
---
확인할 사항

- [ ]  GET /api/v1/courses/{courseId}/chapters 요청 시 특정 강의의 챕터 목록이 노출 순서대로 조회되는지 확인
- [ ]  챕터가 없는 강의 조회 시 data: []로 응답되는지 확인
- [ ]  POST /api/v1/courses/{courseId}/chapters 요청 시 챕터 영상 파일과 기본 정보가 정상 등록되는지 확인
- [ ]  PUT /api/v1/courses/{courseId}/chapters/{chapterId} 요청 시 챕터 제목, 영상, 재생 시간, 노출 순서가 정상 수정되는지 확인
- [ ]  DELETE /api/v1/courses/{courseId}/chapters/{chapterId} 요청 시 챕터가 Soft Delete 처리되는지 확인
- [ ]  삭제된 챕터가 목록 조회에서 제외되는지 확인
- [ ]  존재하지 않는 강의 ID 요청 시 404 LMS_001 응답이 반환되는지 확인
- [ ]  존재하지 않는 챕터 ID 요청 시 404 LMS_009 응답이 반환되는지 확인
- [ ]  Service 계층에서 log.info, log.warn 로그가 정상 출력되는지 확인
- [ ]  Swagger에서 챕터 관리 태그와 챕터 목록/등록/수정/삭제 API 4개가 노출되는지 확인
- [ ]  Swagger에서 PathVariable, RequestDTO, ResponseDTO의 설명 및 example이 노출되는지 확인
- [ ]  request.http 또는 Postman으로 주요 API req/res 결과 확인