### PR TITLE
feature/refund 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.apache.pdfbox:pdfbox:3.0.3'  // pdf 생성
+    implementation 'org.apache.poi:poi-ooxml:5.2.3'
 
     // JWT를 생성, 파싱, 검증하는 데 필요한 인터페이스, 추상 클래스, 예외 클래스, 데이터 모델(예: Claims, JwsHeader 등)이 포함
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
@@ -5,16 +5,28 @@ import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
 import com.kidmily.algoga_server.global.exception.BusinessException;
 import com.kidmily.algoga_server.payment.application.usecase.PaymentQueryUseCase;
 import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
 import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
 import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
 import com.kidmily.algoga_server.payment.infrastructure.pdf.ConfirmationPdfGenerator;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentStatsResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -62,6 +74,92 @@ public class PaymentQueryService implements PaymentQueryUseCase {
         return paymentRepository.findByUserId(userId)
                 .stream()
                 .map(PaymentResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<PaymentResponse> getAdminPayments(LocalDate from, LocalDate to) {
+        log.info("[PaymentQueryService] 어드민 결제 내역 조회 - from: {}, to: {}", from, to);
+        LocalDateTime fromDt = from.atStartOfDay();
+        LocalDateTime toDt = to.atTime(LocalTime.MAX);
+        return paymentRepository.findByCreatedAtBetween(fromDt, toDt)
+                .stream()
+                .map(PaymentResponse::from)
+                .toList();
+    }
+
+    @Override
+    public byte[] getAdminPaymentsExcel(LocalDate from, LocalDate to) {
+        log.info("[PaymentQueryService] 어드민 결제 내역 엑셀 다운로드 - from: {}, to: {}", from, to);
+        List<PaymentResponse> payments = getAdminPayments(from, to);
+
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("결제내역");
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerStyle.setFont(headerFont);
+
+            Row header = sheet.createRow(0);
+            String[] columns = {"결제ID", "유저ID", "예약ID", "강의ID", "결제유형", "금액", "마일리지사용", "상태", "결제일시"};
+            for (int i = 0; i < columns.length; i++) {
+                Cell cell = header.createCell(i);
+                cell.setCellValue(columns[i]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            int rowNum = 1;
+            for (PaymentResponse p : payments) {
+                Row row = sheet.createRow(rowNum++);
+                row.createCell(0).setCellValue(p.paymentId());
+                row.createCell(1).setCellValue(p.userId());
+                row.createCell(2).setCellValue(p.bookingId() != null ? p.bookingId() : 0);
+                row.createCell(3).setCellValue(p.courseId() != null ? p.courseId() : 0);
+                row.createCell(4).setCellValue(p.paymentType().name());
+                row.createCell(5).setCellValue(p.amount());
+                row.createCell(6).setCellValue(p.usedMileage());
+                row.createCell(7).setCellValue(p.status().name());
+                row.createCell(8).setCellValue(p.createdAt().toString());
+            }
+
+            for (int i = 0; i < columns.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            workbook.write(out);
+            return out.toByteArray();
+
+        } catch (IOException e) {
+            log.warn("[PaymentQueryService] 엑셀 생성 실패: {}", e.getMessage());
+            throw new BusinessException(PaymentErrorCode.EXCEL_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public List<PaymentStatsResponse> getAdminPaymentStats() {
+        log.info("[PaymentQueryService] 어드민 월별 수익 통계 조회");
+
+        Map<String, List<Payment>> grouped = paymentRepository
+                .findByCreatedAtBetween(LocalDateTime.of(2000, 1, 1, 0, 0), LocalDateTime.now())
+                .stream()
+                .filter(p -> p.getStatus() == PaymentStatus.SUCCESS)
+                .collect(Collectors.groupingBy(p ->
+                        p.getCreatedAt().getYear() + "-" + p.getCreatedAt().getMonthValue()
+                ));
+
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    String[] parts = entry.getKey().split("-");
+                    int year = Integer.parseInt(parts[0]);
+                    int month = Integer.parseInt(parts[1]);
+                    int totalAmount = entry.getValue().stream().mapToInt(Payment::getAmount).sum();
+                    long count = entry.getValue().size();
+                    return new PaymentStatsResponse(year, month, totalAmount, count);
+                })
+                .sorted(Comparator.comparingInt(PaymentStatsResponse::year)
+                        .thenComparingInt(PaymentStatsResponse::month))
                 .toList();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentQueryUseCase.java
@@ -1,11 +1,16 @@
 package com.kidmily.algoga_server.payment.application.usecase;
 
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentStatsResponse;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface PaymentQueryUseCase {
     PaymentResponse getPayment(Long paymentId);
     byte[] getConfirmationPdf(Long paymentId);
     List<PaymentResponse> getMyPayments(Long userId);
+    List<PaymentResponse> getAdminPayments(LocalDate from, LocalDate to);
+    byte[] getAdminPaymentsExcel(LocalDate from, LocalDate to);
+    List<PaymentStatsResponse> getAdminPaymentStats();
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/repository/PaymentRepository.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.payment.domain.repository;
 
 import com.kidmily.algoga_server.payment.domain.model.Payment;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,4 +12,6 @@ public interface PaymentRepository {
     Optional<Payment> findByIdempotencyKey(String idempotencyKey);
     Optional<Payment> findByPortonePaymentId(String portonePaymentId);
     List<Payment> findByUserId(Long userId);
+    List<Payment> findByBookingId(Long bookingId);
+    List<Payment> findByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/exception/PaymentErrorCode.java
@@ -15,7 +15,8 @@ public enum PaymentErrorCode implements BaseErrorCode {
     DUPLICATE_PAYMENT(HttpStatus.CONFLICT, "PAY_004", "이미 처리된 결제입니다."),
     PORTONE_API_ERROR(HttpStatus.BAD_GATEWAY, "PAY_005", "결제 처리 중 오류가 발생했습니다."),
     INVALID_WEBHOOK(HttpStatus.BAD_REQUEST, "PAY_006", "유효하지 않은 웹훅 요청입니다."),
-    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY_007", "강의 정보를 찾을 수 없습니다.");
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY_007", "강의 정보를 찾을 수 없습니다."),
+    EXCEL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PAY_008", "엑셀 파일 생성에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
@@ -6,6 +6,7 @@ import com.kidmily.algoga_server.payment.infrastructure.mapper.PaymentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,6 +44,22 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
     @Override
     public List<Payment> findByUserId(Long userId) {
         return springDataPaymentRepository.findByUserId(userId)
+                .stream()
+                .map(paymentMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Payment> findByBookingId(Long bookingId) {
+        return springDataPaymentRepository.findByBookingId(bookingId)
+                .stream()
+                .map(paymentMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Payment> findByCreatedAtBetween(LocalDateTime from, LocalDateTime to) {
+        return springDataPaymentRepository.findByCreatedAtBetween(from, to)
                 .stream()
                 .map(paymentMapper::toDomain)
                 .toList();

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/SpringDataPaymentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/SpringDataPaymentRepository.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.payment.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,4 +10,6 @@ public interface SpringDataPaymentRepository extends JpaRepository<PaymentJpaEnt
     Optional<PaymentJpaEntity> findByIdempotencyKey(String idempotencyKey);
     Optional<PaymentJpaEntity> findByPortonePaymentId(String portonePaymentId);
     List<PaymentJpaEntity> findByUserId(Long userId);
+    List<PaymentJpaEntity> findByBookingId(Long bookingId);
+    List<PaymentJpaEntity> findByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/AdminPaymentController.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/AdminPaymentController.java
@@ -1,0 +1,60 @@
+package com.kidmily.algoga_server.payment.presentation;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.payment.application.usecase.PaymentQueryUseCase;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentStatsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/payments")
+@RequiredArgsConstructor
+@Tag(name = "Admin Payment", description = "어드민 정산 API")
+public class AdminPaymentController {
+
+    private final PaymentQueryUseCase paymentQueryUseCase;
+
+    @GetMapping
+    @Operation(summary = "[어드민] 결제 내역 조회", description = "기간별 전체 결제 내역을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PaymentResponse>>> getAdminPayments(
+            @Parameter(description = "시작일 (yyyy-MM-dd)", example = "2026-01-01")
+            @RequestParam LocalDate from,
+            @Parameter(description = "종료일 (yyyy-MM-dd)", example = "2026-12-31")
+            @RequestParam LocalDate to
+    ) {
+        List<PaymentResponse> response = paymentQueryUseCase.getAdminPayments(from, to);
+        return ResponseEntity.ok(ApiResponse.success("ADMIN_PAYMENTS", "결제 내역 조회에 성공했습니다.", response));
+    }
+
+    @GetMapping("/excel")
+    @Operation(summary = "[어드민] 결제 내역 엑셀 다운로드", description = "기간별 결제 내역을 엑셀로 다운로드합니다.")
+    public ResponseEntity<byte[]> getAdminPaymentsExcel(
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to
+    ) {
+        byte[] excel = paymentQueryUseCase.getAdminPaymentsExcel(from, to);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"payments_" + from + "_" + to + ".xlsx\"")
+                .contentType(MediaType.parseMediaType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(excel);
+    }
+
+    @GetMapping("/stats")
+    @Operation(summary = "[어드민] 월별 수익 통계", description = "월별 결제 합계와 건수 통계를 반환합니다.")
+    public ResponseEntity<ApiResponse<List<PaymentStatsResponse>>> getAdminPaymentStats() {
+        List<PaymentStatsResponse> response = paymentQueryUseCase.getAdminPaymentStats();
+        return ResponseEntity.ok(ApiResponse.success("PAYMENT_STATS", "월별 수익 통계 조회에 성공했습니다.", response));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentStatsResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentStatsResponse.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.payment.presentation.api.response;
+
+public record PaymentStatsResponse(
+        int year,
+        int month,
+        int totalAmount,
+        long count
+) {}

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
@@ -5,6 +5,7 @@ import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
 import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
 import com.kidmily.algoga_server.global.exception.BusinessException;
 import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
 import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
 import com.kidmily.algoga_server.refund.application.command.CreateRefundCommand;
 import com.kidmily.algoga_server.refund.application.usecase.RefundCommandUseCase;
@@ -16,6 +17,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -32,7 +37,6 @@ public class RefundCommandService implements RefundCommandUseCase {
         log.info("[RefundCommandService] 환불 요청 - bookingId: {}, userId: {}",
                 command.bookingId(), command.userId());
 
-        // 예약 조회 및 취소 상태 확인
         Booking booking = bookingRepository.findById(command.bookingId())
                 .orElseThrow(() -> {
                     log.warn("[RefundCommandService] 예약을 찾을 수 없음 - bookingId: {}", command.bookingId());
@@ -44,20 +48,17 @@ public class RefundCommandService implements RefundCommandUseCase {
             throw new BusinessException(RefundErrorCode.BOOKING_NOT_CANCELLED);
         }
 
-        // 중복 환불 요청 방지
         if (refundRepository.existsByBookingId(command.bookingId())) {
             log.warn("[RefundCommandService] 이미 환불 요청됨 - bookingId: {}", command.bookingId());
             throw new BusinessException(RefundErrorCode.ALREADY_REFUND_REQUESTED);
         }
 
-        // 결제 조회 (환불 금액 산정)
         Payment payment = paymentRepository.findById(command.paymentId())
                 .orElseThrow(() -> {
                     log.warn("[RefundCommandService] 결제를 찾을 수 없음 - paymentId: {}", command.paymentId());
                     return new BusinessException(RefundErrorCode.PAYMENT_NOT_FOUND);
                 });
 
-        // 환불 금액 계산 (출발일 기준)
         int refundAmount = calculateRefundAmount(booking, payment.getAmount());
 
         RefundRequest refundRequest = RefundRequest.create(
@@ -70,6 +71,55 @@ public class RefundCommandService implements RefundCommandUseCase {
 
         RefundRequest saved = refundRepository.save(refundRequest);
         log.info("[RefundCommandService] 환불 요청 완료 - refundId: {}, amount: {}",
+                saved.getId(), saved.getAmount());
+
+        return saved.getId();
+    }
+
+    @Override
+    public Long convertToRefund(Long bookingId) {
+        log.info("[RefundCommandService] CS 환불 전환 - bookingId: {}", bookingId);
+
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> {
+                    log.warn("[RefundCommandService] 예약을 찾을 수 없음 - bookingId: {}", bookingId);
+                    return new BusinessException(RefundErrorCode.BOOKING_NOT_FOUND);
+                });
+
+        if (booking.getStatus() != BookingStatus.CANCEL_REQUESTED) {
+            log.warn("[RefundCommandService] 취소 요청 상태가 아닌 예약 - status: {}", booking.getStatus());
+            throw new BusinessException(RefundErrorCode.BOOKING_NOT_CANCELLED);
+        }
+
+        if (refundRepository.existsByBookingId(bookingId)) {
+            log.warn("[RefundCommandService] 이미 환불 요청됨 - bookingId: {}", bookingId);
+            throw new BusinessException(RefundErrorCode.ALREADY_REFUND_REQUESTED);
+        }
+
+        List<Payment> payments = paymentRepository.findByBookingId(bookingId)
+                .stream()
+                .filter(p -> p.getStatus() == PaymentStatus.SUCCESS)
+                .toList();
+
+        if (payments.isEmpty()) {
+            log.warn("[RefundCommandService] 성공한 결제 내역 없음 - bookingId: {}", bookingId);
+            throw new BusinessException(RefundErrorCode.PAYMENT_NOT_FOUND);
+        }
+
+        int totalPaid = payments.stream().mapToInt(Payment::getAmount).sum();
+        int refundAmount = calculateRefundAmount(booking, totalPaid);
+        Long paymentId = payments.get(payments.size() - 1).getId();
+
+        RefundRequest refundRequest = RefundRequest.create(
+                bookingId,
+                paymentId,
+                booking.getUserId(),
+                "CS 환불 전환 처리",
+                refundAmount
+        );
+
+        RefundRequest saved = refundRepository.save(refundRequest);
+        log.info("[RefundCommandService] CS 환불 전환 완료 - refundId: {}, amount: {}",
                 saved.getId(), saved.getAmount());
 
         return saved.getId();
@@ -131,17 +181,15 @@ public class RefundCommandService implements RefundCommandUseCase {
                 });
     }
 
-    // 환불 정책: 출발일 2주 전 100%, 1주 전 50%, 이후 0%
     private int calculateRefundAmount(Booking booking, int paidAmount) {
-        long daysUntilDeparture = java.time.temporal.ChronoUnit.DAYS.between(
-                java.time.LocalDate.now(), booking.getCheckInDate());
+        long daysUntilDeparture = ChronoUnit.DAYS.between(LocalDate.now(), booking.getCheckInDate());
 
         if (daysUntilDeparture >= 14) {
-            return paidAmount;          // 100%
+            return paidAmount;
         } else if (daysUntilDeparture >= 7) {
-            return paidAmount / 2;      // 50%
+            return paidAmount / 2;
         } else {
-            return 0;                   // 0%
+            return 0;
         }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundQueryService.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.refund.application.service;
 
 import com.kidmily.algoga_server.refund.application.usecase.RefundQueryUseCase;
+import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
 import com.kidmily.algoga_server.refund.presentation.api.response.RefundResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class RefundQueryService implements RefundQueryUseCase {
 
     @Override
     public List<RefundResponse> getMyRefunds(Long userId) {
+        log.warn("[RefundQueryService] 내 환불 목록 조회 - userId: {}", userId);
         return refundRepository.findAllByUserId(userId)
                 .stream()
                 .map(RefundResponse::from)
@@ -27,8 +29,15 @@ public class RefundQueryService implements RefundQueryUseCase {
     }
 
     @Override
-    public List<RefundResponse> getAllRefunds() {
-        return refundRepository.findAll()
+    public List<RefundResponse> getAllRefunds(RefundStatus status) {
+        log.warn("[RefundQueryService] 전체 환불 목록 조회 - status: {}", status);
+        if (status == null) {
+            return refundRepository.findAll()
+                    .stream()
+                    .map(RefundResponse::from)
+                    .toList();
+        }
+        return refundRepository.findAllByStatus(status)
                 .stream()
                 .map(RefundResponse::from)
                 .toList();

--- a/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundCommandUseCase.java
@@ -3,8 +3,9 @@ package com.kidmily.algoga_server.refund.application.usecase;
 import com.kidmily.algoga_server.refund.application.command.CreateRefundCommand;
 
 public interface RefundCommandUseCase {
-    Long handle(CreateRefundCommand command);   // 환불 요청
-    void approve(Long refundId);                // 승인
-    void reject(Long refundId, String rejectReason); // 반려
-    void complete(Long refundId);               // 완료
+    Long handle(CreateRefundCommand command);
+    Long convertToRefund(Long bookingId);
+    void approve(Long refundId);
+    void reject(Long refundId, String rejectReason);
+    void complete(Long refundId);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundQueryUseCase.java
@@ -1,10 +1,11 @@
 package com.kidmily.algoga_server.refund.application.usecase;
 
+import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.presentation.api.response.RefundResponse;
 
 import java.util.List;
 
 public interface RefundQueryUseCase {
     List<RefundResponse> getMyRefunds(Long userId);
-    List<RefundResponse> getAllRefunds();
+    List<RefundResponse> getAllRefunds(RefundStatus status);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/domain/repository/RefundRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/domain/repository/RefundRepository.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.refund.domain.repository;
 
 import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
+import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +11,6 @@ public interface RefundRepository {
     Optional<RefundRequest> findById(Long refundId);
     List<RefundRequest> findAllByUserId(Long userId);
     List<RefundRequest> findAll();
+    List<RefundRequest> findAllByStatus(RefundStatus status);
     boolean existsByBookingId(Long bookingId);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/RefundRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/RefundRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.refund.infrastructure.persistence;
 
 import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
+import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
 import com.kidmily.algoga_server.refund.infrastructure.mapper.RefundMapper;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,6 @@ public class RefundRepositoryAdapter implements RefundRepository {
 
     private final SpringDataRefundRepository springDataRefundRepository;
     private final RefundMapper refundMapper;
-
 
     @Override
     public RefundRequest save(RefundRequest refundRequest) {
@@ -40,6 +40,14 @@ public class RefundRepositoryAdapter implements RefundRepository {
     @Override
     public List<RefundRequest> findAll() {
         return springDataRefundRepository.findAll()
+                .stream()
+                .map(refundMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<RefundRequest> findAllByStatus(RefundStatus status) {
+        return springDataRefundRepository.findAllByStatus(status)
                 .stream()
                 .map(refundMapper::toDomain)
                 .toList();

--- a/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/SpringDataRefundRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/SpringDataRefundRepository.java
@@ -1,10 +1,12 @@
 package com.kidmily.algoga_server.refund.infrastructure.persistence;
 
+import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface SpringDataRefundRepository extends JpaRepository<RefundJpaEntity, Long> {
     List<RefundJpaEntity> findAllByUserId(Long userId);
+    List<RefundJpaEntity> findAllByStatus(RefundStatus status);
     boolean existsByBookingId(Long bookingId);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/presentation/api/RefundController.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/presentation/api/RefundController.java
@@ -1,13 +1,15 @@
 package com.kidmily.algoga_server.refund.presentation.api;
 
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.refund.application.command.CreateRefundCommand;
 import com.kidmily.algoga_server.refund.application.usecase.RefundCommandUseCase;
 import com.kidmily.algoga_server.refund.application.usecase.RefundQueryUseCase;
+import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.exception.RefundErrorCode;
 import com.kidmily.algoga_server.refund.presentation.api.request.CreateRefundRequest;
 import com.kidmily.algoga_server.refund.presentation.api.response.RefundResponse;
-import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,19 +30,20 @@ public class RefundController {
     private final RefundCommandUseCase refundCommandUseCase;
     private final RefundQueryUseCase refundQueryUseCase;
 
-    // ── 유좌 API ──────────────────────────────────────
+    // ── 유저 API ──────────────────────────────────────
 
     @PostMapping("/api/v1/refund-requests")
     @Operation(summary = "환불 요청", description = "취소된 예약에 대해 환불을 요청합니다.")
     @ApiErrorCodeExample(domain = RefundErrorCode.class,
             value = {"BOOKING_NOT_FOUND", "BOOKING_NOT_CANCELLED", "ALREADY_REFUND_REQUESTED", "PAYMENT_NOT_FOUND"})
     public ResponseEntity<ApiResponse<Long>> createRefund(
-            @Valid @RequestBody CreateRefundRequest request
+            @Valid @RequestBody CreateRefundRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         CreateRefundCommand command = new CreateRefundCommand(
                 request.bookingId(),
                 request.paymentId(),
-                request.userId(),
+                userDetails.getUser().getId(),
                 request.reason()
         );
         Long refundId = refundCommandUseCase.handle(command);
@@ -50,24 +54,39 @@ public class RefundController {
     @GetMapping("/api/v1/refund-requests/me")
     @Operation(summary = "내 환불 요청 목록", description = "본인의 환불 요청 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<RefundResponse>>> getMyRefunds(
-            @Parameter(description = "사용자 ID", example = "1")
-            @RequestParam Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        List<RefundResponse> response = refundQueryUseCase.getMyRefunds(userId);
+        List<RefundResponse> response = refundQueryUseCase.getMyRefunds(userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("REFUND_LIST", "환불 목록 조회에 성공했습니다.", response));
     }
 
     // ── 어드민 API ────────────────────────────────────
 
+    @PostMapping("/api/v1/admin/bookings/{bookingId}/to-refund")
+    @Operation(summary = "[어드민] 취소 예약 환불 전환", description = "CS가 취소 요청된 예약을 환불 요청으로 전환합니다.")
+    @ApiErrorCodeExample(domain = RefundErrorCode.class,
+            value = {"BOOKING_NOT_FOUND", "BOOKING_NOT_CANCELLED", "ALREADY_REFUND_REQUESTED", "PAYMENT_NOT_FOUND"})
+    public ResponseEntity<ApiResponse<Long>> convertToRefund(
+            @Parameter(description = "예약 ID", example = "1")
+            @PathVariable Long bookingId
+    ) {
+        Long refundId = refundCommandUseCase.convertToRefund(bookingId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("REFUND_CONVERTED", "환불 요청으로 전환됐습니다.", refundId));
+    }
+
     @GetMapping("/api/v1/admin/refund-requests")
-    @Operation(summary = "[어드민] 환불 요청 목록", description = "전체 환불 요청 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<RefundResponse>>> getAllRefunds() {
-        List<RefundResponse> response = refundQueryUseCase.getAllRefunds();
+    @Operation(summary = "[어드민] 환불 요청 목록", description = "전체 환불 요청 목록을 상태별로 조회합니다.")
+    public ResponseEntity<ApiResponse<List<RefundResponse>>> getAllRefunds(
+            @Parameter(description = "환불 상태 필터 (REQUESTED/APPROVED/REJECTED/COMPLETED)")
+            @RequestParam(required = false) RefundStatus status
+    ) {
+        List<RefundResponse> response = refundQueryUseCase.getAllRefunds(status);
         return ResponseEntity.ok(ApiResponse.success("REFUND_LIST", "환불 목록 조회에 성공했습니다.", response));
     }
 
     @PutMapping("/api/v1/admin/refund-requests/{refundId}/approve")
-    @Operation(summary = "[어드민] 환불 승인", description = "환불 요청을 승인합니다.")
+    @Operation(summary = "[어드민] 환불 승인", description = "환불 요청을 승인합니다. REQUESTED → APPROVED")
     @ApiErrorCodeExample(domain = RefundErrorCode.class, value = {"REFUND_NOT_FOUND", "INVALID_REFUND_STATUS"})
     public ResponseEntity<ApiResponse<Void>> approve(
             @Parameter(description = "환불 요청 ID", example = "1")
@@ -78,7 +97,7 @@ public class RefundController {
     }
 
     @PutMapping("/api/v1/admin/refund-requests/{refundId}/reject")
-    @Operation(summary = "[어드민] 환불 반려", description = "환불 요청을 반려합니다.")
+    @Operation(summary = "[어드민] 환불 반려", description = "환불 요청을 반려합니다. REQUESTED → REJECTED")
     @ApiErrorCodeExample(domain = RefundErrorCode.class, value = {"REFUND_NOT_FOUND", "INVALID_REFUND_STATUS"})
     public ResponseEntity<ApiResponse<Void>> reject(
             @Parameter(description = "환불 요청 ID", example = "1")
@@ -90,7 +109,7 @@ public class RefundController {
     }
 
     @PutMapping("/api/v1/admin/refund-requests/{refundId}/complete")
-    @Operation(summary = "[어드민] 환불 완료", description = "환불을 완료 처리합니다.")
+    @Operation(summary = "[어드민] 환불 완료", description = "환불을 완료 처리합니다. APPROVED → COMPLETED")
     @ApiErrorCodeExample(domain = RefundErrorCode.class, value = {"REFUND_NOT_FOUND", "INVALID_REFUND_STATUS"})
     public ResponseEntity<ApiResponse<Void>> complete(
             @Parameter(description = "환불 요청 ID", example = "1")


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
결제(Payment) 및 환불(Refund) 도메인 전체 구현

- **결제**: 패키지 예약 결제, 강의 단독 결제, PortOne v2 웹훅 처리, 예약 확인서 PDF 다운로드, 내 결제 내역 조회
- **환불**: 환불 신청 / 승인 / 거절 / 완료 처리, 환불 내역 조회 (유저/어드민)
- **어드민 정산**: 기간별 결제 내역 조회 및 엑셀 다운로드, 월별 수익 통계 조회

## 🔗 Issue
Closes #121 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] `POST /api/v1/payments` — 패키지 결제 처리 및 PortOne 웹훅 연동 확인
- [ ] `POST /api/v1/payments/lecture` — 강의 단독 결제 (쿠폰/마일리지 적용) 확인
- [ ] `GET /api/v1/payments/{paymentId}/confirmation` — 예약 확인서 PDF 다운로드 확인
- [ ] `POST /api/v1/refunds` — 환불 신청 후 승인/거절/완료 플로우 확인
- [ ] `GET /api/v1/admin/payments` — 기간 필터 결제 내역 조회 확인
- [ ] `GET /api/v1/admin/payments/excel` — 엑셀 파일 정상 다운로드 확인
- [ ] `GET /api/v1/admin/payments/stats` — 월별 수익 통계 정상 응답 확인
