### PR TITLE
[Feature] 커뮤니티 댓글/대댓글 CRUD, 좋아요 싫어요, 신고 기능 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/community/application/command/CreateCommentCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/CreateCommentCommand.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.community.application.command;
+
+public record CreateCommentCommand(
+        Long postId,
+        Long userId,
+        Long parentId,
+        String content
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/CreatePostCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/CreatePostCommand.java
@@ -1,6 +1,6 @@
 package com.kidmily.algoga_server.community.application.command;
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/CreateReportCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/CreateReportCommand.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.community.application.command;
+
+import com.kidmily.algoga_server.community.domain.model.ReasonType;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+
+public record CreateReportCommand(
+        Long userId,
+        Long targetId,
+        TargetType targetType,
+        ReasonType reasonType,
+        String detail
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/DeleteCommentCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/DeleteCommentCommand.java
@@ -1,0 +1,7 @@
+package com.kidmily.algoga_server.community.application.command;
+
+public record DeleteCommentCommand(
+        Long commentId,
+        Long userId
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/ToggleReactionCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/ToggleReactionCommand.java
@@ -1,0 +1,11 @@
+package com.kidmily.algoga_server.community.application.command;
+
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+
+public record ToggleReactionCommand(
+        Long userId,
+        TargetType targetType,
+        Long targetId,
+        Boolean isLike  // true: 좋아요, false: 싫어요
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/UpdateCommentCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/UpdateCommentCommand.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.community.application.command;
+
+public record UpdateCommentCommand(
+        Long commentId,
+        Long userId,
+        String content
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/command/UpdatePostCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/command/UpdatePostCommand.java
@@ -1,6 +1,6 @@
 package com.kidmily.algoga_server.community.application.command;
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 
 import java.util.List;
 

--- a/src/main/java/com/kidmily/algoga_server/community/application/policy/DeleteCommentPolicy.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/policy/DeleteCommentPolicy.java
@@ -1,0 +1,26 @@
+package com.kidmily.algoga_server.community.application.policy;
+
+import com.kidmily.algoga_server.community.domain.model.Comment;
+import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteCommentPolicy {
+
+    private final CommentRepository commentRepository;
+
+    public void execute(Comment comment, Long requesterId) {
+        comment.delete(requesterId);
+        commentRepository.delete(comment);
+
+        if (!comment.isReply()) {
+            commentRepository.findActiveRepliesByParentId(comment.getCommentId())
+                    .forEach(reply -> {
+                        reply.delete(requesterId);
+                        commentRepository.delete(reply);
+                    });
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/CommentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/CommentCommandService.java
@@ -1,0 +1,86 @@
+package com.kidmily.algoga_server.community.application.service;
+
+import com.kidmily.algoga_server.community.application.command.CreateCommentCommand;
+import com.kidmily.algoga_server.community.application.command.DeleteCommentCommand;
+import com.kidmily.algoga_server.community.application.command.UpdateCommentCommand;
+import com.kidmily.algoga_server.community.application.policy.DeleteCommentPolicy;
+import com.kidmily.algoga_server.community.application.usecase.CommentCommandUseCase;
+import com.kidmily.algoga_server.community.domain.model.Comment;
+import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
+import com.kidmily.algoga_server.community.domain.repository.PostRepository;
+import com.kidmily.algoga_server.community.exception.CommentException;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.exception.PostException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentCommandService implements CommentCommandUseCase {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final DeleteCommentPolicy deleteCommentPolicy;
+
+    // 댓글 작성
+    @Override
+    public Comment handle(CreateCommentCommand command) {
+        log.info("[CommentCommandService] 댓글 작성 요청 수신 - postId: {}, userId: {}, parentId: {}",
+                command.postId(), command.userId(), command.parentId());
+
+        postRepository.findById(command.postId())
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        // 대댓글인 경우 부모 댓글 존재 여부 검증
+        if (command.parentId() != null) {
+            commentRepository.findById(command.parentId())
+                    .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+        }
+
+        Comment comment = Comment.create(
+                command.postId(),
+                command.userId(),
+                command.parentId(),
+                command.content()
+        );
+
+        Comment savedComment = commentRepository.save(comment);
+
+        log.info("[CommentCommandService] 댓글 작성 완료 - commentId: {}", savedComment.getCommentId());
+
+        return savedComment;
+    }
+
+    // 댓글 수정
+    @Override
+    public Comment handle(UpdateCommentCommand command) {
+        log.info("[CommentCommandService] 댓글 수정 요청 수신 - commentId: {}, userId: {}",
+                command.commentId(), command.userId());
+
+        Comment comment = commentRepository.findById(command.commentId())
+                .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+
+        comment.updateContent(command.userId(), command.content());
+        Comment updatedComment = commentRepository.update(comment);
+
+        log.info("[CommentCommandService] 댓글 수정 완료 - commentId: {}", updatedComment.getCommentId());
+        return updatedComment;
+    }
+
+    // 댓글 삭제
+    @Override
+    public void handle(DeleteCommentCommand command) {
+        log.info("[CommentCommandService] 댓글 삭제 요청 수신 - commentId: {}, userId: {}",
+                command.commentId(), command.userId());
+
+        Comment comment = commentRepository.findById(command.commentId())
+                .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+
+        deleteCommentPolicy.execute(comment, command.userId());
+
+        log.info("[CommentCommandService] 댓글 삭제 완료 - commentId: {}", command.commentId());
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.community.application.service;
 
 import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
+import com.kidmily.algoga_server.community.domain.model.Comment;
 import com.kidmily.algoga_server.community.domain.model.Post;
 import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
 import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
@@ -8,7 +9,7 @@ import com.kidmily.algoga_server.community.domain.repository.PostRepository;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.exception.PostException;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
 import com.kidmily.algoga_server.community.presentation.api.response.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,11 +48,16 @@ public class PostQueryService implements PostQueryUseCase {
         Long dislikeCount = likeDislikeRepository.countDislikes(TargetType.POST, postId);
 
 
-        List<CommentResponse> comments = commentRepository
-                .findActiveCommentsByPostId(postId)
-                .stream()
-                .map(c -> new CommentResponse(c.getCommentId(), c.getUserId(), c.getContent(), c.getCreatedAt()))
-                .toList();
+//        List<CreateCommentResponse> comments = commentRepository
+//                .findActiveCommentsByPostId(postId)
+//                .stream()
+//                .map(c -> new CreateCommentResponse(c.getCommentId(), c.getUserId(), c.getContent(),  c.getParentId(), c.getCreatedAt()))
+//                .toList();
+
+
+        List<CommentResponse> comments = toCommentTree(
+                commentRepository.findActiveCommentsByPostId(postId)
+        );
 
         // 💡 [수정] 태그 변환 로직을 메서드 안쪽으로 이동시켰습니다.
         Stream<TagResponse> categoryStream = post.getCategory() != null ?
@@ -160,4 +166,31 @@ public class PostQueryService implements PostQueryUseCase {
                 post.getCreatedAt()
         );
     }
+
+    private List<CommentResponse> toCommentTree(List<Comment> comments) {
+        // 일반 댓글만 추출
+        List<CommentResponse> roots = comments.stream()
+                .filter(c -> c.getParentId() == null)
+                .map(c -> new CommentResponse(
+                        c.getCommentId(),
+                        c.getUserId(),
+                        c.getContent(),
+                        c.getCreatedAt(),
+                        // 해당 댓글의 대댓글 붙이기
+                        comments.stream()
+                                .filter(r -> c.getCommentId().equals(r.getParentId()))
+                                .map(r -> new CommentResponse(
+                                        r.getCommentId(),
+                                        r.getUserId(),
+                                        r.getContent(),
+                                        r.getCreatedAt(),
+                                        List.of()
+                                ))
+                                .toList()
+                ))
+                .toList();
+        return roots;
+    }
+
+
 }

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
@@ -8,7 +8,7 @@ import com.kidmily.algoga_server.community.domain.repository.LikeDislikeReposito
 import com.kidmily.algoga_server.community.domain.repository.PostRepository;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.exception.PostException;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import com.kidmily.algoga_server.community.domain.model.TargetType;
 import com.kidmily.algoga_server.community.presentation.api.response.*;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/ReactionCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/ReactionCommandService.java
@@ -1,0 +1,82 @@
+package com.kidmily.algoga_server.community.application.service;
+
+import com.kidmily.algoga_server.community.application.command.ToggleReactionCommand;
+import com.kidmily.algoga_server.community.application.usecase.ReactionCommandUseCase;
+import com.kidmily.algoga_server.community.domain.model.LikeDislike;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
+import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
+import com.kidmily.algoga_server.community.domain.repository.PostRepository;
+import com.kidmily.algoga_server.community.exception.CommentException;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.exception.PostException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReactionCommandService implements ReactionCommandUseCase {
+
+    private final LikeDislikeRepository likeDislikeRepository;
+    private final PostRepository postRepository;         // ← 추가
+    private final CommentRepository commentRepository;   //
+
+    @Override
+    public ReactionResult handle(ToggleReactionCommand command) {
+
+        // 대상 존재 여부 검증
+        if (command.targetType() == TargetType.POST) {
+            postRepository.findById(command.targetId())
+                    .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+        } else if (command.targetType() == TargetType.COMMENT) {
+            commentRepository.findById(command.targetId())
+                    .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+        }
+
+
+        log.info("[ReactionCommandService] 반응 토글 요청 - userId: {}, targetType: {}, targetId: {}, isLike: {}",
+                command.userId(), command.targetType(), command.targetId(), command.isLike());
+
+        Optional<LikeDislike> existing = likeDislikeRepository.findByUserAndTarget(
+                command.userId(), command.targetType(), command.targetId()
+        );
+
+        ReactionStatus status;
+
+        if (existing.isEmpty()) {
+            likeDislikeRepository.save(LikeDislike.create(
+                    command.userId(), command.targetType(), command.targetId(), command.isLike()
+            ));
+            log.info("[ReactionCommandService] 반응 추가 완료");
+            status = ReactionStatus.ADDED;
+
+        } else {
+            LikeDislike current = existing.get();
+
+            if (current.isSameReaction(command.isLike())) {
+                likeDislikeRepository.delete(current);
+                log.info("[ReactionCommandService] 반응 취소 완료");
+                status = ReactionStatus.REMOVED;
+
+            } else {
+                likeDislikeRepository.delete(current);
+                likeDislikeRepository.save(LikeDislike.create(
+                        command.userId(), command.targetType(), command.targetId(), command.isLike()
+                ));
+                log.info("[ReactionCommandService] 반응 전환 완료");
+                status = ReactionStatus.CHANGED;
+            }
+        }
+
+        Long likeCount = likeDislikeRepository.countLikes(command.targetType(), command.targetId());
+        Long dislikeCount = likeDislikeRepository.countDislikes(command.targetType(), command.targetId());
+
+        return new ReactionResult(status, likeCount, dislikeCount);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/ReportCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/ReportCommandService.java
@@ -1,0 +1,62 @@
+package com.kidmily.algoga_server.community.application.service;
+
+import com.kidmily.algoga_server.community.application.command.CreateReportCommand;
+import com.kidmily.algoga_server.community.application.usecase.ReportCommandUseCase;
+import com.kidmily.algoga_server.community.domain.model.Report;
+import com.kidmily.algoga_server.community.domain.repository.PostRepository;
+import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
+import com.kidmily.algoga_server.community.domain.repository.ReportRepository;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+import com.kidmily.algoga_server.community.exception.CommentException;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.exception.PostException;
+import com.kidmily.algoga_server.community.exception.ReportException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReportCommandService implements ReportCommandUseCase {
+
+    private final ReportRepository reportRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Override
+    public Long handle(CreateReportCommand command) {
+        log.info("[ReportCommandService] 신고 요청 수신 - userId: {}, targetType: {}, targetId: {}",
+                command.userId(), command.targetType(), command.targetId());
+
+        // 대상 존재 여부 검증
+        if (command.targetType() == TargetType.POST) {
+            postRepository.findById(command.targetId())
+                    .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+        } else if (command.targetType() == TargetType.COMMENT) {
+            commentRepository.findById(command.targetId())
+                    .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+        }
+
+        // 중복 신고 검증
+        if (reportRepository.existsByUserAndTarget(command.userId(), command.targetType(), command.targetId())) {
+            throw new ReportException(PostErrorCode.REPORT_DUPLICATED);
+        }
+
+        Report report = Report.create(
+                command.userId(),
+                command.targetId(),
+                command.targetType(),
+                command.reasonType(),
+                command.detail()
+        );
+
+        Report savedReport = reportRepository.save(report);
+
+        log.info("[ReportCommandService] 신고 완료 - reportId: {}", savedReport.getReportId());
+
+        return savedReport.getReportId();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/usecase/CommentCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/usecase/CommentCommandUseCase.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.community.application.usecase;
+
+import com.kidmily.algoga_server.community.application.command.CreateCommentCommand;
+import com.kidmily.algoga_server.community.application.command.DeleteCommentCommand;
+import com.kidmily.algoga_server.community.application.command.UpdateCommentCommand;
+import com.kidmily.algoga_server.community.domain.model.Comment;
+
+public interface CommentCommandUseCase {
+    Comment handle(CreateCommentCommand command);
+    Comment handle(UpdateCommentCommand command);
+    void handle(DeleteCommentCommand command);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/usecase/PostQueryUseCase.java
@@ -1,6 +1,6 @@
 package com.kidmily.algoga_server.community.application.usecase;
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import com.kidmily.algoga_server.community.presentation.api.response.PostListResponse;
 import com.kidmily.algoga_server.community.presentation.api.response.PostResponse;
 

--- a/src/main/java/com/kidmily/algoga_server/community/application/usecase/ReactionCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/usecase/ReactionCommandUseCase.java
@@ -1,0 +1,20 @@
+package com.kidmily.algoga_server.community.application.usecase;
+
+import com.kidmily.algoga_server.community.application.command.ToggleReactionCommand;
+import com.kidmily.algoga_server.community.presentation.api.response.ToggleReactionResponse;
+
+public interface ReactionCommandUseCase {
+    ReactionResult handle(ToggleReactionCommand command);
+
+    enum ReactionStatus {
+        ADDED,
+        REMOVED,
+        CHANGED
+    }
+
+    record ReactionResult(
+            ReactionStatus status,
+            Long likeCount,
+            Long dislikeCount
+    ) {}
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/usecase/ReportCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/usecase/ReportCommandUseCase.java
@@ -1,0 +1,7 @@
+package com.kidmily.algoga_server.community.application.usecase;
+
+import com.kidmily.algoga_server.community.application.command.CreateReportCommand;
+
+public interface ReportCommandUseCase {
+    Long handle(CreateReportCommand command);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Comment.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Comment.java
@@ -1,0 +1,82 @@
+package com.kidmily.algoga_server.community.domain.model;
+
+import com.kidmily.algoga_server.community.exception.CommentException;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+
+import java.time.LocalDateTime;
+
+public class Comment {
+
+    private final Long commentId;
+    private final Long postId;
+    private final Long userId;
+    private final Long parentId;   // null이면 일반 댓글, 값 있으면 대댓글
+    private String content;
+    private boolean deleted;
+    private final LocalDateTime createdAt;
+
+    // 신규 생성용
+    public static Comment create(Long postId, Long userId, Long parentId, String content) {
+        validate(content);
+        return new Comment(null, postId, userId, parentId, content, false, null);
+    }
+
+    public void updateContent(Long requesterId, String newContent) {
+        validateOwnerForUpdate(requesterId);
+        validate(newContent);
+        this.content = newContent;
+    }
+
+    public void delete(Long requesterId) {
+        validateOwnerForDelete(requesterId);
+        this.deleted = true;
+    }
+
+    private void validateOwnerForUpdate(Long requesterId) {
+        if (!this.userId.equals(requesterId)) {
+            throw new CommentException(PostErrorCode.COMMENT_UPDATE_FORBIDDEN);
+        }
+    }
+
+    private void validateOwnerForDelete(Long requesterId) {
+        if (!this.userId.equals(requesterId)) {
+            throw new CommentException(PostErrorCode.COMMENT_DELETE_FORBIDDEN);
+        }
+    }
+
+    // DB 복원용
+    public static Comment reconstitute(Long commentId, Long postId, Long userId,
+                                       Long parentId, String content,
+                                       boolean deleted, LocalDateTime createdAt) {
+        return new Comment(commentId, postId, userId, parentId, content, deleted, createdAt);
+    }
+
+    private static void validate(String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("내용을 입력해주세요.");
+        }
+        if (content.length() > 500) {
+            throw new IllegalArgumentException("댓글은 최대 500자입니다.");
+        }
+    }
+
+    private Comment(Long commentId, Long postId, Long userId, Long parentId,
+                    String content, boolean deleted, LocalDateTime createdAt) {
+        this.commentId = commentId;
+        this.postId = postId;
+        this.userId = userId;
+        this.parentId = parentId;
+        this.content = content;
+        this.deleted = deleted;
+        this.createdAt = createdAt;
+    }
+
+    public Long getCommentId() { return commentId; }
+    public Long getPostId() { return postId; }
+    public Long getUserId() { return userId; }
+    public Long getParentId() { return parentId; }
+    public String getContent() { return content; }
+    public boolean isDeleted() { return deleted; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public boolean isReply() { return parentId != null; }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/LikeDislike.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/LikeDislike.java
@@ -1,0 +1,53 @@
+package com.kidmily.algoga_server.community.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeDislike {
+
+    private Long likeId;
+    private Long userId;
+    private TargetType targetType;
+    private Long targetId;
+    private Boolean isLike;
+    private LocalDateTime createdAt;
+
+    private LikeDislike(Long userId, TargetType targetType, Long targetId, Boolean isLike) {
+        this.userId = userId;
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.isLike = isLike;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    private LikeDislike(Long likeId, Long userId, TargetType targetType, Long targetId,
+                        Boolean isLike, LocalDateTime createdAt) {
+        this.likeId = likeId;
+        this.userId = userId;
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.isLike = isLike;
+        this.createdAt = createdAt;
+    }
+
+    // 신규 생성
+    public static LikeDislike create(Long userId, TargetType targetType, Long targetId, Boolean isLike) {
+        return new LikeDislike(userId, targetType, targetId, isLike);
+    }
+
+    // DB 복원
+    public static LikeDislike reconstitute(Long likeId, Long userId, TargetType targetType,
+                                           Long targetId, Boolean isLike, LocalDateTime createdAt) {
+        return new LikeDislike(likeId, userId, targetType, targetId, isLike, createdAt);
+    }
+
+    // 같은 타입(좋아요/싫어요)인지 확인
+    public boolean isSameReaction(Boolean isLike) {
+        return this.isLike.equals(isLike);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
@@ -2,7 +2,6 @@ package com.kidmily.algoga_server.community.domain.model;
 
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.exception.PostException;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/PostTagType.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/PostTagType.java
@@ -1,4 +1,4 @@
-package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+package com.kidmily.algoga_server.community.domain.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/ReasonType.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/ReasonType.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.community.domain.model;
+
+public enum ReasonType {
+    SPAM,           // 스팸/광고
+    ABUSE,          // 욕설/비방
+    FALSE_INFO,     // 허위 정보
+    INAPPROPRIATE,  // 부적절한 콘텐츠
+    COPYRIGHT,      // 저작권 침해
+    ETC             // 기타
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Report.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Report.java
@@ -1,0 +1,64 @@
+package com.kidmily.algoga_server.community.domain.model;
+
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.exception.ReportException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report {
+
+    private static final int MAX_DETAIL_LENGTH = 255;
+
+    private Long reportId;
+    private Long userId;
+    private Long targetId;
+    private TargetType targetType;
+    private ReasonType reasonType;
+    private String detail;
+    private LocalDateTime createdAt;
+
+    private Report(Long userId, Long targetId, TargetType targetType,
+                   ReasonType reasonType, String detail) {
+        validateDetail(detail);
+
+        this.userId = userId;
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.reasonType = reasonType;
+        this.detail = detail;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    private Report(Long reportId, Long userId, Long targetId, TargetType targetType,
+                   ReasonType reasonType, String detail, LocalDateTime createdAt) {
+        this.reportId = reportId;
+        this.userId = userId;
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.reasonType = reasonType;
+        this.detail = detail;
+        this.createdAt = createdAt;
+    }
+
+    public static Report create(Long userId, Long targetId, TargetType targetType,
+                                ReasonType reasonType, String detail) {
+        return new Report(userId, targetId, targetType, reasonType, detail);
+    }
+
+    public static Report reconstitute(Long reportId, Long userId, Long targetId,
+                                      TargetType targetType, ReasonType reasonType,
+                                      String detail, LocalDateTime createdAt) {
+        return new Report(reportId, userId, targetId, targetType, reasonType, detail, createdAt);
+    }
+
+    private void validateDetail(String detail) {
+        if (detail != null && detail.length() > MAX_DETAIL_LENGTH) {
+            throw new ReportException(PostErrorCode.REPORT_DETAIL_TOO_LONG);
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/TargetType.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/TargetType.java
@@ -1,0 +1,6 @@
+package com.kidmily.algoga_server.community.domain.model;
+
+public enum TargetType {
+    POST,
+    COMMENT
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/CommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/CommentRepository.java
@@ -1,9 +1,15 @@
 package com.kidmily.algoga_server.community.domain.repository;
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.CommentJpaEntity;
+import com.kidmily.algoga_server.community.domain.model.Comment;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository {
-    List<CommentJpaEntity> findActiveCommentsByPostId(Long postId);
+    Comment save(Comment comment);
+    List<Comment> findActiveCommentsByPostId(Long postId);
+    Comment update(Comment comment);
+    void delete(Comment comment);
+    Optional<Comment> findById(Long commentId);
+    List<Comment> findActiveRepliesByParentId(Long parentId);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/LikeDislikeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/LikeDislikeRepository.java
@@ -1,6 +1,6 @@
 package com.kidmily.algoga_server.community.domain.repository;
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
 
 public interface LikeDislikeRepository {
     Long countLikes(TargetType targetType, Long targetId);

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/LikeDislikeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/LikeDislikeRepository.java
@@ -1,8 +1,14 @@
 package com.kidmily.algoga_server.community.domain.repository;
 
+import com.kidmily.algoga_server.community.domain.model.LikeDislike;
 import com.kidmily.algoga_server.community.domain.model.TargetType;
+
+import java.util.Optional;
 
 public interface LikeDislikeRepository {
     Long countLikes(TargetType targetType, Long targetId);
     Long countDislikes(TargetType targetType, Long targetId);
+    Optional<LikeDislike> findByUserAndTarget(Long userId, TargetType targetType, Long targetId);
+    LikeDislike save(LikeDislike likeDislike);
+    void delete(LikeDislike likeDislike);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
@@ -1,7 +1,7 @@
 package com.kidmily.algoga_server.community.domain.repository;
 
 import com.kidmily.algoga_server.community.domain.model.Post;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/ReportRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/ReportRepository.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.community.domain.repository;
+
+import com.kidmily.algoga_server.community.domain.model.Report;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+
+public interface ReportRepository {
+    Report save(Report report);
+    boolean existsByUserAndTarget(Long userId, TargetType targetType, Long targetId);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/exception/CommentException.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/CommentException.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.community.exception;
+
+public class CommentException extends RuntimeException {
+    private final PostErrorCode errorCode;
+
+    public CommentException(PostErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public PostErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
@@ -18,23 +18,30 @@ public enum PostErrorCode implements BaseErrorCode {
     POST_FREE_TAG_DUPLICATED(HttpStatus.BAD_REQUEST, "POST_005", "자유 태그에 중복된 값이 있습니다."),
     POST_TITLE_BLANK(HttpStatus.BAD_REQUEST, "POST_006", "제목은 필수입니다."),
     POST_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "POST_007", "본문은 필수입니다."),
+    REPORT_DETAIL_TOO_LONG(HttpStatus.BAD_REQUEST, "POST_020", "신고 상세 내용은 최대 255자입니다."),
 
     // 401 - 인증
     POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_008", "게시글 작성 권한이 없습니다."),
     COMMENT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_009", "댓글 작성 권한이 없습니다."),
+    REACTION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_010", "좋아요/싫어요 권한이 없습니다."),
+    REPORT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_022", "신고 권한이 없습니다."),
+
+    // 409
+    REPORT_DUPLICATED(HttpStatus.CONFLICT, "POST_021", "이미 신고한 대상입니다."),
 
     // 413 - 이미지
-    POST_IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_010", "이미지는 최대 10장까지 업로드 가능합니다."),
-    POST_IMAGE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_011", "이미지 한 장의 크기는 최대 10MB입니다."),
+    POST_IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_011", "이미지는 최대 10장까지 업로드 가능합니다."),
+    POST_IMAGE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_012", "이미지 한 장의 크기는 최대 10MB입니다."),
 
-    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_012", "게시글을 수정할 권한이 없습니다."),
-    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_013", "게시글을 삭제할 권한이 없습니다."),
-    POST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_014", "해당 목록을 조회할 권한이 없습니다."),
-    COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_015", "댓글을 수정할 권한이 없습니다."),
-    COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_016", "댓글을 삭제할 권한이 없습니다."),
+    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_013", "게시글을 수정할 권한이 없습니다."),
+    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_014", "게시글을 삭제할 권한이 없습니다."),
+    POST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_015", "해당 목록을 조회할 권한이 없습니다."),
+    COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_016", "댓글을 수정할 권한이 없습니다."),
+    COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_017", "댓글을 삭제할 권한이 없습니다."),
     // 404
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_017", "게시글을 찾을 수 없습니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_018", "댓글을 찾을 수 없습니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_018", "게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_019", "댓글을 찾을 수 없습니다.");
+
 
 
     private final HttpStatus status;

--- a/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
@@ -21,17 +21,21 @@ public enum PostErrorCode implements BaseErrorCode {
 
     // 401 - 인증
     POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_008", "게시글 작성 권한이 없습니다."),
+    COMMENT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_009", "댓글 작성 권한이 없습니다."),
 
     // 413 - 이미지
-    POST_IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_009", "이미지는 최대 10장까지 업로드 가능합니다."),
-    POST_IMAGE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_010", "이미지 한 장의 크기는 최대 10MB입니다."),
+    POST_IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_010", "이미지는 최대 10장까지 업로드 가능합니다."),
+    POST_IMAGE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "POST_011", "이미지 한 장의 크기는 최대 10MB입니다."),
 
-    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_011", "게시글을 수정할 권한이 없습니다."),
-    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_012", "게시글을 삭제할 권한이 없습니다."),
-    POST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_013", "해당 목록을 조회할 권한이 없습니다."),
-
+    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_012", "게시글을 수정할 권한이 없습니다."),
+    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_013", "게시글을 삭제할 권한이 없습니다."),
+    POST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_014", "해당 목록을 조회할 권한이 없습니다."),
+    COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_015", "댓글을 수정할 권한이 없습니다."),
+    COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_016", "댓글을 삭제할 권한이 없습니다."),
     // 404
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_014", "게시글을 찾을 수 없습니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_017", "게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_018", "댓글을 찾을 수 없습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kidmily/algoga_server/community/exception/ReportException.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/ReportException.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.community.exception;
+
+public class ReportException extends RuntimeException {
+    private final PostErrorCode errorCode;
+
+    public ReportException(PostErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public PostErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/CommentMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/CommentMapper.java
@@ -1,0 +1,37 @@
+package com.kidmily.algoga_server.community.infrastructure.mapper;
+
+import com.kidmily.algoga_server.community.domain.model.Comment;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.CommentJpaEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface CommentMapper {
+
+    // toJpaEntity → 신규 생성 시 commentId/createdAt은 DB가 채움
+    default CommentJpaEntity toJpaEntity(Comment comment) {
+        if (comment == null) return null;
+
+        return CommentJpaEntity.builder()
+                .postId(comment.getPostId())
+                .userId(comment.getUserId())
+                .parentId(comment.getParentId())
+                .content(comment.getContent())
+                .build();
+    }
+
+    // toDomain → reconstitute 사용
+    default Comment toDomain(CommentJpaEntity jpaEntity) {
+        if (jpaEntity == null) return null;
+
+        return Comment.reconstitute(
+                jpaEntity.getCommentId(),
+                jpaEntity.getPostId(),
+                jpaEntity.getUserId(),
+                jpaEntity.getParentId(),
+                jpaEntity.getContent(),
+                jpaEntity.getIsDeleted(),
+                jpaEntity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/LikeDislikeMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/LikeDislikeMapper.java
@@ -1,0 +1,32 @@
+package com.kidmily.algoga_server.community.infrastructure.mapper;
+
+import com.kidmily.algoga_server.community.domain.model.LikeDislike;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.LikeDislikeJpaEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface LikeDislikeMapper {
+
+    default LikeDislikeJpaEntity toJpaEntity(LikeDislike likeDislike) {
+        if (likeDislike == null) return null;
+        return LikeDislikeJpaEntity.builder()
+                .userId(likeDislike.getUserId())
+                .targetType(likeDislike.getTargetType())
+                .targetId(likeDislike.getTargetId())
+                .isLike(likeDislike.getIsLike())
+                .build();
+    }
+
+    default LikeDislike toDomain(LikeDislikeJpaEntity entity) {
+        if (entity == null) return null;
+        return LikeDislike.reconstitute(
+                entity.getLikeId(),
+                entity.getUserId(),
+                entity.getTargetType(),
+                entity.getTargetId(),
+                entity.getIsLike(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/PostMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/PostMapper.java
@@ -3,7 +3,7 @@ import com.kidmily.algoga_server.community.domain.model.Post;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostImage;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTag;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/ReportMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/ReportMapper.java
@@ -1,0 +1,34 @@
+package com.kidmily.algoga_server.community.infrastructure.mapper;
+
+import com.kidmily.algoga_server.community.domain.model.Report;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.ReportJpaEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface ReportMapper {
+
+    default ReportJpaEntity toJpaEntity(Report report) {
+        if (report == null) return null;
+        return ReportJpaEntity.builder()
+                .userId(report.getUserId())
+                .targetId(report.getTargetId())
+                .targetType(report.getTargetType())
+                .reasonType(report.getReasonType())
+                .detail(report.getDetail())
+                .build();
+    }
+
+    default Report toDomain(ReportJpaEntity entity) {
+        if (entity == null) return null;
+        return Report.reconstitute(
+                entity.getReportId(),
+                entity.getUserId(),
+                entity.getTargetId(),
+                entity.getTargetType(),
+                entity.getReasonType(),
+                entity.getDetail(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
@@ -1,21 +1,67 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence;
 
+import com.kidmily.algoga_server.community.domain.model.Comment;
 import com.kidmily.algoga_server.community.domain.repository.CommentRepository;
+import com.kidmily.algoga_server.community.exception.CommentException;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.infrastructure.mapper.CommentMapper;  // ← 경로 변경
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.CommentJpaEntity;
 import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataCommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class CommentRepositoryAdapter implements CommentRepository {
 
     private final SpringDataCommentRepository springDataRepository;
+    private final CommentMapper commentMapper;
 
     @Override
-    public List<CommentJpaEntity> findActiveCommentsByPostId(Long postId) {
-        return springDataRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId);
+    public Comment save(Comment comment) {
+        return commentMapper.toDomain(
+                springDataRepository.save(commentMapper.toJpaEntity(comment))
+        );
+    }
+
+    @Override
+    public List<Comment> findActiveCommentsByPostId(Long postId) {
+        return springDataRepository
+                .findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId)
+                .stream()
+                .map(commentMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<Comment> findById(Long commentId) {
+        return springDataRepository.findById(commentId)
+                .map(commentMapper::toDomain);
+    }
+
+    @Override
+    public Comment update(Comment comment) {
+        CommentJpaEntity entity = springDataRepository.findById(comment.getCommentId())
+                .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+        entity.updateContent(comment.getContent());
+        return commentMapper.toDomain(entity);
+    }
+
+    @Override
+    public void delete(Comment comment) {
+        CommentJpaEntity entity = springDataRepository.findById(comment.getCommentId())
+                .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+        entity.softDelete();
+    }
+
+    @Override
+    public List<Comment> findActiveRepliesByParentId(Long parentId) {
+        return springDataRepository.findByParentIdAndIsDeletedFalse(parentId)
+                .stream()
+                .map(commentMapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
@@ -45,7 +45,7 @@ public class CommentRepositoryAdapter implements CommentRepository {
     @Override
     public Comment update(Comment comment) {
         CommentJpaEntity entity = springDataRepository.findById(comment.getCommentId())
-                .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+                .orElseThrow();
         entity.updateContent(comment.getContent());
         return commentMapper.toDomain(entity);
     }
@@ -53,7 +53,7 @@ public class CommentRepositoryAdapter implements CommentRepository {
     @Override
     public void delete(Comment comment) {
         CommentJpaEntity entity = springDataRepository.findById(comment.getCommentId())
-                .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+                .orElseThrow();
         entity.softDelete();
     }
 

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/LikeDislikeRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/LikeDislikeRepositoryAdapter.java
@@ -1,7 +1,7 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence;
 
 import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
 import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataLikeDislikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/LikeDislikeRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/LikeDislikeRepositoryAdapter.java
@@ -1,16 +1,21 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence;
 
-import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
+import com.kidmily.algoga_server.community.domain.model.LikeDislike;
 import com.kidmily.algoga_server.community.domain.model.TargetType;
+import com.kidmily.algoga_server.community.domain.repository.LikeDislikeRepository;
+import com.kidmily.algoga_server.community.infrastructure.mapper.LikeDislikeMapper;
 import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataLikeDislikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class LikeDislikeRepositoryAdapter implements LikeDislikeRepository {
 
     private final SpringDataLikeDislikeRepository springDataRepository;
+    private final LikeDislikeMapper likeDislikeMapper;
 
     @Override
     public Long countLikes(TargetType targetType, Long targetId) {
@@ -20,5 +25,23 @@ public class LikeDislikeRepositoryAdapter implements LikeDislikeRepository {
     @Override
     public Long countDislikes(TargetType targetType, Long targetId) {
         return springDataRepository.countByTargetTypeAndTargetIdAndLike(targetType, targetId, false);
+    }
+
+    @Override
+    public Optional<LikeDislike> findByUserAndTarget(Long userId, TargetType targetType, Long targetId) {
+        return springDataRepository.findByUserIdAndTargetTypeAndTargetId(userId, targetType, targetId)
+                .map(likeDislikeMapper::toDomain);
+    }
+
+    @Override
+    public LikeDislike save(LikeDislike likeDislike) {
+        return likeDislikeMapper.toDomain(
+                springDataRepository.save(likeDislikeMapper.toJpaEntity(likeDislike))
+        );
+    }
+
+    @Override
+    public void delete(LikeDislike likeDislike) {
+        springDataRepository.deleteById(likeDislike.getLikeId());
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
@@ -5,7 +5,7 @@ import com.kidmily.algoga_server.community.domain.repository.PostRepository;
 import com.kidmily.algoga_server.community.infrastructure.mapper.PostMapper;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTag;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -43,7 +43,7 @@ public class PostRepositoryAdapter implements PostRepository {
     @Override
     public Post update(Post post) {
         // 기존 엔티티 조회
-        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId()).get();
+        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId()).orElseThrow();
 
 
         // 기존 태그/이미지 전부 삭제 (orphanRemoval이 처리)
@@ -83,7 +83,7 @@ public class PostRepositoryAdapter implements PostRepository {
 
     @Override
     public void delete(Post post) {
-        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId()).get();
+        PostJpaEntity jpaEntity = springDataRepository.findById(post.getId()).orElseThrow();
 
         jpaEntity.softDelete();  // PostJpaEntity에 이미 있음
         springDataRepository.save(jpaEntity);

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/ReportRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/ReportRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence;
+
+import com.kidmily.algoga_server.community.domain.model.Report;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+import com.kidmily.algoga_server.community.domain.repository.ReportRepository;
+import com.kidmily.algoga_server.community.infrastructure.mapper.ReportMapper;
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportRepositoryAdapter implements ReportRepository {
+
+    private final SpringDataReportRepository springDataRepository;
+    private final ReportMapper reportMapper;
+
+    @Override
+    public Report save(Report report) {
+        return reportMapper.toDomain(
+                springDataRepository.save(reportMapper.toJpaEntity(report))
+        );
+    }
+
+    @Override
+    public boolean existsByUserAndTarget(Long userId, TargetType targetType, Long targetId) {
+        return springDataRepository.existsByUserIdAndTargetTypeAndTargetId(userId, targetType, targetId);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/CommentJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/CommentJpaEntity.java
@@ -54,4 +54,8 @@ public class CommentJpaEntity {
     public void softDelete() {
         this.isDeleted = true;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/LikeDislikeJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/LikeDislikeJpaEntity.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
 
+import com.kidmily.algoga_server.community.domain.model.TargetType;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
@@ -1,4 +1,5 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTag.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostTag.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
 
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/ReportJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/ReportJpaEntity.java
@@ -1,0 +1,47 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
+
+import com.kidmily.algoga_server.community.domain.model.ReasonType;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reports")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReportJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private TargetType targetType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason_type")
+    private ReasonType reasonType;
+
+    @Column(name = "detail", length = 255)
+    private String detail;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/TargetType.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/TargetType.java
@@ -1,6 +1,0 @@
-package com.kidmily.algoga_server.community.infrastructure.persistence.entity;
-
-public enum TargetType {
-    POST,
-    COMMENT
-}

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataCommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataCommentRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SpringDataCommentRepository extends JpaRepository<CommentJpaEntity, Long> {
-    Long countByPostIdAndIsDeletedFalse(Long postId);
-
     List<CommentJpaEntity> findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId);
+    List<CommentJpaEntity> findByParentIdAndIsDeletedFalse(Long parentId);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataLikeDislikeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataLikeDislikeRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface SpringDataLikeDislikeRepository extends JpaRepository<LikeDislikeJpaEntity, Long> {
     @Query("SELECT COUNT(l) FROM LikeDislikeJpaEntity l " +
             "WHERE l.targetType = :targetType AND l.targetId = :targetId AND l.isLike = :isLike")
@@ -13,5 +15,9 @@ public interface SpringDataLikeDislikeRepository extends JpaRepository<LikeDisli
             @Param("targetType") TargetType targetType,
             @Param("targetId") Long targetId,
             @Param("isLike") Boolean isLike
+    );
+
+    Optional<LikeDislikeJpaEntity> findByUserIdAndTargetTypeAndTargetId(
+            Long userId, TargetType targetType, Long targetId
     );
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataLikeDislikeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataLikeDislikeRepository.java
@@ -1,7 +1,7 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence.repository;
 
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.LikeDislikeJpaEntity;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.TargetType;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
@@ -1,7 +1,7 @@
 package com.kidmily.algoga_server.community.infrastructure.persistence.repository;
 
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostJpaEntity;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataReportRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataReportRepository.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.community.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+import com.kidmily.algoga_server.community.infrastructure.persistence.entity.ReportJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataReportRepository extends JpaRepository<ReportJpaEntity, Long> {
+    boolean existsByUserIdAndTargetTypeAndTargetId(Long userId, TargetType targetType, Long targetId);
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
@@ -1,12 +1,15 @@
 package com.kidmily.algoga_server.community.presentation.advice;
 
+import com.kidmily.algoga_server.community.exception.CommentException;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.exception.PostException;
 import com.kidmily.algoga_server.global.common.api.response.ErrorResponse;
 import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -39,5 +42,40 @@ public class CommunityExceptionAdvice implements CommonExceptionAdvice {
                 traceId
         );
         return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(CommentException.class)
+    public ResponseEntity<ErrorResponse> handleCommentException(CommentException e) {
+        String traceId = getOrCreateTraceId();
+        PostErrorCode errorCode = e.getErrorCode();
+
+        log.warn("[CommentDomainException] traceId: {}, code: {}, message: {}",
+                traceId, errorCode.getCode(), errorCode.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                traceId
+        );
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        String traceId = getOrCreateTraceId();
+
+        log.warn("[HttpMessageNotReadableException] traceId: {}, message: {}", traceId, e.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "POST_000",
+                "잘못된 요청입니다. 입력값을 확인해주세요.",
+                traceId
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/advice/CommunityExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.community.presentation.advice;
 import com.kidmily.algoga_server.community.exception.CommentException;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.exception.PostException;
+import com.kidmily.algoga_server.community.exception.ReportException;
 import com.kidmily.algoga_server.global.common.api.response.ErrorResponse;
 import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
 import lombok.extern.slf4j.Slf4j;
@@ -77,5 +78,23 @@ public class CommunityExceptionAdvice implements CommonExceptionAdvice {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(ReportException.class)
+    public ResponseEntity<ErrorResponse> handleReportException(ReportException e) {
+        String traceId = getOrCreateTraceId();
+        PostErrorCode errorCode = e.getErrorCode();
+
+        log.warn("[ReportDomainException] traceId: {}, code: {}, message: {}",
+                traceId, errorCode.getCode(), errorCode.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                traceId
+        );
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommentController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommentController.java
@@ -1,0 +1,67 @@
+package com.kidmily.algoga_server.community.presentation.api;
+
+import com.kidmily.algoga_server.community.application.command.DeleteCommentCommand;
+import com.kidmily.algoga_server.community.application.command.UpdateCommentCommand;
+import com.kidmily.algoga_server.community.application.usecase.CommentCommandUseCase;
+import com.kidmily.algoga_server.community.domain.model.Comment;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.presentation.api.request.UpdateCommentRequest;
+import com.kidmily.algoga_server.community.presentation.api.response.UpdateCommentResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comments")
+@Tag(name = "Community", description = "커뮤니티 도메인 API")
+public class CommentController {
+
+    private final CommentCommandUseCase commentCommandUseCase;
+
+    @PatchMapping("/{commentId}")
+    @Operation(summary = "댓글 수정", description = "본인 댓글의 내용을 수정합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정에 성공했습니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "COMMENT_NOT_FOUND",
+            "COMMENT_UNAUTHORIZED",
+            "COMMENT_UPDATE_FORBIDDEN"
+    })
+    public ResponseEntity<ApiResponse<UpdateCommentResponse>> updateComment(
+            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
+            @Valid @RequestBody UpdateCommentRequest request
+    ) {
+        Long currentUserId = 1L;
+
+        UpdateCommentCommand command = new UpdateCommentCommand(commentId, currentUserId, request.content());
+        Comment updatedComment = commentCommandUseCase.handle(command);
+
+        return ResponseEntity.ok(ApiResponse.success("COMMENT_UPDATED", "댓글 수정에 성공했습니다.",
+                new UpdateCommentResponse(updatedComment.getCommentId())));
+    }
+
+    @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글 삭제", description = "본인 댓글을 Soft Delete 처리합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "댓글이 성공적으로 삭제되었습니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "COMMENT_NOT_FOUND",
+            "COMMENT_UNAUTHORIZED",
+            "COMMENT_DELETE_FORBIDDEN"
+    })
+    public ResponseEntity<Void> deleteComment(
+            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId
+    ) {
+        Long currentUserId = 1L;
+
+        DeleteCommentCommand command = new DeleteCommentCommand(commentId, currentUserId);
+        commentCommandUseCase.handle(command);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
@@ -1,19 +1,19 @@
 package com.kidmily.algoga_server.community.presentation.api;
 
-import com.kidmily.algoga_server.community.application.command.CreatePostCommand;
-import com.kidmily.algoga_server.community.application.command.DeletePostCommand;
-import com.kidmily.algoga_server.community.application.command.UpdatePostCommand;
+import com.kidmily.algoga_server.community.application.command.*;
+import com.kidmily.algoga_server.community.application.usecase.CommentCommandUseCase;
 import com.kidmily.algoga_server.community.application.usecase.PostCommandUseCase;
 import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
+import com.kidmily.algoga_server.community.domain.model.Comment;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.presentation.api.request.CreateCommentRequest;
 import com.kidmily.algoga_server.community.presentation.api.request.CreatePostRequest;
+import com.kidmily.algoga_server.community.presentation.api.request.UpdateCommentRequest;
 import com.kidmily.algoga_server.community.presentation.api.request.UpdatePostRequest;
 import com.kidmily.algoga_server.community.presentation.api.response.*;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
-import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExamples;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
-import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,6 +34,7 @@ public class CommunityController {
 
     private final PostCommandUseCase postCommandUseCase;
     private final PostQueryUseCase postQueryUseCase;
+    private final CommentCommandUseCase commentCommandUseCase;
 
     @PostMapping
     @Operation(summary = "게시글 작성", description = "나라, 자유, 수강강의 태그 및 최대 10장의 사진을 포함해 게시글을 등록합니다.")
@@ -177,5 +178,80 @@ public class CommunityController {
 
         PostListResponse responseData = postQueryUseCase.getMyPosts(currentUserId, lastPostId, categories);
         return ResponseEntity.ok(ApiResponse.success("MY_POSTS_FOUND", "내가 작성한 게시글 목록 조회에 성공했습니다.", responseData));
+    }
+
+    @PostMapping("/{postId}/comments")
+    @Operation(summary = "댓글/대댓글 작성", description = "게시글에 댓글 또는 대댓글을 작성합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 작성에 성공했습니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "POST_NOT_FOUND",       // 400 존재하지 않는 게시글
+            "COMMENT_UNAUTHORIZED"     // 401 비로그인
+    })
+    public ResponseEntity<ApiResponse<CreateCommentResponse>> createComment(
+            @Parameter(description = "게시글 ID", example = "1")
+            @PathVariable Long postId,
+            @RequestBody @Valid CreateCommentRequest request
+    ) {
+        Long currentUserId = 1L;
+
+        CreateCommentCommand command = new CreateCommentCommand(
+                postId,
+                currentUserId,
+                request.parentId(),
+                request.content()
+        );
+
+        Comment savedComment = commentCommandUseCase.handle(command);
+
+        CreateCommentResponse responseData = new CreateCommentResponse(
+                savedComment.getCommentId(),
+                savedComment.getUserId(),
+                savedComment.getContent(),
+                savedComment.getParentId(),
+                savedComment.getCreatedAt()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("COMMENT_CREATED", "댓글 작성에 성공했습니다.", responseData));
+    }
+
+    @PatchMapping("/api/v1/comments/{commentId}")
+    @Operation(summary = "댓글 수정", description = "본인 댓글의 내용을 수정합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정에 성공했습니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "COMMENT_NOT_FOUND",
+            "COMMENT_UNAUTHORIZED",
+            "COMMENT_UPDATE_FORBIDDEN"
+    })
+    public ResponseEntity<ApiResponse<UpdateCommentResponse>> updateComment(
+            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
+            @Valid @RequestBody UpdateCommentRequest request
+    ) {
+        Long currentUserId = 1L;
+
+        UpdateCommentCommand command = new UpdateCommentCommand(commentId, currentUserId, request.content());
+        Comment updatedComment = commentCommandUseCase.handle(command);
+
+        return ResponseEntity.ok(ApiResponse.success("COMMENT_UPDATED", "댓글 수정에 성공했습니다.",
+                new UpdateCommentResponse(updatedComment.getCommentId())));
+    }
+
+    @DeleteMapping("/api/v1/comments/{commentId}")
+    @Operation(summary = "댓글 삭제", description = "본인 댓글을 Soft Delete 처리합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "댓글이 성공적으로 삭제되었습니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "COMMENT_NOT_FOUND",
+            "COMMENT_UNAUTHORIZED",
+            "COMMENT_DELETE_FORBIDDEN"
+    })
+    public ResponseEntity<Void> deleteComment(
+            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId
+    ) {
+        Long currentUserId = 1L;
+
+        DeleteCommentCommand command = new DeleteCommentCommand(commentId, currentUserId);
+        commentCommandUseCase.handle(command);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
@@ -4,13 +4,11 @@ import com.kidmily.algoga_server.community.application.command.*;
 import com.kidmily.algoga_server.community.application.usecase.CommentCommandUseCase;
 import com.kidmily.algoga_server.community.application.usecase.PostCommandUseCase;
 import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
+import com.kidmily.algoga_server.community.application.usecase.ReactionCommandUseCase;
 import com.kidmily.algoga_server.community.domain.model.Comment;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
-import com.kidmily.algoga_server.community.presentation.api.request.CreateCommentRequest;
-import com.kidmily.algoga_server.community.presentation.api.request.CreatePostRequest;
-import com.kidmily.algoga_server.community.presentation.api.request.UpdateCommentRequest;
-import com.kidmily.algoga_server.community.presentation.api.request.UpdatePostRequest;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
+import com.kidmily.algoga_server.community.presentation.api.request.*;
 import com.kidmily.algoga_server.community.presentation.api.response.*;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
@@ -35,6 +33,8 @@ public class CommunityController {
     private final PostCommandUseCase postCommandUseCase;
     private final PostQueryUseCase postQueryUseCase;
     private final CommentCommandUseCase commentCommandUseCase;
+    private final ReactionCommandUseCase reactionCommandUseCase;
+
 
     @PostMapping
     @Operation(summary = "게시글 작성", description = "나라, 자유, 수강강의 태그 및 최대 10장의 사진을 포함해 게시글을 등록합니다.")
@@ -159,26 +159,6 @@ public class CommunityController {
         return ResponseEntity.ok(ApiResponse.success("POST_FOUND", "게시글 조회에 성공했습니다.", responseData));
     }
 
-    // 마이페이지 - 내가 쓸 글 목록 조회
-    @GetMapping("/me/posts")
-    @Operation(summary = "내가 작성한 게시글 목록 조회", description = "마이페이지에서 본인이 작성한 글 목록을 무한 스크롤 방식으로 최신순 조회합니다.")
-    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
-            "POST_UNAUTHORIZED",      // 401 Unauthorized
-            "POST_ACCESS_FORBIDDEN",   // 403 권한 부족
-            "POST_NOT_FOUND"          // 404 Not Found
-    })
-    public ResponseEntity<ApiResponse<PostListResponse>> getMyPosts(
-            @Parameter(description = "마지막 게시글 ID (첫 페이지는 생략)", example = "420")
-            @RequestParam(required = false) Long lastPostId,
-
-            @Parameter(description = "필터링할 카테고리 (다중 선택 가능, 생략 시 전체)", example = "QUESTION,TRAVEL_REVIEW")
-            @RequestParam(required = false) List<PostTagType> categories
-    ) {
-        long currentUserId = 1L; // TODO: Spring Security 적용 후 토큰에서 추출하도록 교체
-
-        PostListResponse responseData = postQueryUseCase.getMyPosts(currentUserId, lastPostId, categories);
-        return ResponseEntity.ok(ApiResponse.success("MY_POSTS_FOUND", "내가 작성한 게시글 목록 조회에 성공했습니다.", responseData));
-    }
 
     @PostMapping("/{postId}/comments")
     @Operation(summary = "댓글/대댓글 작성", description = "게시글에 댓글 또는 대댓글을 작성합니다.")
@@ -215,43 +195,4 @@ public class CommunityController {
                 .body(ApiResponse.created("COMMENT_CREATED", "댓글 작성에 성공했습니다.", responseData));
     }
 
-    @PatchMapping("/api/v1/comments/{commentId}")
-    @Operation(summary = "댓글 수정", description = "본인 댓글의 내용을 수정합니다.")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정에 성공했습니다.")
-    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
-            "COMMENT_NOT_FOUND",
-            "COMMENT_UNAUTHORIZED",
-            "COMMENT_UPDATE_FORBIDDEN"
-    })
-    public ResponseEntity<ApiResponse<UpdateCommentResponse>> updateComment(
-            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
-            @Valid @RequestBody UpdateCommentRequest request
-    ) {
-        Long currentUserId = 1L;
-
-        UpdateCommentCommand command = new UpdateCommentCommand(commentId, currentUserId, request.content());
-        Comment updatedComment = commentCommandUseCase.handle(command);
-
-        return ResponseEntity.ok(ApiResponse.success("COMMENT_UPDATED", "댓글 수정에 성공했습니다.",
-                new UpdateCommentResponse(updatedComment.getCommentId())));
-    }
-
-    @DeleteMapping("/api/v1/comments/{commentId}")
-    @Operation(summary = "댓글 삭제", description = "본인 댓글을 Soft Delete 처리합니다.")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "댓글이 성공적으로 삭제되었습니다.")
-    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
-            "COMMENT_NOT_FOUND",
-            "COMMENT_UNAUTHORIZED",
-            "COMMENT_DELETE_FORBIDDEN"
-    })
-    public ResponseEntity<Void> deleteComment(
-            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId
-    ) {
-        Long currentUserId = 1L;
-
-        DeleteCommentCommand command = new DeleteCommentCommand(commentId, currentUserId);
-        commentCommandUseCase.handle(command);
-
-        return ResponseEntity.noContent().build();
-    }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/MyPostController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/MyPostController.java
@@ -1,0 +1,52 @@
+package com.kidmily.algoga_server.community.presentation.api;
+
+import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.presentation.api.response.PostListResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+// 추후 유저 도메인 통합 시 삭제 예정
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/me")
+@Tag(name = "Community", description = "커뮤니티 도메인 API")
+public class MyPostController {
+
+    private final PostQueryUseCase postQueryUseCase;
+
+    // 마이페이지 - 내가 쓸 글 목록 조회
+    @GetMapping("/posts")
+    @Operation(summary = "내가 작성한 게시글 목록 조회", description = "마이페이지에서 본인이 작성한 글 목록을 무한 스크롤 방식으로 최신순 조회합니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "POST_UNAUTHORIZED",      // 401 Unauthorized
+            "POST_ACCESS_FORBIDDEN",   // 403 권한 부족
+            "POST_NOT_FOUND"          // 404 Not Found
+    })
+
+    public ResponseEntity<ApiResponse<PostListResponse>> getMyPosts(
+            @Parameter(description = "마지막 게시글 ID (첫 페이지는 생략)", example = "420")
+            @RequestParam(required = false) Long lastPostId,
+
+            @Parameter(description = "필터링할 카테고리 (다중 선택 가능, 생략 시 전체)", example = "QUESTION,TRAVEL_REVIEW")
+            @RequestParam(required = false) List<PostTagType> categories
+    ) {
+        long currentUserId = 1L; // TODO: Spring Security 적용 후 토큰에서 추출하도록 교체
+
+        PostListResponse responseData = postQueryUseCase.getMyPosts(currentUserId, lastPostId, categories);
+        return ResponseEntity.ok(ApiResponse.success("MY_POSTS_FOUND", "내가 작성한 게시글 목록 조회에 성공했습니다.", responseData));
+    }
+
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReactionController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReactionController.java
@@ -1,0 +1,55 @@
+package com.kidmily.algoga_server.community.presentation.api;
+
+import com.kidmily.algoga_server.community.application.command.ToggleReactionCommand;
+import com.kidmily.algoga_server.community.application.usecase.ReactionCommandUseCase;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.presentation.api.request.ToggleReactionRequest;
+import com.kidmily.algoga_server.community.presentation.api.response.ToggleReactionResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reactions")
+@Tag(name = "Community", description = "커뮤니티 도메인 API")
+public class ReactionController {
+
+    private final ReactionCommandUseCase reactionCommandUseCase;
+
+    @PostMapping
+    @Operation(summary = "좋아요/싫어요 토글", description = "게시글/댓글에 좋아요 또는 싫어요를 토글합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "반응 처리에 성공했습니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "REACTION_UNAUTHORIZED",
+            "POST_NOT_FOUND",
+            "COMMENT_NOT_FOUND"
+    })
+    public ResponseEntity<ApiResponse<ToggleReactionResponse>> toggleReaction(
+            @Valid @RequestBody ToggleReactionRequest request
+    ) {
+        Long currentUserId = 1L;
+
+        ToggleReactionCommand command = new ToggleReactionCommand(
+                currentUserId,
+                request.targetType(),
+                request.targetId(),
+                request.isLike()
+        );
+
+        ReactionCommandUseCase.ReactionResult result = reactionCommandUseCase.handle(command);
+
+        ToggleReactionResponse responseData = new ToggleReactionResponse(
+                result.status(),
+                result.likeCount(),
+                result.dislikeCount()
+        );
+
+        return ResponseEntity.ok(ApiResponse.success("REACTION_TOGGLED", "반응 처리에 성공했습니다.", responseData));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReportController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReportController.java
@@ -1,0 +1,54 @@
+package com.kidmily.algoga_server.community.presentation.api;
+
+import com.kidmily.algoga_server.community.application.command.CreateReportCommand;
+import com.kidmily.algoga_server.community.application.usecase.ReportCommandUseCase;
+import com.kidmily.algoga_server.community.exception.PostErrorCode;
+import com.kidmily.algoga_server.community.presentation.api.request.CreateReportRequest;
+import com.kidmily.algoga_server.community.presentation.api.response.CreateReportResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reports")
+@Tag(name = "Community", description = "커뮤니티 도메인 API")
+public class ReportController {
+
+    private final ReportCommandUseCase reportCommandUseCase;
+
+    @PostMapping
+    @Operation(summary = "게시글/댓글 신고", description = "부적절한 게시글 또는 댓글을 신고합니다. 동일 대상 중복 신고 불가.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "신고가 접수되었습니다.")
+    @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
+            "REPORT_UNAUTHORIZED",
+            "POST_NOT_FOUND",
+            "COMMENT_NOT_FOUND",
+            "REPORT_DUPLICATED"
+    })
+    public ResponseEntity<ApiResponse<CreateReportResponse>> createReport(
+            @Valid @RequestBody CreateReportRequest request
+    ) {
+        Long currentUserId = 1L;
+
+        CreateReportCommand command = new CreateReportCommand(
+                currentUserId,
+                request.targetId(),
+                request.targetType(),
+                request.reasonType(),
+                request.detail()
+        );
+
+        Long reportId = reportCommandUseCase.handle(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("REPORT_CREATED", "신고가 접수되었습니다.",
+                        new CreateReportResponse(reportId)));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreateCommentRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.kidmily.algoga_server.community.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "댓글 생성 요청")
+public record CreateCommentRequest(
+
+        @Schema(description = "부모 댓글 ID (대댓글일 경우 입력, 일반 댓글은 null)", example = "null")
+        Long parentId,
+
+        @Schema(description = "댓글 내용", example = "엔화는 환전하고 가시는거 추천해요")
+        @NotBlank(message = "내용을 입력해주세요.")
+        @Size(max = 500, message = "댓글은 최대 500자입니다.")
+        String content
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreatePostRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreatePostRequest.java
@@ -1,7 +1,7 @@
 package com.kidmily.algoga_server.community.presentation.api.request;
 
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreateReportRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/CreateReportRequest.java
@@ -1,0 +1,27 @@
+package com.kidmily.algoga_server.community.presentation.api.request;
+
+import com.kidmily.algoga_server.community.domain.model.ReasonType;
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "신고 요청")
+public record CreateReportRequest(
+
+        @Schema(description = "신고 대상 타입 (POST, COMMENT)", example = "POST")
+        @NotNull(message = "신고 대상 타입은 필수입니다.")
+        TargetType targetType,
+
+        @Schema(description = "신고 대상 ID", example = "1")
+        @NotNull(message = "신고 대상 ID는 필수입니다.")
+        Long targetId,
+
+        @Schema(description = "신고 사유 (SPAM, ABUSE, FALSE_INFO, INAPPROPRIATE, COPYRIGHT, ETC)", example = "SPAM")
+        @NotNull(message = "신고 사유는 필수입니다.")
+        ReasonType reasonType,
+
+        @Schema(description = "상세 내용 (선택)", example = "광고성 게시글입니다.")
+        @Size(max = 255, message = "상세 내용은 최대 255자입니다.")
+        String detail
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/ToggleReactionRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/ToggleReactionRequest.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.community.presentation.api.request;
+
+import com.kidmily.algoga_server.community.domain.model.TargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "좋아요/싫어요 요청")
+public record ToggleReactionRequest(
+
+        @Schema(description = "대상 타입 (POST, COMMENT)", example = "POST")
+        @NotNull(message = "대상 타입은 필수입니다.")
+        TargetType targetType,
+
+        @Schema(description = "대상 ID", example = "1")
+        @NotNull(message = "대상 ID는 필수입니다.")
+        Long targetId,
+
+        @Schema(description = "좋아요 여부 (true: 좋아요, false: 싫어요)", example = "true")
+        @NotNull(message = "좋아요/싫어요 여부는 필수입니다.")
+        Boolean isLike
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/UpdateCommentRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/UpdateCommentRequest.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.community.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "댓글 수정 요청")
+public record UpdateCommentRequest(
+        @Schema(description = "수정할 내용", example = "엔화는 환전하고 가시는거 추천해요")
+        @NotBlank(message = "내용을 입력해주세요.")
+        @Size(max = 500, message = "댓글은 최대 500자입니다.")
+        String content
+) {
+
+}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/UpdatePostRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/request/UpdatePostRequest.java
@@ -1,6 +1,6 @@
 package com.kidmily.algoga_server.community.presentation.api.request;
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CreateCommentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CreateCommentResponse.java
@@ -3,11 +3,10 @@ package com.kidmily.algoga_server.community.presentation.api.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-@Schema(description = "댓글 조회 응답")
-public record CommentResponse(
-        @Schema(description = "댓글 ID", example = "1")
+@Schema(description = "댓글 작성 응답")
+public record CreateCommentResponse(
+        @Schema(description = "생성된 댓글 ID", example = "1")
         Long commentId,
 
         @Schema(description = "작성자 ID", example = "1")
@@ -16,9 +15,9 @@ public record CommentResponse(
         @Schema(description = "내용", example = "엔화는 환전하고 가시는거 추천해요")
         String content,
 
-        @Schema(description = "작성일시")
-        LocalDateTime createdAt,
+        @Schema(description = "부모 댓글 ID (대댓글인 경우, 일반 댓글은 null)")
+        Long parentId,
 
-        @Schema(description = "대댓글 목록")
-        List<CommentResponse> replies
+        @Schema(description = "작성일시")
+        LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CreateReportResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CreateReportResponse.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "신고 응답")
+public record CreateReportResponse(
+        @Schema(description = "생성된 신고 ID", example = "1")
+        Long reportId
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/TagResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/TagResponse.java
@@ -1,6 +1,6 @@
 package com.kidmily.algoga_server.community.presentation.api.response;
 
-import com.kidmily.algoga_server.community.infrastructure.persistence.entity.PostTagType;
+import com.kidmily.algoga_server.community.domain.model.PostTagType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "태그 응답")

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/ToggleReactionResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/ToggleReactionResponse.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+import io.swagger.v3.oas.annotations.media.Schema;
+import com.kidmily.algoga_server.community.application.usecase.ReactionCommandUseCase.ReactionStatus;
+
+@Schema(description = "좋아요/싫어요 응답")
+public record ToggleReactionResponse(
+        @Schema(description = "처리 결과 (ADDED, REMOVED, CHANGED)", example = "ADDED")
+        ReactionStatus status,
+
+        @Schema(description = "좋아요 수", example = "10")
+        Long likeCount,
+
+        @Schema(description = "싫어요 수", example = "2")
+        Long dislikeCount
+) {}

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/UpdateCommentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/UpdateCommentResponse.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.community.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "댓글 수정 응답")
+public record UpdateCommentResponse(
+        @Schema(description = "수정된 댓글 ID", example = "1")
+        Long commentId
+) {
+}


### PR DESCRIPTION
## 설명
### 댓글 CRUD
게시글에 댓글 및 대댓글을 작성/수정/삭제할 수 있습니다.
- 댓글 작성 시 `parentId: null`이면 일반 댓글, 값이 있으면 대댓글로 처리됩니다.
- 댓글 삭제 시 해당 댓글의 대댓글도 함께 Soft Delete 처리됩니다.
- 본인 댓글만 수정/삭제 가능하며, 타인 댓글 접근 시 403을 반환합니다.

### 좋아요/싫어요
게시글과 댓글에 좋아요 또는 싫어요를 토글할 수 있습니다.
- 같은 버튼을 다시 누르면 취소됩니다.
- 좋아요 누른 상태에서 싫어요를 누르면 자동으로 전환됩니다.
- 좋아요와 싫어요를 동시에 가질 수 없습니다.

### 신고
게시글과 댓글을 신고할 수 있습니다.
- 신고 사유 6가지 중 하나를 선택하며 상세 내용은 선택사항입니다.
- 동일 대상에 중복 신고 시 409를 반환합니다.

## 비고
#댓글
댓글 삭제 시 대댓글도 같이 삭제
대댓글의 대댓글은 막음 댓글의 대댓글만 가능
게시글 상세 조회할 때 댓글 리스트도 같이 조회됨
추후 댓글에도 무한 스크롤 방식 도입 고려
(현재는 다 보여짐)
댓글 카운트는 대댓글 제외


#신고
매니저용 신고 목록 조회 API 추후 구현 예정

#API 정리

댓글 작성
POST /api/v1/posts/{postId}/comments
{
  "parentId": null,
  "content": "댓글 내용"
}

댓글 수정
PATCH /api/v1/comments/{commentId}
{
  "content": "수정할 내용"
}

댓글 삭제
DELETE /api/v1/comments/{commentId}

좋아요/싫어요
POST /api/v1/reactions
{
  "targetType": "POST",
  "targetId": 1,
  "isLike": true
}

POST /api/v1/reactions
{
  "targetType": "COMMENT",
  "targetId": 1,
  "isLike": false
}

신고
POST /api/v1/reports
{
  "targetType": "POST",
  "targetId": 1,
  "reasonType": "SPAM",
  "detail": "상세 내용 (선택)"
}
reasonType: SPAM / ABUSE / FALSE_INFO / INAPPROPRIATE / COPYRIGHT / ETC

## 🔗 Issue
Closes #59

---




## 확인할 사항

- [ ] 댓글 작성 - 일반 댓글 (`parentId: null`) / 대댓글 (`parentId: 댓글ID`) 정상 동작 확인
- [ ] 댓글 작성 - 존재하지 않는 게시글/부모 댓글 ID 입력 시 404 응답 확인
- [ ] 댓글 수정 - 본인 댓글 수정 정상 동작 확인
- [ ] 댓글 수정 - 타인 댓글 수정 시도 시 403 응답 확인
- [ ] 댓글 삭제 - 일반 댓글 삭제 시 대댓글도 함께 Soft Delete 확인
- [ ] 댓글 삭제 - 타인 댓글 삭제 시도 시 403 응답 확인
- [ ] 좋아요/싫어요 - 누르면 추가, 같은 버튼 다시 누르면 취소 확인
- [ ] 좋아요/싫어요 - 좋아요 누른 상태에서 싫어요 누르면 전환 확인 (likeCount -1, dislikeCount +1)
- [ ] 좋아요/싫어요 - 존재하지 않는 게시글/댓글 ID 입력 시 404 응답 확인
- [ ] 신고 - 정상 신고 접수 확인 (201 응답)
- [ ] 신고 - 동일 대상 중복 신고 시 409 응답 확인
- [ ] 신고 - 상세 내용 없이 신고 가능 확인 (선택사항)
- [ ] 신고 - 존재하지 않는 게시글/댓글 신고 시 404 응답 확인
