### PR TITLE
[Feature] 콘텐츠 매니저 퀴즈 관리 CRUD API 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateQuizCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateQuizCommand.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.lms.application.command;
+
+public record CreateQuizCommand(
+        Long courseId,
+        String question,
+        String option1,
+        String option2,
+        String option3,
+        String option4,
+        int correctOption,
+        String explanation
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateQuizCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateQuizCommand.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.lms.application.command;
+
+public record UpdateQuizCommand(
+        String question,
+        String option1,
+        String option2,
+        String option3,
+        String option4,
+        int correctOption,
+        String explanation
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminQuizService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminQuizService.java
@@ -1,0 +1,154 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.command.CreateQuizCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateQuizCommand;
+import com.kidmily.algoga_server.lms.application.usecase.AdminQuizUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Quiz;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.QuizRepository;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminQuizService implements AdminQuizUseCase {
+
+    private final QuizRepository quizRepository;
+    private final CourseRepository courseRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Quiz> getQuizzes(Long courseId) {
+        log.info("[Quiz Query] 어드민 퀴즈 목록 조회 요청. courseId={}", courseId);
+
+        validateCourse(courseId, "퀴즈 목록 조회");
+
+        List<Quiz> quizzes = quizRepository.findByCourseId(courseId);
+
+        log.info("[Quiz Query] 어드민 퀴즈 목록 조회 완료. courseId={}, count={}",
+                courseId, quizzes.size());
+
+        return quizzes;
+    }
+
+    @Override
+    public Quiz createQuiz(CreateQuizCommand command) {
+        log.info("[Quiz Command] 퀴즈 등록 요청. courseId={}, question={}",
+                command.courseId(), command.question());
+
+        validateCourse(command.courseId(), "퀴즈 등록");
+        validateOptions(command.option1(), command.option2(), command.option3(), command.option4());
+        validateCorrectOption(command.correctOption());
+
+        Quiz quiz = Quiz.create(
+                command.courseId(),
+                command.question(),
+                command.option1(),
+                command.option2(),
+                command.option3(),
+                command.option4(),
+                command.correctOption(),
+                command.explanation()
+        );
+
+        Quiz savedQuiz = quizRepository.save(quiz);
+
+        log.info("[Quiz Command] 퀴즈 등록 완료. courseId={}, quizId={}",
+                savedQuiz.getCourseId(), savedQuiz.getId());
+
+        return savedQuiz;
+    }
+
+    @Override
+    public Quiz updateQuiz(
+            Long courseId,
+            Long quizId,
+            UpdateQuizCommand command
+    ) {
+        log.info("[Quiz Command] 퀴즈 수정 요청. courseId={}, quizId={}, question={}",
+                courseId, quizId, command.question());
+
+        validateCourse(courseId, "퀴즈 수정");
+        validateOptions(command.option1(), command.option2(), command.option3(), command.option4());
+        validateCorrectOption(command.correctOption());
+
+        Quiz updatedQuiz = quizRepository.updateBasicInfo(
+                quizId,
+                courseId,
+                command.question(),
+                command.option1(),
+                command.option2(),
+                command.option3(),
+                command.option4(),
+                command.correctOption(),
+                command.explanation()
+        ).orElseThrow(() -> {
+            log.warn("[Quiz Command] 퀴즈 수정 실패. 존재하지 않거나 삭제된 퀴즈입니다. courseId={}, quizId={}",
+                    courseId, quizId);
+            return new LmsException(LmsErrorCode.QUIZ_NOT_FOUND);
+        });
+
+        log.info("[Quiz Command] 퀴즈 수정 완료. courseId={}, quizId={}",
+                courseId, updatedQuiz.getId());
+
+        return updatedQuiz;
+    }
+
+    @Override
+    public void deleteQuiz(Long courseId, Long quizId) {
+        log.info("[Quiz Command] 퀴즈 삭제 요청. courseId={}, quizId={}",
+                courseId, quizId);
+
+        validateCourse(courseId, "퀴즈 삭제");
+
+        boolean deleted = quizRepository.softDelete(quizId, courseId);
+
+        if (!deleted) {
+            log.warn("[Quiz Command] 퀴즈 삭제 실패. 존재하지 않거나 이미 삭제된 퀴즈입니다. courseId={}, quizId={}",
+                    courseId, quizId);
+            throw new LmsException(LmsErrorCode.QUIZ_NOT_FOUND);
+        }
+
+        log.info("[Quiz Command] 퀴즈 삭제 완료. courseId={}, quizId={}",
+                courseId, quizId);
+    }
+
+    private void validateCourse(Long courseId, String action) {
+        if (courseRepository.findByIdAndDeletedFalse(courseId).isEmpty()) {
+            log.warn("[Quiz Command] {} 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}",
+                    action, courseId);
+            throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+        }
+    }
+
+    private void validateOptions(
+            String option1,
+            String option2,
+            String option3,
+            String option4
+    ) {
+        if (isBlank(option1) || isBlank(option2) || isBlank(option3) || isBlank(option4)) {
+            log.warn("[Quiz Command] 퀴즈 보기 검증 실패. 4개 보기가 모두 필요합니다.");
+            throw new LmsException(LmsErrorCode.INVALID_QUIZ_OPTION);
+        }
+    }
+
+    private void validateCorrectOption(int correctOption) {
+        if (correctOption < 1 || correctOption > 4) {
+            log.warn("[Quiz Command] 퀴즈 정답 번호 검증 실패. correctOption={}", correctOption);
+            throw new LmsException(LmsErrorCode.INVALID_QUIZ_ANSWER);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
@@ -1,4 +1,0 @@
-package com.kidmily.algoga_server.lms.application.service;
-
-public class QuizService {
-}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminQuizUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminQuizUseCase.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.lms.application.usecase;
+
+import com.kidmily.algoga_server.lms.application.command.CreateQuizCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateQuizCommand;
+import com.kidmily.algoga_server.lms.domain.model.Quiz;
+
+import java.util.List;
+
+public interface AdminQuizUseCase {
+
+    List<Quiz> getQuizzes(Long courseId);
+
+    Quiz createQuiz(CreateQuizCommand command);
+
+    Quiz updateQuiz(Long courseId, Long quizId, UpdateQuizCommand command);
+
+    void deleteQuiz(Long courseId, Long quizId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/QuizUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/QuizUseCase.java
@@ -1,4 +1,0 @@
-package com.kidmily.algoga_server.lms.application.usecase;
-
-public class QuizUseCase {
-}

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/Quiz.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/Quiz.java
@@ -1,4 +1,129 @@
 package com.kidmily.algoga_server.lms.domain.model;
 
 public class Quiz {
+
+    private final Long id;
+    private final Long courseId;
+    private final String question;
+    private final String option1;
+    private final String option2;
+    private final String option3;
+    private final String option4;
+    private final int correctOption;
+    private final String explanation;
+    private final boolean deleted;
+
+    private Quiz(
+            Long id,
+            Long courseId,
+            String question,
+            String option1,
+            String option2,
+            String option3,
+            String option4,
+            int correctOption,
+            String explanation,
+            boolean deleted
+    ) {
+        this.id = id;
+        this.courseId = courseId;
+        this.question = question;
+        this.option1 = option1;
+        this.option2 = option2;
+        this.option3 = option3;
+        this.option4 = option4;
+        this.correctOption = correctOption;
+        this.explanation = explanation;
+        this.deleted = deleted;
+    }
+
+    public static Quiz create(
+            Long courseId,
+            String question,
+            String option1,
+            String option2,
+            String option3,
+            String option4,
+            int correctOption,
+            String explanation
+    ) {
+        return new Quiz(
+                null,
+                courseId,
+                question,
+                option1,
+                option2,
+                option3,
+                option4,
+                correctOption,
+                explanation,
+                false
+        );
+    }
+
+    public static Quiz withId(
+            Long id,
+            Long courseId,
+            String question,
+            String option1,
+            String option2,
+            String option3,
+            String option4,
+            int correctOption,
+            String explanation,
+            boolean deleted
+    ) {
+        return new Quiz(
+                id,
+                courseId,
+                question,
+                option1,
+                option2,
+                option3,
+                option4,
+                correctOption,
+                explanation,
+                deleted
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCourseId() {
+        return courseId;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public String getOption1() {
+        return option1;
+    }
+
+    public String getOption2() {
+        return option2;
+    }
+
+    public String getOption3() {
+        return option3;
+    }
+
+    public String getOption4() {
+        return option4;
+    }
+
+    public int getCorrectOption() {
+        return correctOption;
+    }
+
+    public String getExplanation() {
+        return explanation;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/QuizRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/QuizRepository.java
@@ -1,4 +1,29 @@
 package com.kidmily.algoga_server.lms.domain.repository;
 
-public class QuizRepository {
+import com.kidmily.algoga_server.lms.domain.model.Quiz;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuizRepository {
+
+    Quiz save(Quiz quiz);
+
+    List<Quiz> findByCourseId(Long courseId);
+
+    Optional<Quiz> findByIdAndCourseId(Long quizId, Long courseId);
+
+    Optional<Quiz> updateBasicInfo(
+            Long quizId,
+            Long courseId,
+            String question,
+            String option1,
+            String option2,
+            String option3,
+            String option4,
+            int correctOption,
+            String explanation
+    );
+
+    boolean softDelete(Long quizId, Long courseId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
@@ -19,7 +19,9 @@ public enum LmsErrorCode implements BaseErrorCode {
     INVALID_CONTINENT_CODE(HttpStatus.BAD_REQUEST, "LMS_008", "유효하지 않은 대륙 코드입니다."),
     CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_009", "해당 챕터를 찾을 수 없습니다."),
     CHAPTER_VIDEO_REQUIRED(HttpStatus.BAD_REQUEST, "LMS_010", "챕터 영상 파일은 필수입니다."),
-    INVALID_CHAPTER_ORDER(HttpStatus.BAD_REQUEST, "LMS_011", "유효하지 않은 챕터 순서입니다.");
+    INVALID_CHAPTER_ORDER(HttpStatus.BAD_REQUEST, "LMS_011", "유효하지 않은 챕터 순서입니다."),
+    INVALID_QUIZ_OPTION(HttpStatus.BAD_REQUEST, "LMS_012", "퀴즈 보기는 4개 모두 입력해야 합니다."),
+    INVALID_QUIZ_ANSWER(HttpStatus.BAD_REQUEST, "LMS_013", "퀴즈 정답 번호는 1부터 4 사이여야 합니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/QuizRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/QuizRepositoryAdapter.java
@@ -1,4 +1,103 @@
 package com.kidmily.algoga_server.lms.infrastructure.persistence.adapter;
 
-public class QuizRepositoryAdapter {
+import com.kidmily.algoga_server.lms.domain.model.Quiz;
+import com.kidmily.algoga_server.lms.domain.repository.QuizRepository;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.QuizJpaEntity;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.SpringDataQuizRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QuizRepositoryAdapter implements QuizRepository {
+
+    private final SpringDataQuizRepository springDataQuizRepository;
+
+    @Override
+    public Quiz save(Quiz quiz) {
+        QuizJpaEntity entity = new QuizJpaEntity(
+                quiz.getCourseId(),
+                quiz.getQuestion(),
+                quiz.getOption1(),
+                quiz.getOption2(),
+                quiz.getOption3(),
+                quiz.getOption4(),
+                quiz.getCorrectOption(),
+                quiz.getExplanation()
+        );
+
+        QuizJpaEntity savedEntity = springDataQuizRepository.save(entity);
+
+        return toDomain(savedEntity);
+    }
+
+    @Override
+    public List<Quiz> findByCourseId(Long courseId) {
+        return springDataQuizRepository.findByCourseIdAndDeletedFalseOrderByIdAsc(courseId)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<Quiz> findByIdAndCourseId(Long quizId, Long courseId) {
+        return springDataQuizRepository.findByIdAndCourseIdAndDeletedFalse(quizId, courseId)
+                .map(this::toDomain);
+    }
+
+    @Override
+    public Optional<Quiz> updateBasicInfo(
+            Long quizId,
+            Long courseId,
+            String question,
+            String option1,
+            String option2,
+            String option3,
+            String option4,
+            int correctOption,
+            String explanation
+    ) {
+        return springDataQuizRepository.findByIdAndCourseIdAndDeletedFalse(quizId, courseId)
+                .map(entity -> {
+                    entity.updateBasicInfo(
+                            question,
+                            option1,
+                            option2,
+                            option3,
+                            option4,
+                            correctOption,
+                            explanation
+                    );
+
+                    return toDomain(entity);
+                });
+    }
+
+    @Override
+    public boolean softDelete(Long quizId, Long courseId) {
+        return springDataQuizRepository.findByIdAndCourseIdAndDeletedFalse(quizId, courseId)
+                .map(entity -> {
+                    entity.softDelete();
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    private Quiz toDomain(QuizJpaEntity entity) {
+        return Quiz.withId(
+                entity.getId(),
+                entity.getCourseId(),
+                entity.getQuestion(),
+                entity.getOption1(),
+                entity.getOption2(),
+                entity.getOption3(),
+                entity.getOption4(),
+                entity.getCorrectOption(),
+                entity.getExplanation(),
+                entity.isDeleted()
+        );
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/QuizJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/QuizJpaEntity.java
@@ -1,4 +1,88 @@
 package com.kidmily.algoga_server.lms.infrastructure.persistence.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "quizzes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuizJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "quiz_id")
+    private Long id;
+
+    @Column(name = "lecture_id", nullable = false)
+    private Long courseId;
+
+    @Column(nullable = false, length = 500)
+    private String question;
+
+    @Column(name = "option1", nullable = false, length = 255)
+    private String option1;
+
+    @Column(name = "option2", nullable = false, length = 255)
+    private String option2;
+
+    @Column(name = "option3", nullable = false, length = 255)
+    private String option3;
+
+    @Column(name = "option4", nullable = false, length = 255)
+    private String option4;
+
+    @Column(name = "correct_option", nullable = false)
+    private int correctOption;
+
+    @Column(length = 1000)
+    private String explanation;
+
+    @Column(name = "is_deleted")
+    private boolean deleted = false;
+
+    public QuizJpaEntity(
+            Long courseId,
+            String question,
+            String option1,
+            String option2,
+            String option3,
+            String option4,
+            int correctOption,
+            String explanation
+    ) {
+        this.courseId = courseId;
+        this.question = question;
+        this.option1 = option1;
+        this.option2 = option2;
+        this.option3 = option3;
+        this.option4 = option4;
+        this.correctOption = correctOption;
+        this.explanation = explanation;
+        this.deleted = false;
+    }
+
+    public void updateBasicInfo(
+            String question,
+            String option1,
+            String option2,
+            String option3,
+            String option4,
+            int correctOption,
+            String explanation
+    ) {
+        this.question = question;
+        this.option1 = option1;
+        this.option2 = option2;
+        this.option3 = option3;
+        this.option4 = option4;
+        this.correctOption = correctOption;
+        this.explanation = explanation;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataQuizRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataQuizRepository.java
@@ -1,4 +1,14 @@
 package com.kidmily.algoga_server.lms.infrastructure.persistence.repository;
 
-public class SpringDataQuizRepository {
+import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.QuizJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringDataQuizRepository extends JpaRepository<QuizJpaEntity, Long> {
+
+    List<QuizJpaEntity> findByCourseIdAndDeletedFalseOrderByIdAsc(Long courseId);
+
+    Optional<QuizJpaEntity> findByIdAndCourseIdAndDeletedFalse(Long id, Long courseId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminQuizController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminQuizController.java
@@ -1,4 +1,150 @@
 package com.kidmily.algoga_server.lms.presentation.api.admin;
 
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
+import com.kidmily.algoga_server.lms.application.command.CreateQuizCommand;
+import com.kidmily.algoga_server.lms.application.command.UpdateQuizCommand;
+import com.kidmily.algoga_server.lms.application.usecase.AdminQuizUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Quiz;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.presentation.request.admin.CreateQuizRequest;
+import com.kidmily.algoga_server.lms.presentation.request.admin.UpdateQuizRequest;
+import com.kidmily.algoga_server.lms.presentation.response.AdminQuizResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "퀴즈 관리", description = "콘텐츠 매니저 퀴즈 관리 API")
+@RestController
+@RequestMapping("/api/v1/courses/{courseId}/quizzes")
+@RequiredArgsConstructor
 public class AdminQuizController {
+
+    private final AdminQuizUseCase adminQuizUseCase;
+
+    @Operation(
+            summary = "퀴즈 목록 조회",
+            description = "특정 강의에 등록된 퀴즈 목록을 조회합니다. 콘텐츠 매니저용 API이므로 정답과 해설도 함께 반환합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminQuizResponse>>> getQuizzes(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId
+    ) {
+        List<AdminQuizResponse> response = adminQuizUseCase.getQuizzes(courseId)
+                .stream()
+                .map(AdminQuizResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_QUIZZES_FOUND",
+                        "퀴즈 목록 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "퀴즈 등록",
+            description = "특정 강의에 객관식 4지선다 퀴즈를 등록합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "INVALID_QUIZ_OPTION", "INVALID_QUIZ_ANSWER"})
+    @PostMapping
+    public ResponseEntity<ApiResponse<AdminQuizResponse>> createQuiz(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId,
+
+            @Valid @RequestBody CreateQuizRequest request
+    ) {
+        CreateQuizCommand command = new CreateQuizCommand(
+                courseId,
+                request.question(),
+                request.option1(),
+                request.option2(),
+                request.option3(),
+                request.option4(),
+                request.correctOption(),
+                request.explanation()
+        );
+
+        Quiz savedQuiz = adminQuizUseCase.createQuiz(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        "QUIZ_CREATED",
+                        "퀴즈 등록에 성공했습니다.",
+                        AdminQuizResponse.from(savedQuiz)
+                ));
+    }
+
+    @Operation(
+            summary = "퀴즈 수정",
+            description = "특정 강의에 등록된 퀴즈 문제, 보기, 정답, 해설을 수정합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "QUIZ_NOT_FOUND", "INVALID_QUIZ_OPTION", "INVALID_QUIZ_ANSWER"})
+    @PutMapping("/{quizId}")
+    public ResponseEntity<ApiResponse<AdminQuizResponse>> updateQuiz(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "퀴즈 ID", example = "1")
+            @PathVariable Long quizId,
+
+            @Valid @RequestBody UpdateQuizRequest request
+    ) {
+        UpdateQuizCommand command = new UpdateQuizCommand(
+                request.question(),
+                request.option1(),
+                request.option2(),
+                request.option3(),
+                request.option4(),
+                request.correctOption(),
+                request.explanation()
+        );
+
+        Quiz updatedQuiz = adminQuizUseCase.updateQuiz(courseId, quizId, command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "QUIZ_UPDATED",
+                        "퀴즈 수정에 성공했습니다.",
+                        AdminQuizResponse.from(updatedQuiz)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "퀴즈 삭제",
+            description = "특정 강의의 퀴즈를 실제 삭제하지 않고 Soft Delete 처리합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "QUIZ_NOT_FOUND"})
+    @DeleteMapping("/{quizId}")
+    public ResponseEntity<ApiResponse<Void>> deleteQuiz(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "퀴즈 ID", example = "1")
+            @PathVariable Long quizId
+    ) {
+        adminQuizUseCase.deleteQuiz(courseId, quizId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "QUIZ_DELETED",
+                        "퀴즈 삭제에 성공했습니다."
+                )
+        );
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateQuizRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateQuizRequest.java
@@ -6,36 +6,36 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "퀴즈 등록 요청")
-public record CreateQuizRequest(
+@Schema(description = "퀴즈 수정 요청")
+public record UpdateQuizRequest(
 
-        @Schema(description = "퀴즈 문제", example = "일본 오사카 여행 전 준비물로 가장 적절한 것은?")
+        @Schema(description = "수정할 퀴즈 문제", example = "오사카 여행 전 반드시 확인해야 하는 서류는?")
         @NotBlank(message = "퀴즈 문제는 필수입니다.")
         String question,
 
-        @Schema(description = "1번 보기", example = "여권")
+        @Schema(description = "수정할 1번 보기", example = "여권")
         @NotBlank(message = "1번 보기는 필수입니다.")
         String option1,
 
-        @Schema(description = "2번 보기", example = "두꺼운 겨울 패딩")
+        @Schema(description = "수정할 2번 보기", example = "호텔 키")
         @NotBlank(message = "2번 보기는 필수입니다.")
         String option2,
 
-        @Schema(description = "3번 보기", example = "국제운전면허증만")
+        @Schema(description = "수정할 3번 보기", example = "국내 학생증")
         @NotBlank(message = "3번 보기는 필수입니다.")
         String option3,
 
-        @Schema(description = "4번 보기", example = "현지 주민등록증")
+        @Schema(description = "수정할 4번 보기", example = "주민센터 서류")
         @NotBlank(message = "4번 보기는 필수입니다.")
         String option4,
 
-        @Schema(description = "정답 보기 번호. 1부터 4 사이", example = "1")
+        @Schema(description = "수정할 정답 보기 번호. 1부터 4 사이", example = "1")
         @NotNull(message = "정답 번호는 필수입니다.")
         @Min(value = 1, message = "정답 번호는 1 이상이어야 합니다.")
         @Max(value = 4, message = "정답 번호는 4 이하이어야 합니다.")
         Integer correctOption,
 
-        @Schema(description = "해설", example = "해외여행 시 여권은 필수 준비물입니다.")
+        @Schema(description = "수정할 해설", example = "해외 입국을 위해 여권은 필수입니다.")
         String explanation
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/request.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/request.http
@@ -176,3 +176,103 @@ Content-Type: application/json
 
 ### 삭제 후 목록 조회
 GET http://localhost:15000/api/v1/courses/3/chapters
+
+
+
+### ----------------------------------------------------------
+### 퀴즈 관리 - 퀴즈 목록 조회
+GET http://localhost:15000/api/v1/courses/3/quizzes
+
+
+### 퀴즈 관리 - 퀴즈 등록
+### 응답의 data.quizId 값을 아래 수정/삭제 테스트에 사용
+POST http://localhost:15000/api/v1/courses/3/quizzes
+Content-Type: application/json
+
+{
+  "question": "일본 오사카 여행 전 준비물로 가장 적절한 것은?",
+  "option1": "여권",
+  "option2": "두꺼운 겨울 패딩",
+  "option3": "국제운전면허증만",
+  "option4": "현지 주민등록증",
+  "correctOption": 1,
+  "explanation": "해외여행 시 여권은 필수 준비물입니다."
+}
+
+
+### 퀴즈 관리 - 퀴즈 등록 후 목록 조회
+GET http://localhost:15000/api/v1/courses/3/quizzes
+
+
+### 퀴즈 관리 - 퀴즈 수정
+PUT http://localhost:15000/api/v1/courses/3/quizzes/2
+Content-Type: application/json
+
+{
+  "question": "오사카 여행 전 반드시 확인해야 하는 서류는?",
+  "option1": "여권",
+  "option2": "호텔 키",
+  "option3": "국내 학생증",
+  "option4": "주민센터 서류",
+  "correctOption": 1,
+  "explanation": "해외 입국을 위해 여권은 필수입니다."
+}
+
+
+### 퀴즈 관리 - 퀴즈 삭제
+DELETE http://localhost:15000/api/v1/courses/3/quizzes/2
+
+
+### 퀴즈 관리 - 삭제 후 퀴즈 목록 조회
+GET http://localhost:15000/api/v1/courses/3/quizzes
+
+
+### ----------------------------------------------------------
+### 예외 케이스 - 존재하지 않는 강의의 퀴즈 목록 조회
+GET http://localhost:15000/api/v1/courses/9999/quizzes
+
+
+### 예외 케이스 - 존재하지 않는 퀴즈 수정
+### quizId 9999는 존재하지 않는 값
+PUT http://localhost:15000/api/v1/courses/3/quizzes/9999
+Content-Type: application/json
+
+{
+  "question": "없는 퀴즈 수정",
+  "option1": "보기1",
+  "option2": "보기2",
+  "option3": "보기3",
+  "option4": "보기4",
+  "correctOption": 1,
+  "explanation": "없는 퀴즈입니다."
+}
+
+
+### 예외 케이스 - 정답 번호 오류
+POST http://localhost:15000/api/v1/courses/3/quizzes
+Content-Type: application/json
+
+{
+  "question": "정답 번호 오류 테스트",
+  "option1": "보기1",
+  "option2": "보기2",
+  "option3": "보기3",
+  "option4": "보기4",
+  "correctOption": 5,
+  "explanation": "정답 번호는 1부터 4 사이여야 합니다."
+}
+
+
+### 예외 케이스 - 보기 누락
+POST http://localhost:15000/api/v1/courses/3/quizzes
+Content-Type: application/json
+
+{
+  "question": "보기 누락 테스트",
+  "option1": "보기1",
+  "option2": "",
+  "option3": "보기3",
+  "option4": "보기4",
+  "correctOption": 1,
+  "explanation": "보기 4개가 모두 필요합니다."
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminQuizResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminQuizResponse.java
@@ -1,0 +1,50 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.domain.model.Quiz;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀴즈 응답")
+public record AdminQuizResponse(
+
+        @Schema(description = "퀴즈 ID", example = "1")
+        Long quizId,
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "퀴즈 문제", example = "일본 오사카 여행 전 준비물로 가장 적절한 것은?")
+        String question,
+
+        @Schema(description = "1번 보기", example = "여권")
+        String option1,
+
+        @Schema(description = "2번 보기", example = "두꺼운 겨울 패딩")
+        String option2,
+
+        @Schema(description = "3번 보기", example = "국제운전면허증만")
+        String option3,
+
+        @Schema(description = "4번 보기", example = "현지 주민등록증")
+        String option4,
+
+        @Schema(description = "정답 보기 번호", example = "1")
+        int correctOption,
+
+        @Schema(description = "해설", example = "해외여행 시 여권은 필수 준비물입니다.")
+        String explanation
+) {
+
+    public static AdminQuizResponse from(Quiz quiz) {
+        return new AdminQuizResponse(
+                quiz.getId(),
+                quiz.getCourseId(),
+                quiz.getQuestion(),
+                quiz.getOption1(),
+                quiz.getOption2(),
+                quiz.getOption3(),
+                quiz.getOption4(),
+                quiz.getCorrectOption(),
+                quiz.getExplanation()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/QuizResultResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/QuizResultResponse.java
@@ -1,4 +1,0 @@
-package com.kidmily.algoga_server.lms.presentation.response;
-
-public class QuizResultResponse {
-}


### PR DESCRIPTION
## 설명
콘텐츠 매니저가 특정 강의에 포함되는 객관식 퀴즈를 관리할 수 있도록 퀴즈 CRUD API를 구현했습니다.

- 특정 강의의 퀴즈 목록 조회 , 등록, 수정, 삭제 API 구현
- 퀴즈 삭제 시 실제 삭제가 아닌 Soft Delete 처리
- 삭제된 퀴즈는 목록/수정/삭제 대상에서 제외
- 객관식 4지선다 보기 데이터 처리
- 정답 번호 `correctOption` 처리
- 퀴즈 해설 `explanation` 저장 및 응답 처리
- 존재하지 않는 강의 ID 요청 시 `LMS_001` 예외 처리 , 존재하지 않는 퀴즈 ID 요청 시 `LMS_002` 예외 처리 , 보기 4개 누락 시 `LMS_012` 예외 처리 , 정답 번호가 1~4 범위를 벗어나는 경우 `LMS_013` 예외 처리
- Service 계층 로그 추가
  - 정상 요청/처리 흐름은 `log.info`
  - 예상 가능한 예외 상황은 `log.warn`
- Controller, RequestDTO, ResponseDTO에 Swagger 어노테이션 및 example 추가
- `request.http` 퀴즈 관리 테스트 케이스 추가

## 🔗 Issue
Closes #52 

---
## API 응답 구조
퀴즈 목록 조회 API는 공통 응답인 `ApiResponse`의 `data` 안에 `List<AdminQuizResponse>` 형태로 응답.
콘텐츠 매니저용 API이므로 퀴즈 목록 조회 시 정답 번호와 해설도 함께 반환.
프론트에서 사용할 주요 필드는 아래와 같습니다.
- `quizId`: 퀴즈 ID
- `courseId`: 강의 ID
- `question`: 퀴즈 문제
- `option1`: 1번 보기
- `option2`: 2번 보기
- `option3`: 3번 보기
- `option4`: 4번 보기
- `correctOption`: 정답 보기 번호
- `explanation`: 해설

예시 응답:
```json
{
  "timestamp": "2026-05-24T15:38:54.271766200Z",
  "status": 200,
  "code": "ADMIN_QUIZZES_FOUND",
  "message": "퀴즈 목록 조회에 성공했습니다.",
  "data": [
    {
      "quizId": 2,
      "courseId": 3,
      "question": "일본 오사카 여행 전 준비물로 가장 적절한 것은?",
      "option1": "여권",
      "option2": "두꺼운 겨울 패딩",
      "option3": "국제운전면허증만",
      "option4": "현지 주민등록증",
      "correctOption": 1,
      "explanation": "해외여행 시 여권은 필수 준비물입니다."
    }
  ]
}

## 확인할 사항
- [ ] GET /api/v1/courses/{courseId}/quizzes 요청 시 특정 강의의 퀴즈 목록이 조회되는지 확인
- [ ]  퀴즈가 없는 강의 조회 시 data: []로 응답되는지 확인
- [ ]  POST /api/v1/courses/{courseId}/quizzes 요청 시 퀴즈 문제, 보기 4개, 정답 번호, 해설이 정상 등록되는지 확인
- [ ]  PUT /api/v1/courses/{courseId}/quizzes/{quizId} 요청 시 퀴즈 문제, 보기, 정답 번호, 해설이 정상 수정되는지 확인
- [ ]  DELETE /api/v1/courses/{courseId}/quizzes/{quizId} 요청 시 퀴즈가 Soft Delete 처리되는지 확인
- [ ]  삭제된 퀴즈가 목록 조회에서 제외되는지 확인
- [ ]  존재하지 않는 강의 ID 요청 시 404 LMS_001 응답이 반환되는지 확인
- [ ]  존재하지 않는 퀴즈 ID 요청 시 404 LMS_002 응답이 반환되는지 확인
- [ ]  보기 4개 중 누락된 값이 있을 경우 예외 응답이 반환되는지 확인
- [ ]  정답 번호가 1~4 범위를 벗어날 경우 예외 응답이 반환되는지 확인
- [ ]  Service 계층에서 log.info, log.warn 로그가 정상 출력되는지 확인
- [ ]  Swagger에서 퀴즈 관리 태그와 퀴즈 목록/등록/수정/삭제 API 4개가 노출되는지 확인
- [ ]  Swagger에서 PathVariable, RequestDTO, ResponseDTO의 설명 및 example이 노출되는지 확인
- [ ]  request.http 또는 Postman으로 주요 API req/res 결과 확인