### PR TITLE
feature/paymeny 결제 기능구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     // JWT의 페이로드(payload)와 헤더(header)를 JSON 형식으로 직렬화(serialization)하거나 역직렬화(deserialization)하는 데 필요한 Jackson 라이브러리 연동을 제공하는 모듈
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    // PDF 생성
+    implementation 'com.itextpdf:itext-core:8.0.5'
+
+// 이메일
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.booking.domain.repository;
 
 import com.kidmily.algoga_server.booking.domain.model.Booking;
+import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
 
 import java.util.Optional;
 
@@ -11,4 +12,6 @@ public interface BookingRepository {
     Optional<Booking> findById(Long bookingId);
 
     Booking cancel(Long bookingId);
+
+    Booking updateStatus(Long bookingId, BookingStatus status);  // 추가
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
@@ -36,4 +36,11 @@ public class BookingRepositoryAdapter implements BookingRepository {
         entity.updateStatus(BookingStatus.CANCEL_REQUESTED, LocalDateTime.now());
         return bookingMapper.toDomain(springDataBookingRepository.save(entity));
     }
+    @Override
+    public Booking updateStatus(Long bookingId, BookingStatus status) {
+        BookingJpaEntity entity = springDataBookingRepository.findById(bookingId)
+                .orElseThrow();
+        entity.updateStatus(status, LocalDateTime.now());
+        return bookingMapper.toDomain(springDataBookingRepository.save(entity));
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/SecurityConfig.java
@@ -35,7 +35,15 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/api/v1/countries/**",
+                                "/api/v1/packages/**",
+                                "/api/v1/bookings/**",
+                                "/api/v1/payments/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/kidmily/algoga_server/payment/application/command/CreatePaymentCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/command/CreatePaymentCommand.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.payment.application.command;
+
+import com.kidmily.algoga_server.payment.domain.model.PaymentType;
+
+public record CreatePaymentCommand(
+        Long bookingId,
+        Long userId,
+        PaymentType paymentType,
+        int amount,
+        int usedMileage,
+        Long usedCouponId,
+        String portonePaymentId   // 프론트에서 PortOne SDK 결제 후 받은 ID
+) {}

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
@@ -1,0 +1,149 @@
+package com.kidmily.algoga_server.payment.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kidmily.algoga_server.booking.domain.model.Booking;
+import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.payment.application.command.CreatePaymentCommand;
+import com.kidmily.algoga_server.payment.application.usecase.PaymentCommandUseCase;
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
+import com.kidmily.algoga_server.payment.domain.model.PaymentType;
+import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
+import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
+import com.kidmily.algoga_server.payment.infrastructure.portone.PortOneClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PaymentCommandService implements PaymentCommandUseCase {
+
+    private final PaymentRepository paymentRepository;
+    private final BookingRepository bookingRepository;
+    private final PortOneClient portOneClient;
+
+    @Override
+    public Long handle(CreatePaymentCommand command) {
+        log.info("[PaymentCommandService] 결제 요청 - bookingId: {}, type: {}, amount: {}",
+                command.bookingId(), command.paymentType(), command.amount());
+
+        // 예약 조회
+        Booking booking = bookingRepository.findById(command.bookingId())
+                .orElseThrow(() -> {
+                    log.warn("[PaymentCommandService] 예약을 찾을 수 없음 - bookingId: {}", command.bookingId());
+                    return new BusinessException(PaymentErrorCode.BOOKING_NOT_FOUND);
+                });
+
+        // 중복 결제 방지 (멱등성 키)
+        String idempotencyKey = generateIdempotencyKey(command.bookingId(), command.paymentType());
+        paymentRepository.findByIdempotencyKey(idempotencyKey).ifPresent(p -> {
+            if (p.getStatus() == PaymentStatus.SUCCESS) {
+                log.warn("[PaymentCommandService] 이미 완료된 결제 - idempotencyKey: {}", idempotencyKey);
+                throw new BusinessException(PaymentErrorCode.DUPLICATE_PAYMENT);
+            }
+        });
+
+        // 결제 금액 검증
+        validateAmount(booking, command.paymentType(), command.amount());
+
+        // PortOne 결제 검증
+        JsonNode portoneResult = portOneClient.getPayment(command.portonePaymentId());
+        String portoneStatus = portoneResult.path("status").asText();
+        int paidAmount = portoneResult.path("amount").path("total").asInt();
+
+        log.info("[PaymentCommandService] PortOne 검증 결과 - status: {}, amount: {}", portoneStatus, paidAmount);
+
+        // 금액 불일치 검증
+        if (paidAmount != command.amount()) {
+            log.warn("[PaymentCommandService] 결제 금액 불일치 - 요청: {}, PortOne: {}", command.amount(), paidAmount);
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
+        }
+
+        // 결제 저장
+        Payment payment = Payment.create(
+                command.bookingId(),
+                command.userId(),
+                command.paymentType(),
+                command.amount(),
+                command.usedMileage(),
+                command.usedCouponId(),
+                idempotencyKey
+        );
+
+        if ("PAID".equals(portoneStatus)) {
+            payment.markSuccess(command.portonePaymentId());
+            // 예약 상태 업데이트
+            BookingStatus newBookingStatus = resolveBookingStatus(command.paymentType());
+            bookingRepository.updateStatus(command.bookingId(), newBookingStatus);
+            log.info("[PaymentCommandService] 결제 성공 - bookingId: {}, newStatus: {}", command.bookingId(), newBookingStatus);
+        } else {
+            payment.markFailed();
+            log.warn("[PaymentCommandService] 결제 실패 - portoneStatus: {}", portoneStatus);
+        }
+
+        Payment saved = paymentRepository.save(payment);
+        log.info("[PaymentCommandService] 결제 저장 완료 - paymentId: {}", saved.getId());
+
+        return saved.getId();
+    }
+
+    private void validateAmount(Booking booking, PaymentType type, int amount) {
+        int expected = switch (type) {
+            case DEPOSIT -> booking.getDepositPrice();
+            case BALANCE -> booking.getBalancePrice();
+            case FULL -> booking.getTotalPrice();
+            case LECTURE_ONLY -> amount; // 강의 단독은 별도 검증 없음
+        };
+
+        if (type != PaymentType.LECTURE_ONLY && expected != amount) {
+            log.warn("[PaymentCommandService] 결제 금액 불일치 - 예상: {}, 요청: {}", expected, amount);
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
+        }
+    }
+
+    private BookingStatus resolveBookingStatus(PaymentType type) {
+        return switch (type) {
+            case DEPOSIT -> BookingStatus.DEPOSIT_PAID;
+            case BALANCE, FULL -> BookingStatus.FULL_PAID;
+            case LECTURE_ONLY -> BookingStatus.FULL_PAID;
+        };
+    }
+    @Override
+    public void handleWebhook(String portonePaymentId) {
+        log.info("[PaymentCommandService] 웹훅 수신 - portonePaymentId: {}", portonePaymentId);
+
+        // PortOne API로 결제 검증
+        JsonNode portoneResult = portOneClient.getPayment(portonePaymentId);
+        String portoneStatus = portoneResult.path("status").asText();
+
+        // 우리 DB에서 결제 조회
+        paymentRepository.findByPortonePaymentId(portonePaymentId).ifPresent(payment -> {
+            if (payment.getStatus() == PaymentStatus.SUCCESS) {
+                log.info("[PaymentCommandService] 웹훅 - 이미 SUCCESS 처리된 결제, 스킵 - portonePaymentId: {}", portonePaymentId);
+                return;
+            }
+
+            if ("PAID".equals(portoneStatus)) {
+                payment.markSuccess(portonePaymentId);
+                paymentRepository.save(payment);
+                BookingStatus newBookingStatus = resolveBookingStatus(payment.getPaymentType());
+                bookingRepository.updateStatus(payment.getBookingId(), newBookingStatus);
+                log.info("[PaymentCommandService] 웹훅 - 결제 SUCCESS 처리 완료 - bookingId: {}", payment.getBookingId());
+            } else {
+                log.warn("[PaymentCommandService] 웹훅 - 결제 미완료 상태 - portoneStatus: {}", portoneStatus);
+            }
+        });
+    }
+
+    private String generateIdempotencyKey(Long bookingId, PaymentType type) {
+        return bookingId + "_" + type.name();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
@@ -1,0 +1,57 @@
+package com.kidmily.algoga_server.payment.application.service;
+
+import com.kidmily.algoga_server.booking.domain.model.Booking;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.payment.application.usecase.PaymentQueryUseCase;
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
+import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
+import com.kidmily.algoga_server.payment.infrastructure.pdf.ConfirmationPdfGenerator;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PaymentQueryService implements PaymentQueryUseCase {
+
+    private final PaymentRepository paymentRepository;
+    private final BookingRepository bookingRepository;
+    private final ConfirmationPdfGenerator confirmationPdfGenerator;
+
+    @Override
+    public PaymentResponse getPayment(Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> {
+                    log.warn("[PaymentQueryService] 결제 정보를 찾을 수 없음 - paymentId: {}", paymentId);
+                    return new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
+                });
+
+        return PaymentResponse.from(payment);
+    }
+
+    @Override
+    public byte[] getConfirmationPdf(Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> {
+                    log.warn("[PaymentQueryService] PDF 생성 실패 - 결제 없음 - paymentId: {}", paymentId);
+                    return new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
+                });
+
+        Booking booking = bookingRepository.findById(payment.getBookingId())
+                .orElseThrow(() -> {
+                    log.warn("[PaymentQueryService] PDF 생성 실패 - 예약 없음 - bookingId: {}", payment.getBookingId());
+                    return new BusinessException(PaymentErrorCode.BOOKING_NOT_FOUND);
+                });
+
+        log.warn("[PaymentQueryService] 확인서 PDF 생성 - paymentId: {}, bookingId: {}",
+                paymentId, payment.getBookingId());
+
+        return confirmationPdfGenerator.generate(payment, booking);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentCommandUseCase.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.payment.application.usecase;
+
+import com.kidmily.algoga_server.payment.application.command.CreatePaymentCommand;
+
+public interface PaymentCommandUseCase {
+    Long handle(CreatePaymentCommand command);
+    void handleWebhook(String portonePaymentId);
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.payment.application.usecase;
+
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
+
+public interface PaymentQueryUseCase {
+    PaymentResponse getPayment(Long paymentId);
+    byte[] getConfirmationPdf(Long paymentId);
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/model/Payment.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/model/Payment.java
@@ -1,0 +1,73 @@
+package com.kidmily.algoga_server.payment.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment {
+
+    private Long id;
+    private Long bookingId;
+    private Long userId;
+    private PaymentType paymentType;
+    private int amount;
+    private int usedMileage;
+    private Long usedCouponId;
+    private PaymentStatus status;
+    private String idempotencyKey;
+    private String portonePaymentId;
+    private LocalDateTime createdAt;
+
+    public static Payment create(Long bookingId, Long userId, PaymentType paymentType,
+                                 int amount, int usedMileage, Long usedCouponId,
+                                 String idempotencyKey) {
+        Payment payment = new Payment();
+        payment.bookingId = bookingId;
+        payment.userId = userId;
+        payment.paymentType = paymentType;
+        payment.amount = amount;
+        payment.usedMileage = usedMileage;
+        payment.usedCouponId = usedCouponId;
+        payment.status = PaymentStatus.FAILED;
+        payment.idempotencyKey = idempotencyKey;
+        payment.createdAt = LocalDateTime.now();
+        return payment;
+    }
+
+    public static Payment reconstitute(Long id, Long bookingId, Long userId,
+                                       PaymentType paymentType, int amount,
+                                       int usedMileage, Long usedCouponId,
+                                       PaymentStatus status, String idempotencyKey,
+                                       String portonePaymentId, LocalDateTime createdAt) {
+        Payment payment = new Payment();
+        payment.id = id;
+        payment.bookingId = bookingId;
+        payment.userId = userId;
+        payment.paymentType = paymentType;
+        payment.amount = amount;
+        payment.usedMileage = usedMileage;
+        payment.usedCouponId = usedCouponId;
+        payment.status = status;
+        payment.idempotencyKey = idempotencyKey;
+        payment.portonePaymentId = portonePaymentId;
+        payment.createdAt = createdAt;
+        return payment;
+    }
+
+    public void markSuccess(String portonePaymentId) {
+        this.status = PaymentStatus.SUCCESS;
+        this.portonePaymentId = portonePaymentId;
+    }
+
+    public void markFailed() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    public void markRefunded() {
+        this.status = PaymentStatus.REFUNDED;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/model/PaymentStatus.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/model/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.kidmily.algoga_server.payment.domain.model;
+
+public enum PaymentStatus {
+    SUCCESS,
+    FAILED,
+    REFUNDED
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/model/PaymentType.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/model/PaymentType.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.payment.domain.model;
+
+public enum PaymentType {
+    DEPOSIT,        // 계약금
+    BALANCE,        // 잔금
+    FULL,           // 전액
+    LECTURE_ONLY    // 강의 단독
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/repository/PaymentRepository.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.payment.domain.repository;
+
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+
+import java.util.Optional;
+
+public interface PaymentRepository {
+    Payment save(Payment payment);
+    Optional<Payment> findById(Long paymentId);
+    Optional<Payment> findByIdempotencyKey(String idempotencyKey);
+    Optional<Payment> findByPortonePaymentId(String portonePaymentId);
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,22 @@
+package com.kidmily.algoga_server.payment.exception;
+
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements BaseErrorCode {
+
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY_001", "결제 정보를 찾을 수 없습니다."),
+    BOOKING_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY_002", "예약 정보를 찾을 수 없습니다."),
+    INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "PAY_003", "결제 금액이 올바르지 않습니다."),
+    DUPLICATE_PAYMENT(HttpStatus.CONFLICT, "PAY_004", "이미 처리된 결제입니다."),
+    PORTONE_API_ERROR(HttpStatus.BAD_GATEWAY, "PAY_005", "결제 처리 중 오류가 발생했습니다."),
+    INVALID_WEBHOOK(HttpStatus.BAD_REQUEST, "PAY_006", "유효하지 않은 웹훅 요청입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/mapper/PaymentMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/mapper/PaymentMapper.java
@@ -1,0 +1,39 @@
+package com.kidmily.algoga_server.payment.infrastructure.mapper;
+
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.infrastructure.persistence.PaymentJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentMapper {
+
+    public PaymentJpaEntity toJpaEntity(Payment payment){
+        return new PaymentJpaEntity(
+                payment.getBookingId(),
+                payment.getUserId(),
+                payment.getPaymentType(),
+                payment.getAmount(),
+                payment.getUsedMileage(),
+                payment.getUsedCouponId(),
+                payment.getStatus(),
+                payment.getIdempotencyKey(),
+                payment.getPortonePaymentId(),
+                payment.getCreatedAt()
+        );
+    }
+    public Payment toDomain(PaymentJpaEntity entity) {
+        return  Payment.reconstitute(
+                entity.getId(),
+                entity.getBookingId(),
+                entity.getUserId(),
+                entity.getPaymentType(),
+                entity.getAmount(),
+                entity.getUsedMileage(),
+                entity.getUsedCouponId(),
+                entity.getStatus(),
+                entity.getIdempotencyKey(),
+                entity.getPortonePaymentId(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/pdf/ConfirmationPdfGenerator.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/pdf/ConfirmationPdfGenerator.java
@@ -1,0 +1,128 @@
+package com.kidmily.algoga_server.payment.infrastructure.pdf;
+import com.itextpdf.io.font.PdfEncodings;
+import com.itextpdf.kernel.colors.ColorConstants;
+import com.itextpdf.kernel.font.PdfFont;
+import com.itextpdf.kernel.font.PdfFontFactory;
+import com.itextpdf.kernel.geom.PageSize;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.element.Cell;
+import com.itextpdf.layout.element.Paragraph;
+import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.properties.TextAlignment;
+import com.itextpdf.layout.properties.UnitValue;
+import com.kidmily.algoga_server.booking.domain.model.Booking;
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+public class ConfirmationPdfGenerator {
+
+    private static final String FONT_PATH = "C:/Windows/Fonts/malgun.ttf";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+
+    public byte[] generate(Payment payment, Booking booking) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            PdfWriter writer = new PdfWriter(baos);
+            PdfDocument pdfDoc = new PdfDocument(writer);
+            Document document = new Document(pdfDoc, PageSize.A4);
+            document.setMargins(40, 40, 40, 40);
+
+            PdfFont font = PdfFontFactory.createFont(FONT_PATH, PdfEncodings.IDENTITY_H);
+
+            // 제목
+            document.add(new Paragraph("여행 예약 확인서")
+                    .setFont(font)
+                    .setFontSize(22)
+                    .setBold()
+                    .setTextAlignment(TextAlignment.CENTER)
+                    .setMarginBottom(20));
+
+            // 구분선
+            document.add(new Paragraph("─".repeat(60))
+                    .setFont(font)
+                    .setFontColor(ColorConstants.GRAY)
+                    .setTextAlignment(TextAlignment.CENTER)
+                    .setMarginBottom(20));
+
+            // 예약 정보 테이블
+            document.add(new Paragraph("■ 예약 정보")
+                    .setFont(font)
+                    .setFontSize(13)
+                    .setBold()
+                    .setMarginBottom(8));
+
+            Table bookingTable = createTable(font);
+            addRow(bookingTable, font, "예약 번호", booking.getBookingNumber());
+            addRow(bookingTable, font, "체크인", booking.getCheckInDate().format(DATE_FORMATTER));
+            addRow(bookingTable, font, "체크아웃", booking.getCheckOutDate().format(DATE_FORMATTER));
+            addRow(bookingTable, font, "숙박 일수", booking.getNights() + "박");
+            addRow(bookingTable, font, "예약 상태", booking.getStatus().name());
+            document.add(bookingTable);
+
+            document.add(new Paragraph(" ").setMarginBottom(12));
+
+            // 결제 정보 테이블
+            document.add(new Paragraph("■ 결제 정보")
+                    .setFont(font)
+                    .setFontSize(13)
+                    .setBold()
+                    .setMarginBottom(8));
+
+            Table paymentTable = createTable(font);
+            addRow(paymentTable, font, "결제 유형", payment.getPaymentType().name());
+            addRow(paymentTable, font, "결제 금액", String.format("%,d원", payment.getAmount()));
+            addRow(paymentTable, font, "마일리지 사용", String.format("%,d원", payment.getUsedMileage()));
+            addRow(paymentTable, font, "결제 상태", payment.getStatus().name());
+            addRow(paymentTable, font, "결제 일시", payment.getCreatedAt().format(
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+            document.add(paymentTable);
+
+            document.add(new Paragraph(" ").setMarginBottom(20));
+
+            // 총 금액
+            document.add(new Paragraph(String.format("총 여행 금액: %,d원", booking.getTotalPrice()))
+                    .setFont(font)
+                    .setFontSize(14)
+                    .setBold()
+                    .setTextAlignment(TextAlignment.RIGHT)
+                    .setMarginBottom(30));
+
+            // 안내 문구
+            document.add(new Paragraph("본 확인서는 예약 확인 목적으로 발급되었습니다.")
+                    .setFont(font)
+                    .setFontSize(9)
+                    .setFontColor(ColorConstants.GRAY)
+                    .setTextAlignment(TextAlignment.CENTER));
+
+            document.close();
+            return baos.toByteArray();
+
+        } catch (Exception e) {
+            log.warn("[ConfirmationPdfGenerator] PDF 생성 실패 - paymentId: {}", payment.getId(), e);
+            throw new RuntimeException("PDF 생성에 실패했습니다.", e);
+        }
+    }
+
+    private Table createTable(PdfFont font) {
+        Table table = new Table(UnitValue.createPercentArray(new float[]{30, 70}))
+                .setWidth(UnitValue.createPercentValue(100));
+        return table;
+    }
+
+    private void addRow(Table table, PdfFont font, String key, String value) {
+        table.addCell(new Cell()
+                .add(new Paragraph(key).setFont(font).setFontSize(10).setBold())
+                .setBackgroundColor(ColorConstants.LIGHT_GRAY)
+                .setPadding(6));
+        table.addCell(new Cell()
+                .add(new Paragraph(value).setFont(font).setFontSize(10))
+                .setPadding(6));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentJpaEntity.java
@@ -1,0 +1,75 @@
+package com.kidmily.algoga_server.payment.infrastructure.persistence;
+
+import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
+import com.kidmily.algoga_server.payment.domain.model.PaymentType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @Column(name = "booking_id", nullable = false)
+    private Long bookingId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_type", nullable = false)
+    private PaymentType paymentType;
+
+    @Column(name = "amount", nullable = false)
+    private int amount;
+
+    @Column(name = "used_mileage")
+    private int usedMileage;
+
+    @Column(name = "used_coupon_id")
+    private Long usedCouponId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PaymentStatus status;
+
+    @Column(name = "idempotency_key", nullable = false)
+    private String idempotencyKey;
+
+    @Column(name = "portone_payment_id")
+    private String portonePaymentId;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    public PaymentJpaEntity(Long bookingId, Long userId, PaymentType paymentType,
+                            int amount, int usedMileage, Long usedCouponId,
+                            PaymentStatus status, String idempotencyKey,
+                            String portonePaymentId, LocalDateTime createdAt) {
+        this.bookingId = bookingId;
+        this.userId = userId;
+        this.paymentType = paymentType;
+        this.amount = amount;
+        this.usedMileage = usedMileage;
+        this.usedCouponId = usedCouponId;
+        this.status = status;
+        this.idempotencyKey = idempotencyKey;
+        this.portonePaymentId = portonePaymentId;
+        this.createdAt = createdAt;
+    }
+
+    public void updateStatus(PaymentStatus status, String portonePaymentId) {
+        this.status = status;
+        this.portonePaymentId = portonePaymentId;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
@@ -1,0 +1,41 @@
+package com.kidmily.algoga_server.payment.infrastructure.persistence;
+
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
+import com.kidmily.algoga_server.payment.infrastructure.mapper.PaymentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryAdapter implements PaymentRepository {
+
+    private final SpringDataPaymentRepository springDataPaymentRepository;
+    private final PaymentMapper paymentMapper;
+
+    @Override
+    public Payment save(Payment payment) {
+        PaymentJpaEntity entity = paymentMapper.toJpaEntity(payment);
+        return paymentMapper.toDomain(springDataPaymentRepository.save(entity));
+    }
+
+    @Override
+    public Optional<Payment> findById(Long paymentId) {
+        return springDataPaymentRepository.findById(paymentId)
+                .map(paymentMapper::toDomain);
+    }
+
+    @Override
+    public Optional<Payment> findByIdempotencyKey(String idempotencyKey) {
+        return springDataPaymentRepository.findByIdempotencyKey(idempotencyKey)
+                .map(paymentMapper::toDomain);
+    }
+
+    @Override
+    public Optional<Payment> findByPortonePaymentId(String portonePaymentId) {  // 추가된 것
+        return springDataPaymentRepository.findByPortonePaymentId(portonePaymentId)
+                .map(paymentMapper::toDomain);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/SpringDataPaymentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/SpringDataPaymentRepository.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.payment.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataPaymentRepository extends JpaRepository<PaymentJpaEntity, Long> {
+    Optional<PaymentJpaEntity> findByIdempotencyKey(String idempotencyKey);
+    Optional<PaymentJpaEntity>findByPortonePaymentId(String portonePaymentId);
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
@@ -1,0 +1,39 @@
+package com.kidmily.algoga_server.payment.infrastructure.portone;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class PortOneClient {
+
+    private final RestClient restClient;
+    private final PortOneProperties properties;
+
+    public PortOneClient(PortOneProperties properties) {
+        this.properties = properties;
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("Authorization", "PortOne " + properties.getApiSecret())
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    // 결제 단건 조회 - 검증용
+    public JsonNode getPayment(String portonePaymentId) {
+        log.info("[PortOneClient] 결제 조회 요청 - portonePaymentId: {}", portonePaymentId);
+        try {
+            return restClient.get()
+                    .uri("/payments/{paymentId}", portonePaymentId)
+                    .retrieve()
+                    .body(JsonNode.class);
+        } catch (Exception e) {
+            log.warn("[PortOneClient] PortOne API 호출 실패 - portonePaymentId: {}", portonePaymentId);
+            throw new BusinessException(PaymentErrorCode.PORTONE_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneProperties.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneProperties.java
@@ -1,0 +1,17 @@
+package com.kidmily.algoga_server.payment.infrastructure.portone;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "portone")
+public class PortOneProperties {
+    private String baseUrl;
+    private String storeId;
+    private String apiSecret;
+    private String channelKey;
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/PaymentController.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/PaymentController.java
@@ -1,0 +1,87 @@
+package com.kidmily.algoga_server.payment.presentation;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.payment.application.command.CreatePaymentCommand;
+import com.kidmily.algoga_server.payment.application.usecase.PaymentCommandUseCase;
+import com.kidmily.algoga_server.payment.application.usecase.PaymentQueryUseCase;
+import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
+import com.kidmily.algoga_server.payment.presentation.api.request.CreatePaymentRequest;
+import com.kidmily.algoga_server.payment.presentation.api.request.WebhookRequest;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+@Tag(name = "Payment", description = "결제 API")
+public class PaymentController {
+
+    private final PaymentCommandUseCase paymentCommandUseCase;
+    private final PaymentQueryUseCase paymentQueryUseCase;
+
+    @PostMapping
+    @Operation(summary = "결제 처리", description = "PortOne v2 결제 검증 후 저장합니다.")
+    @ApiErrorCodeExample(domain = PaymentErrorCode.class,
+            value = {"BOOKING_NOT_FOUND", "DUPLICATE_PAYMENT", "INVALID_PAYMENT_AMOUNT", "PORTONE_API_ERROR"})
+    public ResponseEntity<ApiResponse<Long>> createPayment(
+            @Valid @RequestBody CreatePaymentRequest request
+    ) {
+        CreatePaymentCommand command = new CreatePaymentCommand(
+                request.bookingId(),
+                request.userId(),
+                request.paymentType(),
+                request.amount(),
+                request.usedMileage(),
+                request.usedCouponId(),
+                request.portonePaymentId()
+        );
+        Long paymentId = paymentCommandUseCase.handle(command);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("PAYMENT_CREATED", "결제가 완료됐습니다.", paymentId));
+    }
+
+    @GetMapping("/{paymentId}")
+    @Operation(summary = "결제 상세 조회", description = "결제 상세 정보를 조회합니다.")
+    @ApiErrorCodeExample(domain = PaymentErrorCode.class, value = {"PAYMENT_NOT_FOUND"})
+    public ResponseEntity<ApiResponse<PaymentResponse>> getPayment(
+            @Parameter(description = "결제 ID", example = "1")
+            @PathVariable Long paymentId
+    ) {
+        PaymentResponse response = paymentQueryUseCase.getPayment(paymentId);
+        return ResponseEntity.ok(ApiResponse.success("PAYMENT_FOUND", "결제 조회에 성공했습니다.", response));
+    }
+    @GetMapping("/{paymentId}/confirmation")
+    @Operation(summary = "예약 확인서 PDF", description = "예약 확인서를 PDF로 다운로드합니다.")
+    @ApiErrorCodeExample(domain = PaymentErrorCode.class, value = {"PAYMENT_NOT_FOUND", "BOOKING_NOT_FOUND"})
+    public ResponseEntity<byte[]> getConfirmation(
+            @Parameter(description = "결제 ID", example = "1")
+            @PathVariable Long paymentId
+    ) {
+        byte[] pdf = paymentQueryUseCase.getConfirmationPdf(paymentId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"confirmation_" + paymentId + ".pdf\"")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
+    }
+    @PostMapping("/webhook")
+    @Operation(summary = "PortOne 웹훅", description = "PortOne 결제 이벤트를 수신합니다.")
+    public ResponseEntity<Void> handleWebhook(
+            @RequestBody WebhookRequest request
+    ) {
+        if ("Transaction.Paid".equals(request.type())) {
+            paymentCommandUseCase.handleWebhook(request.data().paymentId());
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/advice/PaymentExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/advice/PaymentExceptionAdvice.java
@@ -1,0 +1,29 @@
+package com.kidmily.algoga_server.payment.presentation.advice;
+
+import com.kidmily.algoga_server.global.common.api.response.ErrorResponse;
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.kidmily.algoga_server.payment.presentation.api")
+public class PaymentExceptionAdvice implements CommonExceptionAdvice {
+
+    @Override
+    public Logger getLogger() {
+        return log;
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    @Override
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        BaseErrorCode errorCode = e.getErrorCode();
+        log.warn("[Business Exception] code: {}, message: {}", errorCode.getCode(), e.getMessage());
+        return CommonExceptionAdvice.super.handleBusinessException(e);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/api/request/CreatePaymentRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/api/request/CreatePaymentRequest.java
@@ -1,0 +1,27 @@
+package com.kidmily.algoga_server.payment.presentation.api.request;
+
+import com.kidmily.algoga_server.payment.domain.model.PaymentType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreatePaymentRequest(
+        @NotNull(message = "예약 ID는 필수입니다.")
+        Long bookingId,
+
+        @NotNull(message = "사용자 ID는 필수입니다.")
+        Long userId,
+
+        @NotNull(message = "결제 유형은 필수입니다.")
+        PaymentType paymentType,
+
+        @Min(value = 1, message = "결제 금액은 1원 이상이어야 합니다.")
+        int amount,
+
+        int usedMileage,
+
+        Long usedCouponId,
+
+        @NotBlank(message = "PortOne 결제 ID는 필수입니다.")
+        String portonePaymentId
+) {}

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/api/request/WebhookRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/api/request/WebhookRequest.java
@@ -1,0 +1,16 @@
+package com.kidmily.algoga_server.payment.presentation.api.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record WebhookRequest(
+        String type,
+        Data data
+) {
+    public record Data(
+            @JsonProperty("paymentId")
+            String paymentId,
+
+            @JsonProperty("transactionId")
+            String transactionId
+    ) {}
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentResponse.java
@@ -1,0 +1,35 @@
+package com.kidmily.algoga_server.payment.presentation.api.response;
+
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
+import com.kidmily.algoga_server.payment.domain.model.PaymentType;
+
+import java.time.LocalDateTime;
+
+public record PaymentResponse(
+        Long paymentId,
+        Long bookingId,
+        Long userId,
+        PaymentType paymentType,
+        int amount,
+        int usedMileage,
+        Long usedCouponId,
+        PaymentStatus status,
+        String portonePaymentId,
+        LocalDateTime createdAt
+) {
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+                payment.getId(),
+                payment.getBookingId(),
+                payment.getUserId(),
+                payment.getPaymentType(),
+                payment.getAmount(),
+                payment.getUsedMileage(),
+                payment.getUsedCouponId(),
+                payment.getStatus(),
+                payment.getPortonePaymentId(),
+                payment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,3 +39,9 @@ jwt:
 app:
   file:
     upload-root: uploads
+
+portone:
+  base-url: https://api.portone.io
+  store-id: store-9e71265b-7e7b-42d3-b858-ac959180f553
+  api-secret: QIbaruS1C2lxRTCMp8o1RzYTCKxt3maZDKkSDChTYeRDIR549CzTXDHZiBbrPlRSV5Y65uWrCph9fzQp
+  channel-key: channel-key-16bc953e-35b9-4cf7-8ea5-a42f1884381f


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
PortOne v2 REST API를 연동한 결제 도메인을 구현했습니다.
계약금/잔금/전액 3가지 결제 유형을 지원하며, 결제 완료 후 예약 확인서 PDF 다운로드 기능을 포함합니다.
## 🔗 Issue
Closes #58 

---
## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ]  결제 금액이 예약의 계약금/잔금/전액과 일치하는지 검증 로직 확인
- [ ] 멱등성 키(bookingId_paymentType)로 중복 결제 방지 처리 확인
- [ ]  PortOne 웹훅 수신 시 결제 상태 및 예약 상태 동기화 확인
- [ ]   PDF 한글 폰트(맑은 고딕) 렌더링 확인
- [ ] SecurityConfig: 현재 테스트용으로 열려있음, 배포 전 JWT 인증 필요