### PR TITLE
[Feat] 회원가입 시 이용약관 동의 기능 세분화 (필수/선택)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -51,6 +51,9 @@ public class AuthService {
                 .signupPath(request.signupPath())
                 .createdAt(LocalDateTime.now())
                 .requiresPasswordChange(false)
+                .termsServiceAgreed(request.termsServiceAgreed())
+                .termsPrivacyAgreed(request.termsPrivacyAgreed())
+                .termsMarketingAgreed(request.termsMarketingAgreed())
                 .build();
         userRepository.save(user);
     }
@@ -73,7 +76,6 @@ public class AuthService {
         String accessToken = jwtProvider.createAccessToken(user.getEmail());
         String refreshToken = jwtProvider.createRefreshToken(user.getEmail());
 
-        // ⭐️ 여기서 user.getRequiresPasswordChange()를 넘겨줍니다.
         return new AuthTokenResponse(accessToken, refreshToken, user.getRequiresPasswordChange());
     }
 

--- a/src/main/java/com/kidmily/algoga_server/user/domain/User.java
+++ b/src/main/java/com/kidmily/algoga_server/user/domain/User.java
@@ -68,7 +68,16 @@ public class User {
     @Column(name = "requires_password_change")
     private Boolean requiresPasswordChange = false;
 
-    // 기존 코드 아래에 이 메서드들을 추가하세요.
+    // 개별 약관 동의 컬럼
+    @Column(name = "terms_service_agreed", nullable = false)
+    private boolean termsServiceAgreed;
+
+    @Column(name = "terms_privacy_agreed", nullable = false)
+    private boolean termsPrivacyAgreed;
+
+    @Column(name = "terms_marketing_agreed", nullable = false)
+    private boolean termsMarketingAgreed;
+
     public void setTemporaryPassword(String encodedPassword) {
         this.password = encodedPassword;
         this.requiresPasswordChange = true;

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
@@ -24,8 +24,12 @@ public class AuthController {
     private final AuthService authService;
 
     // 일반 회원가입
-    @Operation(summary = "일반 회원가입")
+    @Operation(summary = "일반 회원가입", description = "모든 필수 항목 입력 및 유효성 검사를 거쳐 계정을 생성합니다.")
     @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"ALREADY_EXISTS_EMAIL"})
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "약관 미동의 또는 입력값 유효성 검사 실패")
+    })
     @PostMapping("/signup")
     public ApiResponse<Void> signup(@RequestBody @Valid AuthSignupRequest request) {
         authService.signup(request);
@@ -92,4 +96,6 @@ public class AuthController {
         }
         return ApiResponse.success("AUTH_LOGOUT_SUCCESS", "로그아웃이 완료되었습니다.");
     }
+
+
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
@@ -7,11 +7,11 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "username": "test0505",
-  "email": "test0505@naver.com",
+  "username": "test0606",
+  "email": "test0606@naver.com",
   "password": "password8888",
   "name": "이하연",
-  "phone": "010-9090-1234",
+  "phone": "010-9090-9090",
   "birthDate": "2004-03-02",
   "gender": "FEMALE",
   "nickname": "하연dl하연",

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
@@ -1,20 +1,25 @@
 ### 1. 일반 회원가입 (POST /api/v1/auth/signup)
 # - 정상적인 데이터를 넣어서 가입이 잘 되는지 확인합니다.
+# "termsServiceAgreed" 랑 "termsPrivacyAgreed" 둘 다 필수 동의 약관이기 때문에
+# 둘 중 하나만 false여도 회원가입 안됨
 POST http://localhost:15000/api/v1/auth/signup
 Content-Type: application/json
 Accept: application/json
 
 {
-  "username": "lhy1234lhy",
-  "email": "lhy2004lhy@gmail.com",
+  "username": "test0505",
+  "email": "test0505@naver.com",
   "password": "password8888",
   "name": "이하연",
-  "phone": "010-1111-2222",
+  "phone": "010-9090-1234",
   "birthDate": "2004-03-02",
   "gender": "FEMALE",
-  "nickname": "하연하연",
+  "nickname": "하연dl하연",
   "referralCode": "REF008",
-  "signupPath": "인스타그램"
+  "signupPath": "인스타그램",
+  "termsServiceAgreed": true,
+  "termsPrivacyAgreed": true,
+  "termsMarketingAgreed": false
 }
 
 > {%
@@ -34,14 +39,17 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "username": "lhy1234lhy",
-  "email": "lhy2004lhy@gmail.com",
+  "username": "test0404",
+  "email": "test0404@naver.com",
   "password": "password8888",
   "name": "이하연",
-  "phone": "010-1111-2222",
+  "phone": "010-1212-1234",
   "birthDate": "2004-03-02",
   "gender": "FEMALE",
-  "nickname": "하연하연"
+  "nickname": "하연dl하연",
+  "termsServiceAgreed": true,
+  "termsPrivacyAgreed": true,
+  "termsMarketingAgreed": false
 }
 
 ### ------------------------------------------------------------------------
@@ -54,7 +62,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "username": "lhy1234lhy",
+  "username": "test0404",
   "password": "password8888"
 }
 
@@ -82,7 +90,7 @@ Content-Type: application/json
 
 {
   "name": "이하연",
-  "email": "lhy2004lhy@gmail.com"
+  "email": "test0404@naver.com"
 }
 
 ### ------------------------------------------------------------------------
@@ -94,8 +102,8 @@ POST http://localhost:15000/api/v1/auth/find-password
 Content-Type: application/json
 
 {
-  "username": "lhy1234lhy",
-  "email": "lhy2004lhy@gmail.com"
+  "username": "test0404",
+  "email": "test0404@naver.com"
 }
 
 ### ------------------------------------------------------------------------
@@ -106,8 +114,8 @@ POST http://localhost:15000/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "username": "lhy1234lhy",
-  "password": "4185931a"
+  "username": "test0404",
+  "password": "c455711a"
 }
 
 > {%
@@ -139,9 +147,18 @@ POST http://localhost:15000/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "username": "lhy1234lhy",
+  "username": "test0101",
   "password": "newpassword8888"
 }
+
+> {%
+    // 로그인 응답으로 온 토큰을 인텔리제이 메모리에 임시로 저장합니다.
+    if(response.status === 200) {
+        client.global.set("accessToken", response.body.data.accessToken);
+        client.global.set("refreshToken", response.body.data.refreshToken);
+        client.log("Access Token: " + client.global.get("accessToken"));
+    }
+%}
 
 ### ------------------------------------------------------------------------
 

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/AuthSignupRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/AuthSignupRequest.java
@@ -49,5 +49,20 @@ public record AuthSignupRequest(
         String referralCode,
 
         @Schema(description = "유입 경로 (선택)", example = "인스타그램")
-        String signupPath
+        String signupPath,
+
+        // ️ 필수/선택 약관을 개별 필드로 분리
+        @Schema(description = "이용약관 동의 (필수)", example = "true")
+        @NotNull(message = "이용약관 동의는 필수입니다.")
+        @AssertTrue(message = "이용약관에 동의하셔야 합니다.")
+        Boolean termsServiceAgreed,
+
+        @Schema(description = "개인정보 처리방침 동의 (필수)", example = "true")
+        @NotNull(message = "개인정보 처리방침 동의는 필수입니다.")
+        @AssertTrue(message = "개인정보 처리방침에 동의하셔야 합니다.")
+        Boolean termsPrivacyAgreed,
+
+        @Schema(description = "마케팅 수신 동의 (선택)", example = "false")
+        @NotNull(message = "마케팅 수신 동의 여부는 필수입니다.")
+        Boolean termsMarketingAgreed
 ) {}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
회원가입 프로세스에 약관 동의 3종(이용약관, 개인정보, 마케팅)을 추가한다.
필수 약관 미동의 시 회원가입이 불가능하도록 서버 단에서 400 Bad Request 에러를 반환한다.

## 🔗 Issue
Closes #75 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] .http 파일에서 회원가입 시 "termsServiceAgreed" 랑 "termsPrivacyAgreed" 둘 다 필수 동의 약관이기 때문에 둘 중 하나만 false여도 회원가입 안됨
- [ ]  필수 동의 모두 동의 시 회원가입 완료됨


{
  "timestamp": "2026-05-26T02:48:25.863111700Z",
  "status": 400,
  "errorCode": "GLOBAL_002",
  "message": "이용약관에 동의하셔야 합니다.",
  "traceId": "38857c4d"
}
