### PR TITLE
[Feat] 회원 마이페이지 내 정보 조회, 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
@@ -1,13 +1,29 @@
 package com.kidmily.algoga_server.user.application;
 
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.user.domain.User;
 import com.kidmily.algoga_server.user.domain.UserRepository;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
 import com.kidmily.algoga_server.user.exception.UserException;
+import com.kidmily.algoga_server.user.presentation.request.UpdatePasswordRequest;
+import com.kidmily.algoga_server.user.presentation.request.UpdateProfileRequest;
+import com.kidmily.algoga_server.user.presentation.request.VerifyPasswordRequest;
+import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
+import com.kidmily.algoga_server.user.presentation.response.UserProfileResponse;
+import com.kidmily.algoga_server.user.settings.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Slf4j
 @Service
@@ -16,6 +32,69 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    // 1. 내 프로필 조회
+    @Transactional(readOnly = true)
+    public UserProfileResponse getMyProfile(String email) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+        return UserProfileResponse.from(user);
+    }
+
+    // 2. 정보 수정 진입 전 비밀번호 검증
+    @Transactional(readOnly = true)
+    public void verifyPassword(String email, VerifyPasswordRequest request) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new UserException(UserErrorCode.INVALID_PASSWORD); // "비밀번호가 일치하지 않습니다" 에러
+        }
+    }
+
+    // 3. 내 프로필 수정
+    @Transactional
+    public AuthTokenResponse updateProfile(String email, UpdateProfileRequest request) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        String newEmail = (request.email() != null) ? request.email() : user.getEmail();
+
+        // 이메일 변경 시 중복 체크
+        if (!newEmail.equals(user.getEmail())) {
+            if (userRepository.existsByEmail(newEmail)) {
+                throw new UserException(UserErrorCode.ALREADY_EXISTS_EMAIL);
+            }
+        }
+
+        user.updateProfile(request.nickname(), request.phone(), request.profileImageUrl(), newEmail);
+
+        // 새로운 토큰 생성
+        String newToken = jwtProvider.createAccessToken(newEmail);
+
+        return new AuthTokenResponse(
+                newToken,
+                null,
+                user.getRequiresPasswordChange()
+        );
+    }
+
+    // 4. 비밀번호 변경
+    @Transactional
+    public void updatePassword(String email, UpdatePasswordRequest request) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        // 기존 비밀번호가 맞는지 확인
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.INVALID_PASSWORD);
+        }
+
+        // 새 비밀번호 암호화 후 변경
+        user.updatePassword(passwordEncoder.encode(request.newPassword()));
+    }
 
     // 1. 회원 탈퇴 (Soft Delete)
     public void withdraw(String email) {
@@ -31,4 +110,6 @@ public class UserService {
         // @Transactional 안에서 엔티티 값이 변경되면 JPA가 알아서 DB에 UPDATE 쿼리를 날립니다! (더티 체킹)
         log.info("회원 탈퇴 처리 완료 [이메일: {}]", email);
     }
+
+
 }

--- a/src/main/java/com/kidmily/algoga_server/user/domain/User.java
+++ b/src/main/java/com/kidmily/algoga_server/user/domain/User.java
@@ -78,6 +78,10 @@ public class User {
     @Column(name = "terms_marketing_agreed", nullable = false)
     private boolean termsMarketingAgreed;
 
+    // 마이페이지 사용자 프로필
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
     public void setTemporaryPassword(String encodedPassword) {
         this.password = encodedPassword;
         this.requiresPasswordChange = true;
@@ -120,5 +124,16 @@ public class User {
     public boolean isAccountLocked() {
         if (this.lockedUntil == null) return false;
         return this.lockedUntil.isAfter(LocalDateTime.now());
+    }
+
+    public void updateProfile(String nickname, String phone, String profileImageUrl, String email) {
+        if (nickname != null) this.nickname = nickname;
+        if (phone != null) this.phone = phone;
+        if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
+        if (email != null) this.email = email;
+    }
+
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/domain/UserRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/user/domain/UserRepository.java
@@ -4,13 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    // 이메일과 삭제 여부로 유저 조회
+    Optional<User> findByEmailAndIsDeletedFalse(String email);
+
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
     Optional<User> findByUsername(String username);
     boolean existsByNickname(String nickname);
 
-    // 기존 코드에 아래 한 줄을 추가하세요.
     Optional<User> findByNameAndEmail(String name, String email);
-
     Optional<User> findByUsernameAndEmail(String username, String email);
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/UserController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/UserController.java
@@ -2,15 +2,19 @@ package com.kidmily.algoga_server.user.presentation;
 
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.user.application.UserService;
+import com.kidmily.algoga_server.user.presentation.request.UpdatePasswordRequest;
+import com.kidmily.algoga_server.user.presentation.request.UpdateProfileRequest;
+import com.kidmily.algoga_server.user.presentation.request.VerifyPasswordRequest;
+import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
+import com.kidmily.algoga_server.user.presentation.response.UserProfileResponse;
 import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "회원 정보 API")
 @RestController
@@ -20,22 +24,53 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "내 프로필 임시 조회 (토큰 테스트용)")
+    // 내 프로필 조회
+    @Operation(summary = "내 프로필 상세 조회", description = "로그인한 유저의 전체 정보를 조회합니다.")
     @GetMapping("/me")
-    public ApiResponse<String> getMyProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        // 토큰이 정상적으로 들어왔다면, 시큐리티가 userDetails에 유저 정보를 담아줍니다!
-        String userEmail = userDetails.getUsername();
-
-        return ApiResponse.success(
-                "USER_INFO_SUCCESS",
-                "인증 통과 완료! 접속한 유저: " + userEmail,
-                userEmail
-        );
+    public ApiResponse<UserProfileResponse> getMyProfile(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        UserProfileResponse response = userService.getMyProfile(userDetails.getUsername());
+        return ApiResponse.success("USER_PROFILE_SUCCESS", "프로필 조회를 성공했습니다.", response);
     }
 
+    // 비밀번호 확인 (정보 수정 진입 전)
+    @Operation(summary = "정보 수정 진입 전 비밀번호 확인", description = "사용자가 입력한 현재 비밀번호가 올바른지 검증합니다.")
+    @PostMapping("/me/verify-password")
+    public ApiResponse<Void> verifyPassword(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody VerifyPasswordRequest request) {
+        userService.verifyPassword(userDetails.getUsername(), request);
+        return ApiResponse.success("USER_VERIFY_PW_SUCCESS", "비밀번호가 확인되었습니다.");
+    }
+
+    // 프로필 정보 업데이트
+    @Operation(summary = "내 프로필 정보 업데이트", description = "프로필 사진, 닉네임, 전화번호, 이메일을 수정합니다.")
+    @PatchMapping("/me")
+    public ApiResponse<AuthTokenResponse> updateProfile(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdateProfileRequest request) {
+
+        // ⭐️ 서비스에서 3개 필드가 담긴 응답을 받아옵니다.
+        AuthTokenResponse response = userService.updateProfile(userDetails.getUsername(), request);
+
+        return ApiResponse.success("USER_UPDATE_SUCCESS", "프로필 정보가 수정되었습니다.", response);
+    }
+
+    // 비밀번호 변경
+    @Operation(summary = "비밀번호 변경", description = "현재 비밀번호 확인 후 새로운 비밀번호로 변경합니다.")
+    @PatchMapping("/me/password")
+    public ApiResponse<Void> updatePassword(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdatePasswordRequest request) {
+        userService.updatePassword(userDetails.getUsername(), request);
+        return ApiResponse.success("USER_UPDATE_PW_SUCCESS", "비밀번호가 성공적으로 변경되었습니다.");
+    }
+
+    // 회원 탈퇴
     @Operation(summary = "회원 탈퇴", description = "계정을 Soft Delete 처리합니다.")
     @DeleteMapping("/me")
-    public ApiResponse<Void> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ApiResponse<Void> withdraw(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.withdraw(userDetails.getUsername());
         return ApiResponse.success("USER_WITHDRAW_SUCCESS", "회원 탈퇴가 완료되었습니다.");
     }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
@@ -17,7 +17,7 @@ Accept: application/json
   "nickname": "하연dl하연",
   "referralCode": "REF008",
   "signupPath": "인스타그램",
-  "termsServiceAgreed": true,
+  "termsServiceAgreed": false,
   "termsPrivacyAgreed": true,
   "termsMarketingAgreed": false
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/UpdatePasswordRequest.java
@@ -1,0 +1,17 @@
+package com.kidmily.algoga_server.user.presentation.request;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "비밀번호 변경 요청")
+public record UpdatePasswordRequest(
+        @Schema(description = "현재 비밀번호", example = "password123")
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        String currentPassword,
+
+        @Schema(description = "새 비밀번호 (8자 이상, 영문+숫자 포함)", example = "newPassword123!")
+        @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{8,}$",
+                message = "비밀번호는 최소 8자 이상, 영문과 숫자를 포함해야 합니다.")
+        String newPassword
+) {}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/UpdateProfileRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/UpdateProfileRequest.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.user.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로필 수정 요청")
+public record UpdateProfileRequest(
+        @Schema(description = "닉네임", example = "알고가조아")
+        String nickname,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phone,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "이메일", example = "new@algoga.com")
+        String email
+) {}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/VerifyPasswordRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/VerifyPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.user.presentation.request;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "비밀번호 확인 요청")
+public record VerifyPasswordRequest(
+        @Schema(description = "현재 비밀번호", example = "password123")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password
+) {}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/response/UserProfileResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/response/UserProfileResponse.java
@@ -1,0 +1,55 @@
+package com.kidmily.algoga_server.user.presentation.response;
+
+import com.kidmily.algoga_server.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "유저 프로필 조회 응답")
+public record UserProfileResponse(
+        @Schema(description = "아이디", example = "test0606")
+        String username,
+
+        @Schema(description = "비밀번호 (마스킹 처리됨)", example = "********")
+        String password,
+
+        @Schema(description = "이름", example = "김알고")
+        String name,
+
+        @Schema(description = "닉네임", example = "알고가조아")
+        String nickname,
+
+        @Schema(description = "이메일", example = "test@algoga.com")
+        String email,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phone,
+
+        @Schema(description = "성별", example = "MALE")
+        String gender,
+
+        @Schema(description = "생년월일", example = "2000-01-01")
+        String birthDate,
+
+        @Schema(description = "개인 식별 번호(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+        String personalCode
+) {
+    // User 엔티티를 받아서 DTO로 변환하는 정적 팩토리 메서드
+    public static UserProfileResponse from(User user) {
+        return UserProfileResponse.builder()
+                .username(user.getUsername())
+                .password("********")
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImageUrl(user.getProfileImageUrl())
+                .phone(user.getPhone())
+                .gender(user.getGender().name())
+                .birthDate(user.getBirthDate().toString())
+                .personalCode(user.getPersonalCode())
+                .build();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/userMyPage_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/userMyPage_test.http
@@ -1,0 +1,89 @@
+### 1. 일반 회원가입 (POST /api/v1/auth/signup)
+# - 정상적인 데이터를 넣어서 가입이 잘 되는지 확인합니다.
+# "termsServiceAgreed" 랑 "termsPrivacyAgreed" 둘 다 필수 동의 약관이기 때문에
+# 둘 중 하나만 false여도 회원가입 안됨
+POST http://localhost:15000/api/v1/auth/signup
+Content-Type: application/json
+Accept: application/json
+
+{
+  "username": "test0302",
+  "email": "test0302@naver.com",
+  "password": "password8888",
+  "name": "이하연",
+  "phone": "010-0403-0218",
+  "birthDate": "2004-03-02",
+  "gender": "FEMALE",
+  "nickname": "하연dl하연",
+  "referralCode": "REF008",
+  "signupPath": "인스타그램",
+  "termsServiceAgreed": true,
+  "termsPrivacyAgreed": true,
+  "termsMarketingAgreed": false
+}
+
+> {%
+    // 응답이 오면 상태 코드와 결과를 콘솔에 출력합니다.
+    client.test("회원가입 성공 여부 확인", function() {
+        client.assert(response.status === 201, "상태 코드가 201이 아닙니다.");
+        client.log("응답 메시지: " + response.body.message);
+    });
+%}
+
+### 0. 로그인 (토큰 추출용)
+POST http://localhost:15000/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "username": "test0302",
+  "password": "newpassword8888"
+}
+
+> {%
+    // 로그인 성공 시 응답에서 토큰을 자동으로 저장합니다.
+    if (response.status === 200) {
+        client.global.set("authToken", response.body.data.accessToken);
+    }
+%}
+
+### 1. 내 프로필 상세 조회
+GET http://localhost:15000/api/v1/users/me
+Authorization: Bearer {{authToken}}
+Accept: application/json
+
+### 2. 정보 수정 진입 전 비밀번호 확인
+POST http://localhost:15000/api/v1/users/me/verify-password
+Authorization: Bearer {{authToken}}
+Content-Type: application/json
+
+{
+  "password": "newpassword8888"
+}
+
+### 3. 내 프로필 정보 업데이트 (닉네임, 전화번호, 이메일 변경)
+PATCH http://localhost:15000/api/v1/users/me
+Authorization: Bearer {{authToken}}
+Content-Type: application/json
+
+{
+  "nickname": "채연바보",
+  "phone": "010-0204-2818",
+  "email": "test0428@gmail.com"
+}
+
+> {%
+    // ⭐️ 중요: 프로필 수정 응답에서 새로운 토큰을 받아 다시 저장합니다!
+    if (response.status === 200) {
+        client.global.set("authToken", response.body.data.accessToken);
+    }
+%}
+
+### 4. 비밀번호 변경
+PATCH http://localhost:15000/api/v1/users/me/password
+Authorization: Bearer {{authToken}}
+Content-Type: application/json
+
+{
+  "currentPassword": "newpassword8888",
+  "newPassword": "newspassword8888"
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성

## 🔗 Issue
Closes #84 

---
GET /api/v1/users/me (프로필 조회)

POST /api/v1/users/me/verify-password (비밀번호 검증)

PATCH /api/v1/users/me (프로필 수정)

PATCH /api/v1/users/me/password (비밀번호 변경)



## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ]  프로필 수정(이메일 변경 등) 성공 시, 응답 data로 새로운 accessToken이 발급되어 내려갑니다. 정보 수정 후에는 클라이언트 측에 저장된 토큰을 이 새 토큰으로 꼭 교체해 주세요! (안 그러면 500 에러가 발생합니다.)

- [ ] 내 프로필 조회 시 보안 정책상 비밀번호 값은 실제 길이가 아닌 ******** (고정값)으로 마스킹되어 내려갑니다.

- [ ] 프로필 이미지 업로드(S3) 기능은 다음 PR에서 추가될 예정입니다. 현재는 텍스트(이메일, 닉네임, 번호) 수정만 테스트해 주세요!

