### PR TITLE
[Feat] 로그아웃, 회원 탈퇴 기능 구현 및 테스트를 위한 Security 권한 임시 허용

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/SecurityConfig.java
@@ -35,8 +35,11 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .anyRequest().authenticated()
+                                // ⭐️ 주소 상관없이 모든 요청(anyRequest)을 무조건 허용(permitAll)하겠다는 설정입니다!
+                                .anyRequest().permitAll()
+//                        .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+//                        .anyRequest().authenticated()
+                            
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -6,10 +6,7 @@ import com.kidmily.algoga_server.user.domain.User;
 import com.kidmily.algoga_server.user.domain.UserRepository;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
 import com.kidmily.algoga_server.user.exception.UserException;
-import com.kidmily.algoga_server.user.presentation.request.FindIdRequest;
-import com.kidmily.algoga_server.user.presentation.request.AuthLoginRequest;
-import com.kidmily.algoga_server.user.presentation.request.AuthSignupRequest;
-import com.kidmily.algoga_server.user.presentation.request.FindPasswordRequest;
+import com.kidmily.algoga_server.user.presentation.request.*;
 import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
 import com.kidmily.algoga_server.user.presentation.response.FindIdResponse;
 import com.kidmily.algoga_server.user.settings.JwtProvider;
@@ -107,5 +104,34 @@ public class AuthService {
         if (id == null || id.length() < 3) return id;
         return id.substring(0, 3) + "*".repeat(id.length() - 3);
     }
+
+    // 5. 비밀번호 강제 변경 (임시 비밀번호로 로그인한 유저 대상)
+    public void resetPassword(String email, ResetPasswordRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        // 만약 임시 비밀번호로 로그인한 상태가 아니라면 에러 발생! (보안 방어)
+        if (!user.getRequiresPasswordChange()) {
+            throw new UserException(UserErrorCode.INVALID_PASSWORD); // "정상적인 변경 요청이 아닙니다" 등으로 에러코드 추가해도 좋음!
+        }
+        // 1. 새 비밀번호 암호화
+        String encodedNewPassword = passwordEncoder.encode(request.newPassword());
+
+        // 2. User 엔티티의 changePassword 메서드 호출 (비번 변경 + 플래그 false 처리)
+        user.changePassword(encodedNewPassword);
+
+        userRepository.save(user); // 3. 저장
+
+        log.info("비밀번호 강제 변경 완료 [이메일: {}]", email);
+    }
+
+    // 6. 로그아웃
+    public void logout(String email) {
+        // 현재 Redis를 사용하지 않으므로, 백엔드에서는 로그만 남깁니다.
+        // (실제 토큰 무효화는 클라이언트가 localStorage에서 토큰을 지우는 것으로 완료됩니다.)
+        log.info("로그아웃 처리 완료 [접속 종료 이메일: {}]", email);
+    }
+
+
+
 }
-//

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
@@ -1,0 +1,34 @@
+package com.kidmily.algoga_server.user.application;
+
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import com.kidmily.algoga_server.user.exception.UserErrorCode;
+import com.kidmily.algoga_server.user.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    // 1. 회원 탈퇴 (Soft Delete)
+    public void withdraw(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        if (user.isDeleted()) {
+            throw new UserException(UserErrorCode.DELETED_USER);
+        }
+
+        user.withdraw(); // User 엔티티의 isDeleted 상태를 true로 변경
+
+        // @Transactional 안에서 엔티티 값이 변경되면 JPA가 알아서 DB에 UPDATE 쿼리를 날립니다! (더티 체킹)
+        log.info("회원 탈퇴 처리 완료 [이메일: {}]", email);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/domain/User.java
+++ b/src/main/java/com/kidmily/algoga_server/user/domain/User.java
@@ -81,7 +81,18 @@ public class User {
         this.requiresPasswordChange = false; // 비밀번호를 정상 변경했으므로 플래그 해제
     }
 
+    // 회원 탈퇴 (Soft Delete + 데이터 충돌 방지)
+    public void withdraw() {
+        this.isDeleted = true;
 
+        // 고유 식별자를 생성하여 기존 데이터 뒤에 붙여줍니다. (이메일/아이디 재가입 허용을 위함)
+        String deleteStr = "_deleted_" + java.util.UUID.randomUUID().toString().substring(0, 8);
+
+        this.email = this.email + deleteStr;
+        this.username = this.username + deleteStr;
+        // 전화번호도 중복 검사
+        this.phone = this.phone + deleteStr;
+    }
 
 
     // 실패 횟수 증가 및 잠금 처리

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
@@ -4,16 +4,15 @@ import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.user.application.AuthService;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
-import com.kidmily.algoga_server.user.presentation.request.FindIdRequest;
-import com.kidmily.algoga_server.user.presentation.request.AuthLoginRequest;
-import com.kidmily.algoga_server.user.presentation.request.AuthSignupRequest;
-import com.kidmily.algoga_server.user.presentation.request.FindPasswordRequest;
+import com.kidmily.algoga_server.user.presentation.request.*;
 import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
 import com.kidmily.algoga_server.user.presentation.response.FindIdResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth", description = "회원 인증 API")
@@ -24,6 +23,7 @@ public class AuthController {
 
     private final AuthService authService;
 
+    // 일반 회원가입
     @Operation(summary = "일반 회원가입")
     @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"ALREADY_EXISTS_EMAIL"})
     @PostMapping("/signup")
@@ -37,6 +37,7 @@ public class AuthController {
         );
     }
 
+    // 일반 로그인
     @Operation(summary = "일반 로그인")
     @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"NOT_FOUND_USER", "DELETED_USER", "ACCOUNT_LOCKED", "INVALID_PASSWORD"})
     @PostMapping("/login")
@@ -50,8 +51,7 @@ public class AuthController {
         );
     }
 
-
-
+    // 아이디 찾기
     @Operation(summary = "아이디 찾기", description = "이름과 이메일을 통해 마스킹된 아이디를 찾습니다.") // 문구 수정!
     @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"NOT_FOUND_USER"})
     @PostMapping("/find-id")
@@ -60,12 +60,36 @@ public class AuthController {
         return ApiResponse.success("AUTH_FIND_ID_SUCCESS", "아이디 조회를 성공했습니다.", response);
     }
 
-
+    // 비밀번호 찾기
     @Operation(summary = "비밀번호 찾기", description = "아이디와 이메일 일치 시 임시 비밀번호를 발급합니다.")
     @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"NOT_FOUND_USER"})
     @PostMapping("/find-password")
     public ApiResponse<Void> findPassword(@RequestBody @Valid FindPasswordRequest request) { // ⭐️ FindIdRequest -> FindPasswordRequest로 변경
         authService.findPassword(request);
         return ApiResponse.success("AUTH_FIND_PW_SUCCESS", "임시 비밀번호가 이메일로 발송되었습니다.");
+    }
+
+    // 임시비번 발급 후 비밀번호 강제 변경
+    @Operation(summary = "비밀번호 강제 변경", description = "임시 비밀번호로 로그인한 후, 새 비밀번호로 강제 변경합니다.")
+    @PatchMapping("/reset-password") // ⭐️ POST 대신 리소스를 부분 수정하는 PATCH 사용!
+    public ApiResponse<Void> resetPassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid ResetPasswordRequest request) {
+
+        // 토큰에서 추출한 이메일(username)과 변경할 비밀번호 정보를 넘깁니다.
+        authService.resetPassword(userDetails.getUsername(), request);
+
+        return ApiResponse.success("AUTH_RESET_PW_SUCCESS", "비밀번호 변경이 완료되었습니다. 다시 로그인해주세요.");
+    }
+
+    // 로그아웃
+    @Operation(summary = "로그아웃", description = "로그아웃 처리를 합니다. (클라이언트 단 토큰 삭제 필요)")
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        // 토큰을 통해 인증된 유저 정보가 들어옵니다.
+        if (userDetails != null) {
+            authService.logout(userDetails.getUsername()); // CustomUserDetails에서 반환하는 username은 email입니다.
+        }
+        return ApiResponse.success("AUTH_LOGOUT_SUCCESS", "로그아웃이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/UserController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/UserController.java
@@ -1,18 +1,24 @@
 package com.kidmily.algoga_server.user.presentation;
 
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.user.application.UserService;
 import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "회원 정보 API")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
 public class UserController {
+
+    private final UserService userService;
 
     @Operation(summary = "내 프로필 임시 조회 (토큰 테스트용)")
     @GetMapping("/me")
@@ -25,5 +31,12 @@ public class UserController {
                 "인증 통과 완료! 접속한 유저: " + userEmail,
                 userEmail
         );
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "계정을 Soft Delete 처리합니다.")
+    @DeleteMapping("/me")
+    public ApiResponse<Void> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.withdraw(userDetails.getUsername());
+        return ApiResponse.success("USER_WITHDRAW_SUCCESS", "회원 탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
@@ -5,15 +5,15 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "username": "gkdus",
-  "email": "testuser88@algoga.com",
-  "password": "password12345",
+  "username": "lhy1234lhy",
+  "email": "lhy2004lhy@gmail.com",
+  "password": "password8888",
   "name": "이하연",
-  "phone": "010-8888-9999",
-  "birthDate": "1995-05-15",
-  "gender": "MALE",
+  "phone": "010-1111-2222",
+  "birthDate": "2004-03-02",
+  "gender": "FEMALE",
   "nickname": "하연하연",
-  "referralCode": "REF002",
+  "referralCode": "REF008",
   "signupPath": "인스타그램"
 }
 
@@ -34,13 +34,13 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "username": "gkdus",
-  "email": "testuser88@algoga.com",
-  "password": "password12345",
+  "username": "lhy1234lhy",
+  "email": "lhy2004lhy@gmail.com",
+  "password": "password8888",
   "name": "이하연",
-  "phone": "010-8888-9999",
-  "birthDate": "1995-05-15",
-  "gender": "MALE",
+  "phone": "010-1111-2222",
+  "birthDate": "2004-03-02",
+  "gender": "FEMALE",
   "nickname": "하연하연"
 }
 
@@ -54,8 +54,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "username": "gkdus",
-  "password": "password12345"
+  "username": "lhy1234lhy",
+  "password": "password8888"
 }
 
 > {%
@@ -82,7 +82,7 @@ Content-Type: application/json
 
 {
   "name": "이하연",
-  "email": "testuser88@algoga.com"
+  "email": "lhy2004lhy@gmail.com"
 }
 
 ### ------------------------------------------------------------------------
@@ -94,8 +94,8 @@ POST http://localhost:15000/api/v1/auth/find-password
 Content-Type: application/json
 
 {
-  "username": "gkdus",
-  "email": "testuser88@algoga.com"
+  "username": "lhy1234lhy",
+  "email": "lhy2004lhy@gmail.com"
 }
 
 ### ------------------------------------------------------------------------
@@ -106,6 +106,58 @@ POST http://localhost:15000/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "username": "gkdus",
-  "password": "ce4da01a"
+  "username": "lhy1234lhy",
+  "password": "4185931a"
 }
+
+> {%
+    // ⭐️ 중요: 임시 비밀번호로 로그인해서 받은 토큰을 다시 저장합니다. (비밀번호 변경 API 호출 시 필요함)
+    if(response.status === 200) {
+        client.global.set("accessToken", response.body.data.accessToken);
+        client.log("임시 로그인 Access Token: " + client.global.get("accessToken"));
+        client.log("비밀번호 변경 필요 여부: " + response.body.data.requiresPasswordChange);
+    }
+%}
+
+### ------------------------------------------------------------------------
+
+### 8. 비밀번호 강제 변경 (임시 비밀번호 로그인 직후)
+# 7번에서 저장된 accessToken을 사용하여 새 비밀번호로 변경합니다.
+PATCH http://localhost:15000/api/v1/auth/reset-password
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "newPassword": "newpassword8888"
+}
+
+### ------------------------------------------------------------------------
+
+### 9. 변경된 '새 비밀번호'로 최종 로그인 확인
+# 8번에서 변경한 비밀번호가 잘 작동하는지 확인합니다.
+POST http://localhost:15000/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "username": "lhy1234lhy",
+  "password": "newpassword8888"
+}
+
+### ------------------------------------------------------------------------
+
+### 10. 로그아웃 테스트
+POST http://localhost:15000/api/v1/auth/logout
+Authorization: Bearer {{accessToken}}
+
+> {%
+    // ⭐️ 프론트엔드가 로그아웃 시 브라우저에서 토큰을 지우는 동작을 흉내 냅니다!
+    // client.global.clear("accessToken");
+    // client.global.clear("refreshToken");
+    // client.log("로컬 메모리에서 토큰이 완전히 삭제되었습니다.");
+%}
+
+### ------------------------------------------------------------------------
+
+### 11. 회원 탈퇴 테스트
+DELETE http://localhost:15000/api/v1/users/me
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/ResetPasswordRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/ResetPasswordRequest.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.user.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "비밀번호 강제 변경 요청 (임시 비밀번호 로그인 시)")
+public record ResetPasswordRequest(
+        @Schema(description = "새 비밀번호 (8자 이상, 영문+숫자 포함)", example = "newPassword123")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호는 영문, 숫자 조합 8자 이상이어야 합니다.")
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        String newPassword
+) {}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
1. 로그아웃 기능 (POST `/api/v1/auth/logout`)
   - JWT 기반 로그아웃 백엔드 로직을 구현했다.
   - 호출 시 서버 단에서 로그아웃 로그를 기록하며, 실제 토큰 만료 및 초기화는 클라이언트 단(localStorage 토큰 삭제)에서 담당하도록 설계되었다.
   - 스웨거(Swagger) 문서에서 인증 객체 파라미터가 노출되지 않도록 숨김 처리를 완료했다.

2. 회원 탈퇴 기능 (DELETE `/api/v1/users/me`)
   - 유저 데이터를 안전하게 보존하면서 탈퇴 처리하는 Soft Delete(소프트 딜리트) 방식을 도입했다.
   - 탈퇴 처리 시, 이메일(`email`), 아이디(`username`), 전화번호(`phone`)의 Unique 제약 조건 충돌을 방지하기 위해 데이터 뒤에 랜덤 UUID 접미사(`_deleted_8자리`)를 강제로 붙여 마스킹하는 로직을 구현했다.
   - 이 예외 처리를 통해 탈퇴한 유저가 동일한 정보(이메일, 전화번호 등)로 즉시 재가입할 수 있도록 안정성을 확보했다.

## 🔗 Issue
Closes #61

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
#### 1️⃣ 로그아웃 기능 테스트
- [ ] **로그인 진행**: `POST /api/v1/auth/login`을 호출하여 정상적으로 AccessToken을 발급받습니다.
- [ ] **로그아웃 호출**: 발급받은 토큰을 헤더(`Authorization: Bearer {token}`)에 넣고 `POST /api/v1/auth/logout` API를 호출합니다.
- [ ] **응답 확인**: `200 OK` 상태 코드와 함께 `"로그아웃이 완료되었습니다."` 메시지가 반환되는지 확인합니다.
- [ ] **서버 로그 확인**: 인텔리제이(또는 서버) 콘솔 창에 `로그아웃 처리 완료 [접속 종료 이메일: {email}]` 로그가 정상적으로 찍히는지 확인합니다.

#### 2️⃣ 회원 탈퇴 (Soft Delete & 마스킹) 기능 테스트
- [ ] **로그인 진행**: `POST /api/v1/auth/login`을 호출하여 AccessToken을 발급받습니다.
- [ ] **회원 탈퇴 호출**: 발급받은 토큰을 헤더에 넣고 `DELETE /api/v1/users/me` API를 호출합니다.
- [ ] **응답 확인**: `200 OK` 상태 코드와 함께 `"회원 탈퇴가 완료되었습니다."` 메시지가 반환되는지 확인합니다.
- [ ] **DB 마스킹 확인 (중요 ⭐️)**: DB의 `users` 테이블을 조회하여 다음 사항을 확인합니다.
  - `is_deleted` 컬럼이 `true`로 변경되었는가?
  - `email`, `username`, `phone` 컬럼 데이터 뒤에 `_deleted_{8자리 난수}`가 정상적으로 붙어 있는가? (예: `test@algoga.com_deleted_a1b2c3d4`)
- [ ] **재가입 충돌 테스트 (중요 ⭐️)**: 방금 탈퇴한 유저와 **완전히 똑같은 이메일과 아이디**로 `POST /api/v1/auth/signup` (회원가입 API)을 호출했을 때, 중복 에러(409)가 나지 않고 `201 Created`로 정상 가입되는지 확인합니다.

#### 3️⃣ SecurityConfig 권한 임시 허용 테스트 (타 도메인 팀원용)
- [ ] **토큰 없이 API 호출**: Swagger에 접속하여 로그인(Authorize)을 하지 않은 상태로 본인이 담당하는 도메인의 API(예: 패키지 조회, 공지사항 조회 등)를 호출해 봅니다.
- [ ] **응답 확인**: `401 Unauthorized` 에러가 발생하지 않고, 권한 필터를 무사히 통과하여 비즈니스 로직이 정상 수행되는지 확인합니다.
- [ ] **주의사항 확인**: 토큰 없이 호출할 경우 컨트롤러의 `@AuthenticationPrincipal` 값은 `null`이 들어오므로, 테스트 시 하드코딩(`Long userId = 1L;`)이 필요한지 체크합니다.


※ `SecurityConfig` 임시 변경 내역
  - 타 도메인(패키지, 게시판, 공지사항 등) 팀원들의 API 개발 및 개발 초기 단계에서의 원활한 스웨거/포스트맨 테스트 편의를 위해, 모든 API 요청 주소에 대해 로그인 인증 없이 통과되도록 설정을 변경했다.
  - 설정 내용: `.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())` 
 
  -   - - ⚠️ 타 도메인 작업자 분들 주의 사항
  - 보안 문은 열어두었으나 내부 JWT 필터는 정상 작동하므로, **토큰 없이 API를 호출하면** 컨트롤러 파라미터의 `@AuthenticationPrincipal CustomUserDetails userDetails`에 **`null`**이 주입됩니다.
  - 현재 유저 정보가 필요한 로직을 테스트하실 때는 임시로 `Long userId = 1L;`과 같이 가짜 유저 정보를 하드코딩해서 사용해 주시기 바랍니다. 
  - 만약 정상적인 유저 데이터를 연동해 테스트하고 싶으시다면, 로그인 API를 통해 발급받은 AccessToken을 Authorization 헤더에 Bearer 타입으로 넣어서 요청하시면 하드코딩 없이 정상 동작합니다!  - 
  -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   - 