### PR TITLE
[Feature] 매니저 등록 및 로그인 기능 구현 (접근 제한은 추후에 구현예정)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/admin/application/command/CreateManagerCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/command/CreateManagerCommand.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.admin.application.command;
+
+public record CreateManagerCommand(
+        String loginId,
+        String password,
+        String name,
+        String phone,
+        String email,
+        String role
+) {}

--- a/src/main/java/com/kidmily/algoga_server/admin/application/command/LoginManagerCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/command/LoginManagerCommand.java
@@ -1,0 +1,6 @@
+package com.kidmily.algoga_server.admin.application.command;
+
+public record LoginManagerCommand(
+        String loginId,
+        String password
+) {}

--- a/src/main/java/com/kidmily/algoga_server/admin/application/command/UpdateManagerCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/command/UpdateManagerCommand.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.admin.application.command;
+
+public record UpdateManagerCommand(
+        Long managerId,
+        String role,
+        String phone,
+        String email
+) {}

--- a/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerAuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerAuthService.java
@@ -1,0 +1,59 @@
+package com.kidmily.algoga_server.admin.application.service;
+
+import com.kidmily.algoga_server.admin.application.command.LoginManagerCommand;
+import com.kidmily.algoga_server.admin.application.usecase.ManagerAuthUseCase;
+import com.kidmily.algoga_server.admin.domain.model.Manager;
+import com.kidmily.algoga_server.admin.domain.repository.ManagerRepository;
+import com.kidmily.algoga_server.admin.exception.ManagerErrorCode;
+import com.kidmily.algoga_server.admin.exception.ManagerException;
+import com.kidmily.algoga_server.admin.settings.AdminJwtProvider;
+import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 로그인은 조회만 하므로 readOnly 적용하여 성능 최적화
+public class ManagerAuthService implements ManagerAuthUseCase {
+
+    private final ManagerRepository managerRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AdminJwtProvider adminJwtProvider; // 앞서 만든 어드민 전용 JWT 프로바이더
+
+    @Override
+    public AuthTokenResponse login(LoginManagerCommand command) {
+
+        // 1. 아이디로 매니저 조회
+        Manager manager = managerRepository.findByLoginId(command.loginId())
+                .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
+
+        // 2. 삭제(Soft Delete)된 계정인지 확인
+        if (manager.isDeleted()) {
+            throw new ManagerException(ManagerErrorCode.DELETED_MANAGER);
+        }
+
+        // 3. 비밀번호 검증
+        if (!passwordEncoder.matches(command.password(), manager.getPassword())) {
+            throw new ManagerException(ManagerErrorCode.INVALID_PASSWORD);
+        }
+
+        // 4. JWT 토큰 발급 (시큐리티 표준인 'ROLE_' 접두사 추가)
+        String roleName = "ROLE_" + manager.getRole().name();
+
+        // 주의: AdminJwtProvider에는 PK(manager.getId())를 함께 넣도록 앞서 구현해 두었습니다.
+        String accessToken = adminJwtProvider.createAccessToken(manager.getId(), manager.getLoginId(), roleName);
+        String refreshToken = adminJwtProvider.createRefreshToken(manager.getLoginId());
+
+        return new AuthTokenResponse(accessToken, refreshToken);
+    }
+
+    @PostConstruct
+    public void printMyPasswordHash() {
+        System.out.println("\n=======================================");
+        System.out.println("🔥 내 서버용 완벽한 해시값: " + passwordEncoder.encode("password123!"));
+        System.out.println("=======================================\n");
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerManageService.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerManageService.java
@@ -1,0 +1,64 @@
+package com.kidmily.algoga_server.admin.application.service;
+
+import com.kidmily.algoga_server.admin.application.command.CreateManagerCommand;
+import com.kidmily.algoga_server.admin.application.command.UpdateManagerCommand;
+import com.kidmily.algoga_server.admin.application.usecase.ManagerManageUseCase;
+import com.kidmily.algoga_server.admin.domain.model.Manager;
+import com.kidmily.algoga_server.admin.domain.model.ManagerRole;
+import com.kidmily.algoga_server.admin.domain.repository.ManagerRepository;
+import com.kidmily.algoga_server.admin.exception.ManagerErrorCode;
+import com.kidmily.algoga_server.admin.exception.ManagerException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManagerManageService implements ManagerManageUseCase {
+
+    private final ManagerRepository managerRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void createManager(CreateManagerCommand command) {
+        if (managerRepository.existsByLoginId(command.loginId())) {
+            throw new ManagerException(ManagerErrorCode.ALREADY_EXISTS_LOGIN_ID);
+        }
+        Manager manager = Manager.create(
+                command.loginId(), passwordEncoder.encode(command.password()),
+                command.name(), command.phone(), command.email(),
+                ManagerRole.valueOf(command.role().toUpperCase())
+        );
+        managerRepository.save(manager);
+    }
+
+    @Override
+    public void updateManager(UpdateManagerCommand command) {
+        Manager manager = managerRepository.findById(command.managerId())
+                .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
+
+        manager.update(command.role(), command.phone(), command.email());
+        managerRepository.save(manager);
+    }
+
+    @Override
+    public void deleteManager(Long managerId) {
+        Manager manager = managerRepository.findById(managerId)
+                .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
+
+        manager.delete();
+        managerRepository.save(manager);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Manager> getManagers(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return managerRepository.findAll();
+        }
+        return managerRepository.searchByKeyword(keyword);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/application/usecase/ManagerAuthUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/usecase/ManagerAuthUseCase.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.admin.application.usecase;
+
+import com.kidmily.algoga_server.admin.application.command.LoginManagerCommand;
+import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse; // 반환 DTO는 유저와 공유
+
+public interface ManagerAuthUseCase {
+    AuthTokenResponse login(LoginManagerCommand command);
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/application/usecase/ManagerManageUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/usecase/ManagerManageUseCase.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.admin.application.usecase;
+
+import com.kidmily.algoga_server.admin.application.command.CreateManagerCommand;
+import com.kidmily.algoga_server.admin.application.command.UpdateManagerCommand;
+import com.kidmily.algoga_server.admin.domain.model.Manager;
+import java.util.List;
+
+public interface ManagerManageUseCase {
+    void createManager(CreateManagerCommand command);
+    void updateManager(UpdateManagerCommand command);
+    void deleteManager(Long managerId);
+    List<Manager> getManagers(String keyword);
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/domain/model/Manager.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/domain/model/Manager.java
@@ -1,0 +1,67 @@
+package com.kidmily.algoga_server.admin.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Manager {
+
+    private Long id;
+    private String loginId;
+    private String password;
+    private String name;
+    private String phone;
+    private String email;
+    private ManagerRole role;
+    private boolean isDeleted;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // 슈퍼 어드민이 새로운 매니저를 생성할 때 사용하는 팩토리 메서드
+    public static Manager create(String loginId, String password, String name, String phone, String email, ManagerRole role) {
+        Manager manager = new Manager();
+        manager.loginId = loginId;
+        manager.password = password;
+        manager.name = name;
+        manager.phone = phone;
+        manager.email = email;
+        manager.role = role;
+        manager.isDeleted = false;
+        manager.createdAt = LocalDateTime.now();
+        manager.updatedAt = LocalDateTime.now();
+        return manager;
+    }
+
+    // DB(인프라)에서 조회한 데이터를 도메인 객체로 복원할 때 사용
+    public static Manager reconstitute(Long id, String loginId, String password, String name, String phone, String email, ManagerRole role, boolean isDeleted, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        Manager manager = new Manager();
+        manager.id = id;
+        manager.loginId = loginId;
+        manager.password = password;
+        manager.name = name;
+        manager.phone = phone;
+        manager.email = email;
+        manager.role = role;
+        manager.isDeleted = isDeleted;
+        manager.createdAt = createdAt;
+        manager.updatedAt = updatedAt;
+        return manager;
+    }
+
+    // 🌟 매니저 정보 수정 로직
+    public void update(String role, String phone, String email) {
+        this.role = ManagerRole.valueOf(role.toUpperCase());
+        this.phone = phone;
+        this.email = email;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 🌟 소프트 딜리트(삭제) 로직
+    public void delete() {
+        this.isDeleted = true;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/domain/model/ManagerRole.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/domain/model/ManagerRole.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.admin.domain.model;
+
+public enum ManagerRole {
+    CONTENT_MANAGER,
+    CS_MANAGER,
+    SETTLEMENT_MANAGER,
+    SUPER_ADMIN
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/domain/repository/ManagerRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/domain/repository/ManagerRepository.java
@@ -1,0 +1,16 @@
+package com.kidmily.algoga_server.admin.domain.repository;
+
+import com.kidmily.algoga_server.admin.domain.model.Manager;
+import java.util.List;
+import java.util.Optional;
+
+public interface ManagerRepository {
+    Manager save(Manager manager);
+    Optional<Manager> findById(Long id); // 추가
+    Optional<Manager> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+
+    // 🌟 전체 조회 및 검색 추가
+    List<Manager> findAll();
+    List<Manager> searchByKeyword(String keyword);
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/exception/ManagerErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/exception/ManagerErrorCode.java
@@ -1,0 +1,20 @@
+package com.kidmily.algoga_server.admin.exception;
+
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ManagerErrorCode implements BaseErrorCode {
+    ALREADY_EXISTS_LOGIN_ID(HttpStatus.CONFLICT, "ADMIN_001", "이미 사용 중인 관리자 아이디입니다."),
+    MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_002", "존재하지 않는 관리자 계정입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "ADMIN_003", "비밀번호가 일치하지 않습니다."),
+    DELETED_MANAGER(HttpStatus.FORBIDDEN, "ADMIN_004", "삭제된 관리자 계정입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ADMIN_005", "해당 작업을 수행할 권한이 없습니다."); // 권한 에러 추가
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/exception/ManagerException.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/exception/ManagerException.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.admin.exception;
+
+import com.kidmily.algoga_server.global.exception.BusinessException;
+
+public class ManagerException extends BusinessException {
+    public ManagerException(ManagerErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/infrastructure/mapper/ManagerMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/infrastructure/mapper/ManagerMapper.java
@@ -1,0 +1,34 @@
+package com.kidmily.algoga_server.admin.infrastructure.mapper;
+
+import com.kidmily.algoga_server.admin.domain.model.Manager;
+import com.kidmily.algoga_server.admin.infrastructure.persistence.entity.ManagerJpaEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface ManagerMapper {
+
+    // 1. Domain Entity -> JPA Entity 변환
+    // ManagerJpaEntity의 필드 이름이 같으므로 MapStruct가 자동으로 매핑합니다.
+    ManagerJpaEntity toJpaEntity(Manager manager);
+
+    // 2. JPA Entity -> Domain Entity 변환
+    // 도메인 객체는 캡슐화를 위해 생성자가 닫혀있으므로, reconstitute()를 직접 호출해 복원합니다.
+    default Manager toDomain(ManagerJpaEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return Manager.reconstitute(
+                entity.getId(),
+                entity.getLoginId(),
+                entity.getPassword(),
+                entity.getName(),
+                entity.getPhone(),
+                entity.getEmail(),
+                entity.getRole(),
+                entity.isDeleted(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/infrastructure/persistence/ManagerRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/infrastructure/persistence/ManagerRepositoryAdapter.java
@@ -1,0 +1,61 @@
+package com.kidmily.algoga_server.admin.infrastructure.persistence;
+
+import com.kidmily.algoga_server.admin.domain.model.Manager;
+import com.kidmily.algoga_server.admin.domain.repository.ManagerRepository;
+import com.kidmily.algoga_server.admin.infrastructure.mapper.ManagerMapper;
+import com.kidmily.algoga_server.admin.infrastructure.persistence.entity.ManagerJpaEntity;
+import com.kidmily.algoga_server.admin.infrastructure.persistence.repository.SpringDataManagerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ManagerRepositoryAdapter implements ManagerRepository {
+
+    private final SpringDataManagerRepository jpaRepository;
+    private final ManagerMapper managerMapper; // 🌟 MapStruct 매퍼 주입
+
+    @Override
+    public Manager save(Manager manager) {
+        // MapStruct를 통한 Domain -> JPA Entity 매핑
+        ManagerJpaEntity entity = managerMapper.toJpaEntity(manager);
+
+        // DB 저장
+        ManagerJpaEntity saved = jpaRepository.save(entity);
+
+        // MapStruct를 통한 JPA Entity -> Domain 매핑
+        return managerMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<Manager> findByLoginId(String loginId) {
+        // DB 조회 후 MapStruct 메서드 참조를 활용하여 Domain 반환
+        return jpaRepository.findByLoginId(loginId)
+                .map(managerMapper::toDomain);
+    }
+
+    @Override
+    public boolean existsByLoginId(String loginId) {
+        return jpaRepository.existsByLoginId(loginId);
+    }
+
+    @Override
+    public Optional<Manager> findById(Long id) {
+        return jpaRepository.findById(id).map(managerMapper::toDomain);
+    }
+
+    @Override
+    public List<Manager> findAll() {
+        return jpaRepository.findAll().stream()
+                .map(managerMapper::toDomain).toList();
+    }
+
+    @Override
+    public List<Manager> searchByKeyword(String keyword) {
+        return jpaRepository.findByLoginIdContainingOrNameContaining(keyword, keyword)
+                .stream().map(managerMapper::toDomain).toList();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/infrastructure/persistence/entity/ManagerJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/infrastructure/persistence/entity/ManagerJpaEntity.java
@@ -1,0 +1,61 @@
+package com.kidmily.algoga_server.admin.infrastructure.persistence.entity;
+
+import com.kidmily.algoga_server.admin.domain.model.ManagerRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "managers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManagerJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "manager_id")
+    private Long id;
+
+    @Column(name = "login_id", nullable = false, unique = true, length = 50)
+    private String loginId;
+
+    @Column(nullable = false, length = 255)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ManagerRole role;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public ManagerJpaEntity(Long id, String loginId, String password, String name, String phone, String email, ManagerRole role, boolean isDeleted, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.loginId = loginId;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.role = role;
+        this.isDeleted = isDeleted;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/infrastructure/persistence/repository/SpringDataManagerRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/infrastructure/persistence/repository/SpringDataManagerRepository.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.admin.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.admin.infrastructure.persistence.entity.ManagerJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringDataManagerRepository extends JpaRepository<ManagerJpaEntity, Long> {
+    Optional<ManagerJpaEntity> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+
+    // 🌟 아이디 또는 이름으로 LIKE 검색
+    List<ManagerJpaEntity> findByLoginIdContainingOrNameContaining(String loginId, String name);
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/advice/ManagerExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/advice/ManagerExceptionAdvice.java
@@ -1,0 +1,26 @@
+package com.kidmily.algoga_server.admin.presentation.advice;
+
+import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+// 🌟 어드민(Manager) 도메인의 API 컨트롤러에서 발생하는 예외만 캐치하도록 패키지 제한
+@RestControllerAdvice(basePackages = "com.kidmily.algoga_server.admin.presentation.api")
+public class ManagerExceptionAdvice implements CommonExceptionAdvice {
+
+    @Override
+    public Logger getLogger() {
+        // 인터페이스(CommonExceptionAdvice)에서 로그를 찍을 수 있도록 현재 클래스의 로거를 넘겨줍니다.
+        return log;
+    }
+
+    /*
+     * ManagerException은 BusinessException을 상속받으므로,
+     * CommonExceptionAdvice에 구현된 default handleBusinessException() 메서드가
+     * 에러 코드, 상태 코드, Trace ID 등을 포함하여 응답을 자동으로 처리해 줍니다.
+     * * 만약 어드민 계층에서만 발생하는 아주 특수한 예외(BusinessException이 아닌 외부 라이브러리 예외 등)가
+     * 추가로 생긴다면 이곳에 @ExceptionHandler를 작성하시면 됩니다.
+     */
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
@@ -1,0 +1,43 @@
+package com.kidmily.algoga_server.admin.presentation.api;
+
+import com.kidmily.algoga_server.admin.application.command.LoginManagerCommand;
+import com.kidmily.algoga_server.admin.application.usecase.ManagerAuthUseCase;
+import com.kidmily.algoga_server.admin.exception.ManagerErrorCode;
+import com.kidmily.algoga_server.admin.presentation.api.request.ManagerLoginRequest;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin Auth", description = "관리자 인증 (로그인) API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/auth")
+public class ManagerAuthController {
+
+    private final ManagerAuthUseCase managerAuthUseCase;
+
+    @Operation(summary = "매니저 로그인")
+    @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"MANAGER_NOT_FOUND", "DELETED_MANAGER", "INVALID_PASSWORD"})
+    @PostMapping("/login")
+    public ApiResponse<AuthTokenResponse> login(@RequestBody @Valid ManagerLoginRequest request) {
+
+        // DTO -> Command 변환 (프레젠테이션 계층의 책임)
+        LoginManagerCommand command = new LoginManagerCommand(
+                request.loginId(), request.password()
+        );
+
+        // 서비스(UseCase) 호출
+        AuthTokenResponse response = managerAuthUseCase.login(command);
+
+        return ApiResponse.success(
+                "MANAGER_LOGIN_SUCCESS",
+                "관리자 로그인에 성공했습니다.",
+                response
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
@@ -11,8 +11,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j; // 🌟 추가
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j // 🌟 추가
 @Tag(name = "Admin Auth", description = "관리자 인증 (로그인) API")
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +28,8 @@ public class ManagerAuthController {
     @PostMapping("/login")
     public ApiResponse<AuthTokenResponse> login(@RequestBody @Valid ManagerLoginRequest request) {
 
+        log.info("[Manager Login] 관리자 로그인 시도 - ID: {}", request.loginId()); // 🌟 추가
+
         // DTO -> Command 변환 (프레젠테이션 계층의 책임)
         LoginManagerCommand command = new LoginManagerCommand(
                 request.loginId(), request.password()
@@ -33,6 +37,8 @@ public class ManagerAuthController {
 
         // 서비스(UseCase) 호출
         AuthTokenResponse response = managerAuthUseCase.login(command);
+
+        log.info("[Manager Login] 관리자 로그인 성공 - ID: {}", request.loginId()); // 🌟 추가
 
         return ApiResponse.success(
                 "MANAGER_LOGIN_SUCCESS",

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerManageController.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerManageController.java
@@ -13,10 +13,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j; // 🌟 추가
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j // 🌟 추가
 @Tag(name = "Admin Manage", description = "관리자 계정 관리 API (SUPER_ADMIN 전용)")
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +31,8 @@ public class ManagerManageController {
     @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"ALREADY_EXISTS_LOGIN_ID"})
     @PostMapping
     public ApiResponse<Void> createManager(@RequestBody @Valid ManagerCreateRequest request) {
+        log.info("[Manager Create] 계정 생성 요청 - ID: {}, Role: {}", request.loginId(), request.role()); // 🌟 추가
+
         CreateManagerCommand command = new CreateManagerCommand(
                 request.loginId(), request.password(), request.name(),
                 request.phone(), request.email(), request.role()
@@ -44,6 +48,8 @@ public class ManagerManageController {
             @PathVariable Long managerId,
             @RequestBody @Valid ManagerUpdateRequest request
     ) {
+        log.info("[Manager Update] 계정 정보 수정 요청 - 대상 PK: {}, Role: {}", managerId, request.role()); // 🌟 추가
+
         UpdateManagerCommand command = new UpdateManagerCommand(
                 managerId, request.role(), request.phone(), request.email()
         );
@@ -55,6 +61,8 @@ public class ManagerManageController {
     @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"MANAGER_NOT_FOUND"})
     @DeleteMapping("/{managerId}")
     public ApiResponse<Void> deleteManager(@PathVariable Long managerId) {
+        log.info("[Manager Delete] 계정 삭제 요청 - 대상 PK: {}", managerId); // 🌟 추가
+
         managerManageUseCase.deleteManager(managerId);
         return ApiResponse.success("MANAGER_DELETED", "관리자 계정이 삭제 처리되었습니다.", null);
     }
@@ -64,6 +72,8 @@ public class ManagerManageController {
     public ApiResponse<List<ManagerResponse>> getManagers(
             @RequestParam(required = false) String keyword
     ) {
+        log.info("[Manager List] 계정 조회 요청 - 검색 키워드: {}", keyword); // 🌟 추가
+
         List<ManagerResponse> response = managerManageUseCase.getManagers(keyword)
                 .stream()
                 .map(ManagerResponse::from)

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerManageController.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerManageController.java
@@ -1,0 +1,73 @@
+package com.kidmily.algoga_server.admin.presentation.api;
+
+import com.kidmily.algoga_server.admin.application.command.CreateManagerCommand;
+import com.kidmily.algoga_server.admin.application.command.UpdateManagerCommand;
+import com.kidmily.algoga_server.admin.application.usecase.ManagerManageUseCase;
+import com.kidmily.algoga_server.admin.exception.ManagerErrorCode;
+import com.kidmily.algoga_server.admin.presentation.api.request.ManagerCreateRequest;
+import com.kidmily.algoga_server.admin.presentation.api.request.ManagerUpdateRequest;
+import com.kidmily.algoga_server.admin.presentation.api.response.ManagerResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Admin Manage", description = "관리자 계정 관리 API (SUPER_ADMIN 전용)")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/managers")
+public class ManagerManageController {
+
+    private final ManagerManageUseCase managerManageUseCase;
+
+    @Operation(summary = "매니저 계정 생성")
+    @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"ALREADY_EXISTS_LOGIN_ID"})
+    @PostMapping
+    public ApiResponse<Void> createManager(@RequestBody @Valid ManagerCreateRequest request) {
+        CreateManagerCommand command = new CreateManagerCommand(
+                request.loginId(), request.password(), request.name(),
+                request.phone(), request.email(), request.role()
+        );
+        managerManageUseCase.createManager(command);
+        return ApiResponse.created("MANAGER_CREATED", "관리자 계정이 생성되었습니다.", null);
+    }
+
+    @Operation(summary = "매니저 정보 수정")
+    @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"MANAGER_NOT_FOUND", "DELETED_MANAGER"})
+    @PutMapping("/{managerId}")
+    public ApiResponse<Void> updateManager(
+            @PathVariable Long managerId,
+            @RequestBody @Valid ManagerUpdateRequest request
+    ) {
+        UpdateManagerCommand command = new UpdateManagerCommand(
+                managerId, request.role(), request.phone(), request.email()
+        );
+        managerManageUseCase.updateManager(command);
+        return ApiResponse.success("MANAGER_UPDATED", "관리자 정보가 수정되었습니다.", null);
+    }
+
+    @Operation(summary = "매니저 삭제 (소프트 딜리트)")
+    @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"MANAGER_NOT_FOUND"})
+    @DeleteMapping("/{managerId}")
+    public ApiResponse<Void> deleteManager(@PathVariable Long managerId) {
+        managerManageUseCase.deleteManager(managerId);
+        return ApiResponse.success("MANAGER_DELETED", "관리자 계정이 삭제 처리되었습니다.", null);
+    }
+
+    @Operation(summary = "매니저 전체 조회 및 검색", description = "keyword(아이디 또는 이름)가 없으면 전체를 조회합니다.")
+    @GetMapping
+    public ApiResponse<List<ManagerResponse>> getManagers(
+            @RequestParam(required = false) String keyword
+    ) {
+        List<ManagerResponse> response = managerManageUseCase.getManagers(keyword)
+                .stream()
+                .map(ManagerResponse::from)
+                .toList();
+        return ApiResponse.success("MANAGER_LIST_SUCCESS", "매니저 목록 조회 성공", response);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/admin_test.http
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/admin_test.http
@@ -1,0 +1,45 @@
+### 환경변수 세팅
+@baseUrl = http://localhost:15000
+
+### 1. 매니저 로그인
+POST {{baseUrl}}/api/v1/admin/auth/login
+Content-Type: application/json
+
+{
+  "loginId": "super_admin",
+  "password": "password123!"
+}
+
+> {%
+    // 로그인이 성공하면 응답 바디의 accessToken을 adminToken 변수에 자동으로 할당합니다.
+    client.global.set("adminToken", response.body.data.accessToken);
+%}
+
+### 2. 매니저 계정 생성 (SUPER_ADMIN)
+POST {{baseUrl}}/api/v1/admin/managers
+Content-Type: application/json
+Authorization: Bearer {{adminToken}}
+
+{
+  "loginId": "cs_manager_01",
+  "password": "password123!",
+  "name": "김상담",
+  "phone": "010-1234-5678",
+  "email": "cs_01@algoga.com",
+  "role": "CS_MANAGER"
+}
+
+### 3. 매니저 목록 조회 (SUPER_ADMIN)
+GET {{baseUrl}}/api/v1/admin/managers?keyword=김
+Authorization: Bearer {{adminToken}}
+
+### 4. 공지사항 등록 (CS_MANAGER 이상)
+POST {{baseUrl}}/api/v1/admin/notices/register
+Content-Type: application/json
+Authorization: Bearer {{adminToken}}
+
+{
+  "title": "[공지] 시스템 점검 안내",
+  "content": "5월 30일 새벽 2시부터 시스템 점검이 있습니다.",
+  "type": "MAINTENANCE"
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/request/ManagerCreateRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/request/ManagerCreateRequest.java
@@ -1,0 +1,36 @@
+package com.kidmily.algoga_server.admin.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "매니저 생성 요청 (SUPER_ADMIN 전용)")
+public record ManagerCreateRequest(
+        @Schema(description = "로그인 아이디", example = "admin_01")
+        @NotBlank(message = "아이디는 필수입니다.")
+        String loginId,
+
+        @Schema(description = "비밀번호 (8자 이상, 영문+숫자 포함)", example = "password123")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+~\\-=]{8,}$", message = "비밀번호는 영문, 숫자 조합(특수문자 포함 가능) 8자 이상이어야 합니다.")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password,
+
+        @Schema(description = "이름", example = "홍길동 관리자")
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식을 입력해주세요.")
+        String phone,
+
+        @Schema(description = "이메일", example = "admin@algoga.com")
+        @Email(message = "올바른 이메일 형식을 입력해주세요.")
+        String email,
+
+        @Schema(description = "관리자 권한 (CONTENT_MANAGER, CS_MANAGER, SETTLEMENT_MANAGER, SUPER_ADMIN)", example = "CS_MANAGER")
+        @NotBlank(message = "권한은 필수입니다.")
+        String role
+) {}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/request/ManagerLoginRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/request/ManagerLoginRequest.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.admin.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "매니저 로그인 요청")
+public record ManagerLoginRequest(
+        @Schema(description = "로그인 아이디", example = "admin_01")
+        @NotBlank(message = "아이디는 필수입니다.")
+        String loginId,
+
+        @Schema(description = "비밀번호", example = "password123")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/request/ManagerUpdateRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/request/ManagerUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.admin.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "매니저 수정 요청 (SUPER_ADMIN 전용)")
+public record ManagerUpdateRequest(
+        @Schema(description = "수정할 권한", example = "CONTENT_MANAGER")
+        @NotBlank(message = "권한은 필수입니다.")
+        String role,
+
+        @Schema(description = "수정할 전화번호", example = "010-9999-8888")
+        @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식을 입력해주세요.")
+        String phone,
+
+        @Schema(description = "수정할 이메일", example = "newadmin@algoga.com")
+        @Email(message = "올바른 이메일 형식을 입력해주세요.")
+        String email
+) {}

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/response/ManagerResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/response/ManagerResponse.java
@@ -1,0 +1,26 @@
+package com.kidmily.algoga_server.admin.presentation.api.response;
+
+import com.kidmily.algoga_server.admin.domain.model.Manager;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "매니저 정보 응답")
+public record ManagerResponse(
+        @Schema(description = "매니저 PK", example = "1") Long id,
+        @Schema(description = "로그인 아이디", example = "admin_01") String loginId,
+        @Schema(description = "이름", example = "홍길동 관리자") String name,
+        @Schema(description = "전화번호", example = "010-1234-5678") String phone,
+        @Schema(description = "이메일", example = "admin@algoga.com") String email,
+        @Schema(description = "권한", example = "CS_MANAGER") String role,
+        @Schema(description = "삭제 여부", example = "false") boolean isDeleted,
+        @Schema(description = "생성 일자") LocalDateTime createdAt
+) {
+    // 🌟 도메인 객체를 DTO로 변환해주는 팩토리 메서드
+    public static ManagerResponse from(Manager manager) {
+        return new ManagerResponse(
+                manager.getId(), manager.getLoginId(), manager.getName(),
+                manager.getPhone(), manager.getEmail(), manager.getRole().name(),
+                manager.isDeleted(), manager.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/settings/AdminJwtAuthenticationFilter.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/settings/AdminJwtAuthenticationFilter.java
@@ -1,0 +1,73 @@
+package com.kidmily.algoga_server.admin.settings;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class AdminJwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AdminJwtProvider adminJwtProvider; // 어드민 전용 프로바이더 사용
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && adminJwtProvider.validateToken(token)) {
+            // [기존 코드] 정상적인 토큰일 경우 데이터 추출 및 인증
+            Long id = adminJwtProvider.getId(token);
+            String loginId = adminJwtProvider.getSubject(token);
+            String role = adminJwtProvider.getRole(token);
+
+            CustomManagerDetails managerDetails = new CustomManagerDetails(id, loginId, role);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    managerDetails, null, managerDetails.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } else {
+            // 🚨 [테스트용 임시 코드 시작] 토큰이 없거나 틀려도 무조건 강제 통과!
+            System.out.println("⚠️ [TEST MODE] 인증 없이 무적 권한(SUPER_ADMIN)으로 강제 통과시킵니다.");
+
+            // PK 1번, 아이디 test_admin, 권한 SUPER_ADMIN을 가진 가짜 매니저 객체 생성
+            CustomManagerDetails dummyManager = new CustomManagerDetails(1L, "test_admin", "ROLE_SUPER_ADMIN");
+
+            UsernamePasswordAuthenticationToken dummyAuth = new UsernamePasswordAuthenticationToken(
+                    dummyManager, null, dummyManager.getAuthorities()
+            );
+            // 시큐리티에 가짜 신분증 제출
+            SecurityContextHolder.getContext().setAuthentication(dummyAuth);
+            // 🚨 [테스트용 임시 코드 끝]
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // 🌟 추가: 어드민 API가 아닌 요청(유저 요청 등)은 이 필터를 무시하고 패스하도록 설정
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return !path.startsWith("/api/v1/admin");
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/settings/AdminJwtProvider.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/settings/AdminJwtProvider.java
@@ -1,0 +1,94 @@
+package com.kidmily.algoga_server.admin.settings;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class AdminJwtProvider {
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey key;
+
+    @PostConstruct
+    protected void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 🌟 1. 변경: 파라미터로 managerId(PK)를 추가로 받습니다.
+    public String createAccessToken(Long managerId, String loginId, String role) {
+        return Jwts.builder()
+                .subject(loginId)
+                .claim("id", managerId) // 🌟 토큰 내부에 PK 저장
+                .claim("role", role)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(key)
+                .compact();
+    }
+
+    // (refreshToken은 로그인 연장용이므로 굳이 PK나 Role을 안 넣어도 됩니다)
+    public String createRefreshToken(String loginId) {
+        return Jwts.builder()
+                .subject(loginId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .signWith(key)
+                .compact();
+    }
+
+    // 🌟 2. 추가: 필터에서 사용할 getId 메서드 생성 (빨간 줄 해결!)
+    public Long getId(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("id", Long.class);
+    }
+
+    public String getSubject(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/settings/AdminSecurityConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/settings/AdminSecurityConfig.java
@@ -1,0 +1,37 @@
+package com.kidmily.algoga_server.admin.settings;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class AdminSecurityConfig {
+
+    private final AdminJwtAuthenticationFilter adminJwtAuthenticationFilter;
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain adminSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/api/v1/admin/**")
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // 🌟 싹 다 지우고 이 한 줄만 남깁니다!
+                        // /api/v1/admin/** 으로 들어오는 모든 요청을 토큰/권한 상관없이 무조건 통과시킴
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(adminJwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/settings/CustomManagerDetails.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/settings/CustomManagerDetails.java
@@ -1,0 +1,40 @@
+package com.kidmily.algoga_server.admin.settings;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomManagerDetails implements UserDetails {
+
+    private final Long id;          // 매니저 PK
+    private final String loginId;   // 로그인 아이디
+    private final String role;      // ROLE_CONTENT_MANAGER 등
+
+    public CustomManagerDetails(Long id, String loginId, String role) {
+        this.id = id;
+        this.loginId = loginId;
+        this.role = role;
+    }
+
+    // 🌟 컨트롤러에서 꺼내 쓸 게터 메서드
+    public Long getId() { return id; }
+    public String getRole() { return role; }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 토큰에 "SUPER_ADMIN"으로 들어있든 "ROLE_SUPER_ADMIN"으로 들어있든
+        // 무조건 "ROLE_" 접두사가 붙도록 안전장치를 추가합니다.
+        String authority = role.startsWith("ROLE_") ? role : "ROLE_" + role;
+
+        return Collections.singletonList(new SimpleGrantedAuthority(authority));
+    }
+
+    @Override public String getPassword() { return null; } // 비밀번호는 토큰 인증에 불필요하므로 null
+    @Override public String getUsername() { return loginId; }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/kidmily/algoga_server/admin/settings/annotation/CurrentManager.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/settings/annotation/CurrentManager.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.admin.settings.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+// 🌟 핵심: 이 어노테이션이 불리면 내부적으로 @AuthenticationPrincipal을 수행하되,
+// 만약 익명 사용자(Anonymous)라면 null을 반환하고 레퍼런스 타입이 맞을 때만 바인딩하라는 설정을 둡니다.
+@AuthenticationPrincipal(expression = "#this instanceof T(com.kidmily.algoga_server.admin.settings.CustomManagerDetails) ? #this : null")
+public @interface CurrentManager {
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
매니저 등록 및 로그인 기능 구현. user jwt 와 분리된 manager jwt 사용.

##도메인 컨트롤러에 적용예시##

@PreAuthorize("hasAnyAuthority('CS_MANAGER', 'ROLE_CS_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
    @PostMapping("/register")
    public ResponseEntity<ApiResponse<CreateNoticeResponse>> registerNotice(
            @Valid @RequestBody CreateNoticeRequest request,
            @CurrentManager Long managerId // 🌟 1. 시큐리티에서 PK 꺼내기
    ) {
        // 🌟 2. Command 객체를 만들 때 managerId도 한 번에 포장해서 던지기!
        Long noticeId = noticeCommandUseCase.registerNotice(new CreateNoticeCommand(
                request.title(),
                request.content(),
                request.type(),
                managerId 
        ));

        return ResponseEntity.status(HttpStatus.CREATED)
                .body(ApiResponse.created("NOTICE_CREATED", "공지사항 등록에 성공했습니다.", new CreateNoticeResponse(noticeId)));
    }



## 🔗 Issue
Closes #56 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 다른 도메인 api가 접속이 안되는지 확인
