### PR TITLE
Feature/paymentemail 추가 수정 사항

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/booking/presentation/api/BookingController.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/presentation/api/BookingController.java
@@ -8,6 +8,7 @@ import com.kidmily.algoga_server.booking.presentation.api.request.CreateBookingR
 import com.kidmily.algoga_server.booking.presentation.api.response.BookingResponse;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -57,12 +59,12 @@ public class BookingController {
         return ResponseEntity.ok(ApiResponse.success("BOOKING_FOUND", "예약 조회에 성공했습니다.", response));
     }
 
-    @GetMapping("/api/v1/users/{userId}/bookings")
-    @Operation(summary = "내 예약 목록 조회", description = "유저의 전체 예약 목록을 조회합니다.")
+    @GetMapping("/api/v1/bookings/me")
+    @Operation(summary = "내 예약 목록 조회", description = "로그인한 유저의 전체 예약 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<BookingResponse>>> getMyBookings(
-            @Parameter(description = "유저 ID", example = "1")
-            @PathVariable Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        Long userId = userDetails.getUser().getId();
         List<BookingResponse> response = bookingQueryUseCase.getMyBookings(userId);
         return ResponseEntity.ok(ApiResponse.success("MY_BOOKINGS_FOUND", "내 예약 목록 조회에 성공했습니다.", response));
     }

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/PaymentController.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/PaymentController.java
@@ -9,6 +9,7 @@ import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
 import com.kidmily.algoga_server.payment.presentation.api.request.CreatePaymentRequest;
 import com.kidmily.algoga_server.payment.presentation.api.request.WebhookRequest;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -89,12 +91,12 @@ public class PaymentController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/users/{userId}/payments")
-    @Operation(summary = "내 결제 내역 조회", description = "유저의 전체 결제 내역을 조회합니다.")
+    @GetMapping("/me")
+    @Operation(summary = "내 결제 내역 조회", description = "로그인한 유저의 전체 결제 내역을 조회합니다.")
     public ResponseEntity<ApiResponse<List<PaymentResponse>>> getMyPayments(
-            @Parameter(description = "유저 ID", example = "1")
-            @PathVariable Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        Long userId = userDetails.getUser().getId();
         List<PaymentResponse> response = paymentQueryUseCase.getMyPayments(userId);
         return ResponseEntity.ok(ApiResponse.success("MY_PAYMENTS_FOUND", "내 결제 내역 조회에 성공했습니다.", response));
     }


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성

## 🔗 Issue
Closes #

---
결제 성공 시 사용자 이메일로 결제 완료 안내 메일을 발송합니다.
또한 userId가 URL에 노출되던 내 예약/결제 조회 API를 /me 방식으로 변경했습니다.
- PaymentCompletedEvent 발행 → PaymentMailService 비동기 메일 발송
- GET /api/v1/bookings/me — 내 예약 목록 (JWT 기반)
- GET /api/v1/payments/me — 내 결제 내역 (JWT 기반)
- ⚠️ application.yaml Gmail 앱 비밀번호 설정 필요



## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 결제 성공 시 메일 발송 로그 확인 ([PaymentMailService] 결제 완료 메일 발송 시작)
- [ ] 메일 발송 실패해도 결제 응답에 영향 없는지 확인
- [ ] GET /api/v1/bookings/me, GET /api/v1/payments/me JWT 토큰으로 정상 조회 확인