### PR TITLE
[Feature] 커뮤니티 게시글 전체, 내가 작성한 글, 태그 목록 조회 API 구현, 조회수 증가 로직 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostCommandService.java
@@ -7,7 +7,7 @@ import com.kidmily.algoga_server.community.application.usecase.PostCommandUseCas
 import com.kidmily.algoga_server.community.domain.model.Post;
 import com.kidmily.algoga_server.community.domain.repository.PostRepository;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
-import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.community.exception.PostException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -60,10 +60,7 @@ public class PostCommandService implements PostCommandUseCase {
                 command.postId(), command.requesterId());
 
         Post post = postRepository.findById(command.postId())
-                .orElseThrow(() -> {
-                    log.warn("[PostCommandService] 게시글을 찾을 수 없음 - postId: {}", command.postId());
-                    return new BusinessException(PostErrorCode.POST_NOT_FOUND);
-                });
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
         post.update(
                 command.requesterId(),
@@ -88,10 +85,7 @@ public class PostCommandService implements PostCommandUseCase {
                 command.postId(), command.requesterId());
 
         Post post = postRepository.findById(command.postId())
-                .orElseThrow(() -> {
-                    log.warn("[PostCommandService] 게시글을 찾을 수 없음 - postId: {}", command.postId());
-                    return new BusinessException(PostErrorCode.POST_NOT_FOUND);
-                });
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
         post.delete(command.requesterId());
         postRepository.delete(post);

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
@@ -6,13 +6,10 @@ import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
 import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
 import com.kidmily.algoga_server.community.domain.repository.PostRepository;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.exception.PostException;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
-import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataCommentRepository;
-import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataLikeDislikeRepository;
-import com.kidmily.algoga_server.community.presentation.api.response.CommentResponse;
-import com.kidmily.algoga_server.community.presentation.api.response.PostResponse;
-import com.kidmily.algoga_server.community.presentation.api.response.TagResponse;
-import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.community.presentation.api.response.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +27,7 @@ public class PostQueryService implements PostQueryUseCase {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final LikeDislikeRepository likeDislikeRepository;
+    private static final int PAGE_SIZE = 10;
 
     @Override
     @Transactional
@@ -37,10 +35,8 @@ public class PostQueryService implements PostQueryUseCase {
         log.info("[PostQueryService] 게시글 단건 조회 요청 - postId: {}", postId);
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> {
-                    log.warn("[PostQueryService] 게시글을 찾을 수 없음 - postId: {}", postId);
-                    return new BusinessException(PostErrorCode.POST_NOT_FOUND);
-                });
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
 
         // 조회수 증가
         post.increaseViewCount();
@@ -84,5 +80,84 @@ public class PostQueryService implements PostQueryUseCase {
         );
     }
 
+    @Override
+    public List<PostTagType> getCategories() {
+        return List.of(
+                PostTagType.TRAVEL_REVIEW,
+                PostTagType.TIP_INFO,
+                PostTagType.QUESTION,
+                PostTagType.COMPANION,
+                PostTagType.FREE,
+                PostTagType.LECTURE
+        );
+    }
 
+    @Override
+    public PostListResponse getPosts(Long lastPostId, List<PostTagType> categories) {
+        log.info("[PostQueryService] 게시글 목록 조회 요청 - lastPostId: {}, categories: {}",
+                lastPostId, categories);
+
+        List<Post> posts = postRepository.findPostsByCursor(lastPostId, PAGE_SIZE, categories);
+
+        List<PostListItemResponse> items = posts.stream()
+                .map(this::toListItem)
+                .toList();
+
+        boolean hasNext = items.size() == PAGE_SIZE;
+        Long nextLastPostId = items.isEmpty() ? null : items.get(items.size() - 1).postId();
+
+        return new PostListResponse(items, hasNext, nextLastPostId);
+    }
+
+    // 내가 쓴 글 목록 조회
+    @Override
+    public PostListResponse getMyPosts(Long userId, Long lastPostId, List<PostTagType> categories) {
+        log.info("[PostQueryService] 내가 작성한 게시글 목록 조회 요청 - userId: {}, lastPostId: {}, categories: {}",
+                userId, lastPostId, categories);
+
+        // 도메인 포트(PostRepository) 호출
+        List<Post> posts = postRepository.findMyPostsByCursor(userId, lastPostId, PAGE_SIZE, categories);
+
+        List<PostListItemResponse> items = posts.stream()
+                .map(this::toListItem)
+                .toList();
+
+        boolean hasNext = items.size() == PAGE_SIZE;
+        Long nextLastPostId = items.isEmpty() ? null : items.get(items.size() - 1).postId();
+
+        return new PostListResponse(items, hasNext, nextLastPostId);
+    }
+
+    private PostListItemResponse toListItem(Post post) {
+        Long likeCount = likeDislikeRepository.countLikes(TargetType.POST, post.getId());
+        Long dislikeCount = likeDislikeRepository.countDislikes(TargetType.POST, post.getId());
+        Long commentCount = (long) commentRepository.findActiveCommentsByPostId(post.getId()).size();
+
+        Stream<TagResponse> categoryStream = post.getCategory() != null ?
+                Stream.of(TagResponse.fromCategory(post.getCategory())) : Stream.empty();
+        Stream<TagResponse> freeTagStream = post.getFreeTags() != null ?
+                post.getFreeTags().stream().map(TagResponse::fromFreeTag) : Stream.empty();
+        List<TagResponse> tags = Stream.concat(categoryStream, freeTagStream).toList();
+
+        String thumbnailUrl = (post.getImageUrls() != null && !post.getImageUrls().isEmpty())
+                ? post.getImageUrls().get(0)
+                : null;
+
+        return new PostListItemResponse(
+                post.getId(),
+                post.getAuthorId(),
+                "임시닉네임",  // TODO: User 도메인 추가 후 교체
+                null, // TODO: User 도메인 추가 후 교체, 프로필 url
+                post.getCountryId(), // TODO: 나라 도메인 추가 후 교체
+                "임시나라",  // TODO: 나라 도메인 추가 후 교체
+                tags,
+                post.getTitle(),
+                post.getContent(),
+                thumbnailUrl,
+                likeCount,
+                dislikeCount,
+                commentCount,
+                post.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostQueryUseCase.java
@@ -1,7 +1,20 @@
 package com.kidmily.algoga_server.community.application.usecase;
 
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.presentation.api.response.PostListResponse;
 import com.kidmily.algoga_server.community.presentation.api.response.PostResponse;
+
+import java.util.List;
 
 public interface PostQueryUseCase {
     PostResponse getPost(Long postId);
+
+    // 태그 목록 조회
+    List<PostTagType> getCategories();
+
+    // 전체 게시글 목록 조회
+    PostListResponse getPosts(Long lastPostId, List<PostTagType> categories);
+
+    // 내가 작성한 글 목록 조회
+    PostListResponse getMyPosts(Long userId, Long lastPostId, List<PostTagType> categories);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
@@ -1,8 +1,8 @@
 package com.kidmily.algoga_server.community.domain.model;
 
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.exception.PostException;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
-import com.kidmily.algoga_server.global.exception.BusinessException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -106,13 +106,13 @@ public class Post {
 
     private void validateOwnerForUpdate(Long requesterId) {
         if (!this.authorId.equals(requesterId)) {
-            throw new BusinessException(PostErrorCode.POST_UPDATE_FORBIDDEN);
+            throw new PostException(PostErrorCode.POST_UPDATE_FORBIDDEN);
         }
     }
 
     private void validateOwnerForDelete(Long requesterId) {
         if (!this.authorId.equals(requesterId)) {
-            throw new BusinessException(PostErrorCode.POST_DELETE_FORBIDDEN);
+            throw new PostException(PostErrorCode.POST_DELETE_FORBIDDEN);
         }
     }
 
@@ -133,38 +133,38 @@ public class Post {
     // 3. 도메인 규칙 검증 메서드 (상단 import에 맞게 BusinessException으로 일관성 유지)
     private void validateCategory(PostTagType category) {
         if (category == null) {
-            throw new BusinessException(PostErrorCode.POST_CATEGORY_INVALID);
+            throw new PostException(PostErrorCode.POST_CATEGORY_INVALID);
         }
     }
 
     private void validateTitle(String title) {
         if (title == null || title.trim().isEmpty()) {
-            throw new BusinessException(PostErrorCode.POST_TITLE_BLANK);
+            throw new PostException(PostErrorCode.POST_TITLE_BLANK);
         }
     }
 
     private void validateContent(String content) {
         if (content == null || content.trim().isEmpty()) {
-            throw new BusinessException(PostErrorCode.POST_CONTENT_BLANK);
+            throw new PostException(PostErrorCode.POST_CONTENT_BLANK);
         }
     }
 
     private void validateFreeTags(List<String> freeTags) {
         if (freeTags != null && freeTags.size() > MAX_FREE_TAG_COUNT) {
-            throw new BusinessException(PostErrorCode.POST_FREE_TAG_LIMIT_EXCEEDED);
+            throw new PostException(PostErrorCode.POST_FREE_TAG_LIMIT_EXCEEDED);
         }
         // 중복 검증
         if (freeTags != null) {
             long distinctCount = freeTags.stream().distinct().count();
             if (distinctCount != freeTags.size()) {
-                throw new BusinessException(PostErrorCode.POST_FREE_TAG_DUPLICATED);
+                throw new PostException(PostErrorCode.POST_FREE_TAG_DUPLICATED);
             }
         }
     }
 
     private void validateImages(List<String> imageUrls) {
         if (imageUrls != null && imageUrls.size() > MAX_IMAGE_COUNT) {
-            throw new BusinessException(PostErrorCode.POST_IMAGE_COUNT_EXCEEDED);
+            throw new PostException(PostErrorCode.POST_IMAGE_COUNT_EXCEEDED);
         }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
@@ -1,7 +1,9 @@
 package com.kidmily.algoga_server.community.domain.repository;
 
 import com.kidmily.algoga_server.community.domain.model.Post;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
 
+import java.util.List;
 import java.util.Optional;
 
 // Application, Domain 계층이 사용할 레포지토리 포트(Port)
@@ -10,4 +12,8 @@ public interface PostRepository {
     Optional<Post> findById(Long id);
     Post update(Post post);
     void delete(Post post);
+    // 전체 리스트 조회
+    List<Post> findPostsByCursor(Long lastPostId, int size, List<PostTagType> categories);
+    // 내가 쓴 글 리스트 조회
+    List<Post> findMyPostsByCursor(Long userId, Long lastPostId, int size, List<PostTagType> categories);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
@@ -10,25 +10,28 @@ import org.springframework.http.HttpStatus;
 public enum PostErrorCode implements BaseErrorCode {
 
     // 400 - 입력값 검증
+    POST_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "POST_000", "잘못된 요청입니다. 입력값을 확인해주세요."),
     POST_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "POST_001", "유효하지 않은 카테고리입니다."),
-    POST_CATEGORY_BLANK(HttpStatus.BAD_REQUEST, "POST_00X", "카테고리는 필수입니다."),
-    POST_FREE_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "POST_002", "자유 태그는 최대 10개까지 등록 가능합니다."),
-    POST_COURSE_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "POST_003", "수강강의 태그는 최대 10개까지 등록 가능합니다."),
-    POST_FREE_TAG_DUPLICATED(HttpStatus.BAD_REQUEST, "POST_00X", "자유 태그에 중복된 값이 있습니다."),
-    POST_TITLE_BLANK(HttpStatus.BAD_REQUEST, "POST_007", "제목은 필수입니다."),
-    POST_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "POST_008", "본문은 필수입니다."),
+    POST_CATEGORY_BLANK(HttpStatus.BAD_REQUEST, "POST_002", "카테고리는 필수입니다."),
+    POST_FREE_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "POST_003", "자유 태그는 최대 10개까지 등록 가능합니다."),
+    POST_COURSE_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "POST_004", "수강강의 태그는 최대 10개까지 등록 가능합니다."),
+    POST_FREE_TAG_DUPLICATED(HttpStatus.BAD_REQUEST, "POST_005", "자유 태그에 중복된 값이 있습니다."),
+    POST_TITLE_BLANK(HttpStatus.BAD_REQUEST, "POST_006", "제목은 필수입니다."),
+    POST_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "POST_007", "본문은 필수입니다."),
 
     // 401 - 인증
-    POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_004", "게시글 작성 권한이 없습니다."),
+    POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_008", "게시글 작성 권한이 없습니다."),
 
     // 413 - 이미지
-    POST_IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_005", "이미지는 최대 10장까지 업로드 가능합니다."),
-    POST_IMAGE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_006", "이미지 한 장의 크기는 최대 10MB입니다."),
+    POST_IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_009", "이미지는 최대 10장까지 업로드 가능합니다."),
+    POST_IMAGE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_010", "이미지 한 장의 크기는 최대 10MB입니다."),
 
-    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_00X", "게시글을 수정할 권한이 없습니다."),
-    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_00X", "게시글을 삭제할 권한이 없습니다."),
+    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_011", "게시글을 수정할 권한이 없습니다."),
+    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_012", "게시글을 삭제할 권한이 없습니다."),
+    POST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_013", "해당 목록을 조회할 권한이 없습니다."),
 
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_00X", "게시글을 찾을 수 없습니다.");
+    // 404
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_014", "게시글을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kidmily/algoga_server/community/exception/PostException.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/PostException.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.community.exception;
+
+public class PostException extends RuntimeException {
+    private final PostErrorCode errorCode;
+
+    public PostException(PostErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public PostErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
@@ -2,16 +2,17 @@ package com.kidmily.algoga_server.community.infrastructure.persistence;
 
 import com.kidmily.algoga_server.community.domain.model.Post;
 import com.kidmily.algoga_server.community.domain.repository.PostRepository;
-import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.infrastructure.mapper.PostMapper;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTag;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
 import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataPostRepository;
-import com.kidmily.algoga_server.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -42,8 +43,8 @@ public class PostRepositoryAdapter implements PostRepository {
     @Override
     public Post update(Post post) {
         // 기존 엔티티 조회
-        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId())
-                .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId()).get();
+
 
         // 기존 태그/이미지 전부 삭제 (orphanRemoval이 처리)
         jpaEntity.getPostTags().clear();
@@ -55,7 +56,8 @@ public class PostRepositoryAdapter implements PostRepository {
                 post.getTitle(),
                 post.getContent(),
                 post.getCountryId(),
-                post.getLectureId()
+                post.getLectureId(),
+                post.getViewCount()
         );
 
         // 새 태그 추가
@@ -81,9 +83,41 @@ public class PostRepositoryAdapter implements PostRepository {
 
     @Override
     public void delete(Post post) {
-        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId())
-                .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId()).get();
+
         jpaEntity.softDelete();  // PostJpaEntity에 이미 있음
         springDataRepository.save(jpaEntity);
+    }
+
+    // 게시글 전체 조회
+    @Override
+    public List<Post> findPostsByCursor(Long lastPostId, int size, List<PostTagType> categories) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        // 빈 리스트면 null로 처리해서 전체 조회
+        List<PostTagType> categoriesParam = (categories == null || categories.isEmpty()) ? null : categories;
+
+        List<PostJpaEntity> entities = springDataRepository.findPostsByCursor(
+                lastPostId, categoriesParam, pageable);
+
+        return entities.stream()
+                .map(postMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Post> findMyPostsByCursor(Long userId, Long lastPostId, int size, List<PostTagType> categories) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        // 빈 리스트면 null로 처리해서 전체 조회가 가능하도록 정제
+        List<PostTagType> categoriesParam = (categories == null || categories.isEmpty()) ? null : categories;
+
+        // 통합 Query 메서드 다이렉트 호출
+        List<PostJpaEntity> entities = springDataRepository.findMyPostsByCursor(
+                userId, lastPostId, categoriesParam, pageable);
+
+        return entities.stream()
+                .map(postMapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
@@ -76,11 +76,12 @@ public class PostJpaEntity {
     }
 
     public void update(PostTagType category, String title, String content,
-                       Long countryId, Long lectureId) {
+                       Long countryId, Long lectureId, Integer viewCount) {
         this.title = title;
         this.content = content;
         this.countryId = countryId;
         this.lectureId = lectureId;
+        this.viewCount = viewCount;
     }
 
     public void softDelete() {

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTagType.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTagType.java
@@ -13,7 +13,7 @@ public enum PostTagType {
     COMPANION("동행 구해요"),
     COUNTRY("나라"),
     LECTURE("수강강의"),
-    FREE("자유");
+    FREE("자유(커스텀태그)");
 
     // 한글 명칭을 저장할 변수 (final로 안전하게 보호)
     private final String description;

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
@@ -1,7 +1,38 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence.repository;
 
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SpringDataPostRepository extends JpaRepository<PostJpaEntity, Long> {
+
+    @Query("SELECT DISTINCT p FROM PostJpaEntity p " +
+            "LEFT JOIN p.postTags t " +
+            "WHERE p.isDeleted = false " +
+            "AND (:lastPostId IS NULL OR p.postId < :lastPostId) " +
+            "AND (:categories IS NULL OR t.tagType IN :categories) " +
+            "ORDER BY p.postId DESC")
+    List<PostJpaEntity> findPostsByCursor(
+            @Param("lastPostId") Long lastPostId,
+            @Param("categories") List<PostTagType> categories,
+            Pageable pageable);
+
+    // 💡 마이페이지 전용 단일 통합 쿼리
+    @Query("SELECT DISTINCT p FROM PostJpaEntity p " +
+            "LEFT JOIN p.postTags t " +
+            "WHERE p.isDeleted = false " +
+            "AND p.authorId = :authorId " + // 본인 글 필터링 조건
+            "AND (:lastPostId IS NULL OR p.postId < :lastPostId) " +
+            "AND (:categories IS NULL OR t.tagType IN :categories) " +
+            "ORDER BY p.postId DESC")
+    List<PostJpaEntity> findMyPostsByCursor(
+            @Param("authorId") Long authorId,
+            @Param("lastPostId") Long lastPostId,
+            @Param("categories") List<PostTagType> categories,
+            Pageable pageable);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
@@ -1,9 +1,16 @@
 package com.kidmily.algoga_server.community.presentation.advice;
 
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.exception.PostException;
+import com.kidmily.algoga_server.global.common.api.response.ErrorResponse;
 import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
 
 @Slf4j
 @RestControllerAdvice(basePackages = "com.kidmily.algoga_server.community.presentation.api")
@@ -15,4 +22,22 @@ public class CommunityExceptionAdvice implements CommonExceptionAdvice {
     }
 
     // 커뮤니티 도메인에서만 발생하는 특수 예외가 있다면 이곳에 추가
+
+    @ExceptionHandler(PostException.class)
+    public ResponseEntity<ErrorResponse> handlePostException(PostException e) {
+        String traceId = getOrCreateTraceId();
+        PostErrorCode errorCode = e.getErrorCode();
+
+        log.warn("[PostDomainException] traceId: {}, code: {}, message: {}",
+                traceId, errorCode.getCode(), errorCode.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                traceId
+        );
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
@@ -6,12 +6,12 @@ import com.kidmily.algoga_server.community.application.command.UpdatePostCommand
 import com.kidmily.algoga_server.community.application.usecase.PostCommandUseCase;
 import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
 import com.kidmily.algoga_server.community.presentation.api.request.CreatePostRequest;
 import com.kidmily.algoga_server.community.presentation.api.request.UpdatePostRequest;
-import com.kidmily.algoga_server.community.presentation.api.response.CreatePostResponse;
-import com.kidmily.algoga_server.community.presentation.api.response.PostResponse;
-import com.kidmily.algoga_server.community.presentation.api.response.UpdatePostResponse;
+import com.kidmily.algoga_server.community.presentation.api.response.*;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExamples;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,18 +38,16 @@ public class CommunityController {
     @PostMapping
     @Operation(summary = "게시글 작성", description = "나라, 자유, 수강강의 태그 및 최대 10장의 사진을 포함해 게시글을 등록합니다.")
 
-    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {
-            "INVALID_REQUEST",
-            "UNAUTHORIZED"
-    })
-    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
-            "POST_CATEGORY_INVALID",
-            "POST_FREE_TAG_LIMIT_EXCEEDED",
-            "POST_COURSE_TAG_LIMIT_EXCEEDED",
-            "POST_IMAGE_COUNT_EXCEEDED",
-            "POST_IMAGE_SIZE_EXCEEDED"
-    })
-
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "게시글 작성에 성공했습니다.")
+            @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+                    "POST_INVALID_REQUEST",
+                    "POST_CATEGORY_INVALID",
+                    "POST_FREE_TAG_LIMIT_EXCEEDED",
+                    "POST_COURSE_TAG_LIMIT_EXCEEDED",
+                    "POST_IMAGE_COUNT_EXCEEDED",
+                    "POST_IMAGE_SIZE_EXCEEDED",
+                    "POST_UNAUTHORIZED"
+            })
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
             @Valid @RequestBody CreatePostRequest request
     ) {
@@ -71,18 +69,40 @@ public class CommunityController {
                 .body(ApiResponse.created("POST_CREATED", "게시글 작성에 성공했습니다.", responseData));
     }
 
+    @GetMapping("/tags")
+    @Operation(summary = "게시글 카테고리 태그 목록 조회", description = "게시글 작성 시 선택 가능한 카테고리 태그 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<TagResponse>>> getCategories() {
+        List<TagResponse> responseData = postQueryUseCase.getCategories()
+                .stream()
+                .map(TagResponse::fromCategory)
+                .toList();
+        return ResponseEntity.ok(ApiResponse.success("CATEGORIES_FOUND", "카테고리 목록 조회에 성공했습니다.", responseData));
+    }
+
+    @GetMapping
+    @Operation(summary = "게시글 목록 조회", description = "무한 스크롤 방식으로 게시글 목록을 조회합니다. 카테고리 필터링 가능 (다중 선택 가능).")
+    public ResponseEntity<ApiResponse<PostListResponse>> getPosts(
+            @Parameter(description = "마지막 게시글 ID (첫 페이지는 생략)", example = "420")
+            @RequestParam(required = false) Long lastPostId,
+
+            @Parameter(description = "필터링할 카테고리 (다중 선택 가능, 생략 시 전체)", example = "QUESTION,TRAVEL_REVIEW")
+            @RequestParam(required = false) List<PostTagType> categories
+    ) {
+        PostListResponse responseData = postQueryUseCase.getPosts(lastPostId, categories);
+        return ResponseEntity.ok(ApiResponse.success("POSTS_FOUND", "게시글 목록 조회에 성공했습니다.", responseData));
+    }
+
     @PutMapping("/{postId}")
     @Operation(summary = "게시글 수정", description = "본인 게시글의 제목, 내용, 카테고리, 태그를 수정합니다.")
-    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {
-            "INVALID_REQUEST",
-            "UNAUTHORIZED"
-    })
-    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
-            "POST_NOT_FOUND",
-            "POST_FORBIDDEN",
-            "POST_CATEGORY_INVALID",
-            "POST_FREE_TAG_LIMIT_EXCEEDED"
-    })
+
+            @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+                    "POST_INVALID_REQUEST",
+                    "POST_UNAUTHORIZED",          // 401
+                    "POST_NOT_FOUND",             // 404
+                    "POST_UPDATE_FORBIDDEN",      // 403 (실제 에넘 상수에 맞게 매핑)
+                    "POST_CATEGORY_INVALID",      // 400
+                    "POST_FREE_TAG_LIMIT_EXCEEDED" // 400
+            })
     public ResponseEntity<ApiResponse<UpdatePostResponse>> updatePost(
             @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId,
@@ -108,14 +128,13 @@ public class CommunityController {
 
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "본인 게시글을 Soft Delete 처리합니다. 연관 댓글도 함께 삭제됩니다.")
-    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {
-            "UNAUTHORIZED"
-    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "게시글이 성공적으로 삭제되었습니다. (반환 바디 없음)")
     @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
-            "POST_NOT_FOUND",
-            "POST_FORBIDDEN"
+            "POST_NOT_FOUND",          // 404 Not Found (스웨거 명세에 확실하게 추가 완료)
+            "POST_DELETE_FORBIDDEN",   // 403 Forbidden (본인 글이 아닐 때)
+            "POST_UNAUTHORIZED"        // 401 Unauthorized (로그인 안 했을 때)
     })
-    public ResponseEntity<ApiResponse<Void>> deletePost(
+    public ResponseEntity<Void> deletePost(
             @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId
     ) {
@@ -124,7 +143,7 @@ public class CommunityController {
         DeletePostCommand command = new DeletePostCommand(postId, currentUserId);
         postCommandUseCase.handle(command);
 
-        return ResponseEntity.ok(ApiResponse.success("POST_DELETED", "게시글이 삭제되었습니다.", null));
+        return ResponseEntity.noContent().build();
     }
 
     // 게시글 상세 조회
@@ -137,5 +156,26 @@ public class CommunityController {
     ) {
         PostResponse responseData = postQueryUseCase.getPost(postId);
         return ResponseEntity.ok(ApiResponse.success("POST_FOUND", "게시글 조회에 성공했습니다.", responseData));
+    }
+
+    // 마이페이지 - 내가 쓸 글 목록 조회
+    @GetMapping("/me/posts")
+    @Operation(summary = "내가 작성한 게시글 목록 조회", description = "마이페이지에서 본인이 작성한 글 목록을 무한 스크롤 방식으로 최신순 조회합니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "POST_UNAUTHORIZED",      // 401 Unauthorized
+            "POST_ACCESS_FORBIDDEN",   // 403 권한 부족
+            "POST_NOT_FOUND"          // 404 Not Found
+    })
+    public ResponseEntity<ApiResponse<PostListResponse>> getMyPosts(
+            @Parameter(description = "마지막 게시글 ID (첫 페이지는 생략)", example = "420")
+            @RequestParam(required = false) Long lastPostId,
+
+            @Parameter(description = "필터링할 카테고리 (다중 선택 가능, 생략 시 전체)", example = "QUESTION,TRAVEL_REVIEW")
+            @RequestParam(required = false) List<PostTagType> categories
+    ) {
+        long currentUserId = 1L; // TODO: Spring Security 적용 후 토큰에서 추출하도록 교체
+
+        PostListResponse responseData = postQueryUseCase.getMyPosts(currentUserId, lastPostId, categories);
+        return ResponseEntity.ok(ApiResponse.success("MY_POSTS_FOUND", "내가 작성한 게시글 목록 조회에 성공했습니다.", responseData));
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/PostListItemResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/PostListItemResponse.java
@@ -1,0 +1,52 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "게시글 목록 항목 응답")
+public record PostListItemResponse(
+
+        @Schema(description = "게시글 ID", example = "1")
+        Long postId,
+
+        @Schema(description = "작성자 ID", example = "1")
+        Long authorId,
+
+        @Schema(description = "작성자 닉네임", example = "여행러버")
+        String authorNickname,
+
+        @Schema(description = "작성자 프로필 이미지 URL (User 도메인 연동 전 null)", example = "null")
+        String authorProfileImageUrl,
+
+        @Schema(description = "나라 ID (나라 필터링 시 사용)", example = "1")
+        Long countryId,
+
+        @Schema(description = "나라 이름 (나라 도메인 연동 전 임시값)", example = "임시나라")
+        String countryName,
+
+        @Schema(description = "태그 목록")
+        List<TagResponse> tags,
+
+        @Schema(description = "제목", example = "도쿄 3박 4일 완벽 여행 후기")
+        String title,
+
+        @Schema(description = "본문", example = "알고가 강의 덕분에 완벽한 도쿄 여행을...")
+        String content,
+
+        @Schema(description = "대표 이미지 URL", example = "https://...")
+        String thumbnailUrl,
+
+        @Schema(description = "좋아요 수", example = "234")
+        Long likeCount,
+
+        @Schema(description = "싫어요 수", example = "1")
+        Long dislikeCount,
+
+        @Schema(description = "댓글 수", example = "45")
+        Long commentCount,
+
+        @Schema(description = "작성일시")
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/PostListResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/PostListResponse.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "게시글 목록 응답 (무한 스크롤)")
+public record PostListResponse(
+
+        @Schema(description = "게시글 목록")
+        List<PostListItemResponse> posts,
+
+        @Schema(description = "다음 페이지가 있는지 여부", example = "true")
+        Boolean hasNext,
+
+        @Schema(description = "다음 요청 시 사용할 마지막 게시글 ID (없으면 null)", example = "420")
+        Long lastPostId
+) {}


### PR DESCRIPTION
## 설명
게시글 목록 조회: 커서 기반 페이징을 적용하여 성능을 최적화했으며, 카테고리별 필터링 기능을 추가하였습니다.

나의 게시글 조회: 마이페이지에서 본인이 작성한 글만 필터링하여 조회하는 API를 구현하였습니다.

조회수 증가 로직: 게시글 단건 조회 시 조회수가 1 증가하도록 수정하였습니다.

태그 목록 조회: 게시글 작성 시 선택 가능한 카테고리 태그 목록 조회 API를 추가하였습니다.

# API

## [GET] /api/v1/posts?lastPostId={lastPostId}&size={size}&tags={tags}

설명: 무한 스크롤(커서 기반) 방식으로 게시글 목록을 조회합니다.

Request
Query Parameters

lastPostId (long, optional): 마지막 게시글 ID

categories (list, optional): 카테고리 필터링

Response
200 OK

JSON
{
  "status": "OK",
  "code": "POSTS_FOUND",
  "message": "게시글 목록 조회에 성공했습니다.",
  "data": [ { "postId": 1, "title": "..." } ]
}



## [GET] /api/v1/users/me/posts?lastPostId={lastPostId}&size={size}&tags={tags}

설명: 마이페이지에서 본인이 작성한 글 목록을 최신순으로 조회합니다.

Request
Query Parameters

lastPostId, categories

Response
200 OK

JSON
{
  "status": "OK",
  "code": "MY_POSTS_FOUND",
  "message": "내가 작성한 게시글 조회에 성공했습니다.",
  "data": [ { "postId": 2, "title": "..." } ]
}
Exceptions (Custom Errors)
401 Unauthorized: POST_UNAUTHORIZED

403 Forbidden: POST_ACCESS_FORBIDDEN


## [GET] /api/v1/posts/tags

설명: 게시글 작성 시 선택 가능한 카테고리 태그 목록을 조회합니다.

Response
200 OK

JSON
{
  "status": "OK",
  "code": "CATEGORIES_FOUND",
  "message": "카테고리 목록 조회 성공",
  "data": [ { "type": "TRAVEL_REVIEW", "name": "여행 후기" } ]
}



## 🔗 Issue
Closes #45

---
현재 카테고리 기반 필터링이 구현되어 있습니다.

추후 '나라(Country)' 도메인 개발 완료 시, 상위 5개 국가 필터링 기능을 추가할 예정입니다.



## 확인할 사항
[ ] 커서 기반 페이징 동작: lastPostId를 기준으로 게시글 목록이 정확히 다음 페이지로 넘어가는지 확인 부탁드립니다.

[ ] 필터링 로직: 카테고리(categories)가 빈 리스트이거나 null일 때 전체 게시글이 조회되는지 확인해 주세요.

[ ] 조회수 증가: 상세 조회 API 호출 시 DB의 viewCount가 정상적으로 증가하는지 확인 부탁드립니다.

[ ] 마이페이지 조회: getMyPosts 호출 시 현재 로그인한 사용자의 ID(currentUserId)를 기준으로 정확히 본인 글만 필터링 되는지 확인해 주세요.
