### PR TITLE
[Feature] 관리자 수강생/마일리지 관리 및 강의 난이도 기반 추천 기능 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/AdminMileageTransactionCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/AdminMileageTransactionCommand.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.lms.application.command;
+
+public record AdminMileageTransactionCommand(
+        Long userId,
+        Long managerId,
+        int amount,
+        String reason
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateChapterCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateChapterCommand.java
@@ -1,9 +1,11 @@
 package com.kidmily.algoga_server.lms.application.command;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record CreateChapterCommand(
         Long courseId,
         String title,
-        String videoUrl,
+        MultipartFile videoFile,
         int durationSeconds,
         int chapterOrder
 ) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseCommand.java
@@ -7,6 +7,7 @@ public record CreateCourseCommand(
         String description,
         Integer price,
         String thumbnailUrl,
-        String fileUrl
+        String fileUrl,
+        String level
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseCommand.java
@@ -1,13 +1,15 @@
 package com.kidmily.algoga_server.lms.application.command;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record CreateCourseCommand(
         Long countryId,
         Long managerId,
         String title,
         String description,
         Integer price,
-        String thumbnailUrl,
-        String fileUrl,
-        String level
+        String level,
+        MultipartFile thumbnailFile,
+        MultipartFile attachedFile
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseQnaCommentCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseQnaCommentCommand.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.lms.application.command;
+
+public record CreateCourseQnaCommentCommand(
+        Long courseId,
+        Long qnaId,
+        Long writerId,
+        String writerType,
+        String content
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateChapterCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateChapterCommand.java
@@ -1,8 +1,10 @@
 package com.kidmily.algoga_server.lms.application.command;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record UpdateChapterCommand(
         String title,
-        String videoUrl,
+        MultipartFile videoFile,
         int durationSeconds,
         int chapterOrder
 ) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
@@ -5,6 +5,7 @@ public record UpdateCourseCommand(
         String description,
         Integer price,
         String thumbnailUrl,
-        String fileUrl
+        String fileUrl,
+        String level
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
@@ -1,11 +1,13 @@
 package com.kidmily.algoga_server.lms.application.command;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record UpdateCourseCommand(
         String title,
         String description,
         Integer price,
-        String thumbnailUrl,
-        String fileUrl,
-        String level
+        String level,
+        MultipartFile thumbnailFile,
+        MultipartFile attachedFile
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminMileageHistoryResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminMileageHistoryResult.java
@@ -1,0 +1,20 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.time.LocalDateTime;
+
+public record AdminMileageHistoryResult(
+        Long mileageHistoryId,
+        Long userId,
+        String userName,
+        String userEmail,
+        Long courseId,
+        String courseTitle,
+        Long managerId,
+        String processorName,
+        int amount,
+        int signedAmount,
+        String type,
+        String reason,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminMileageSummaryResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminMileageSummaryResult.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.util.List;
+
+public record AdminMileageSummaryResult(
+        int totalUserCount,
+        int totalMileage,
+        int totalEarnedMileage,
+        int totalUsedMileage,
+        List<AdminMileageUserResult> users
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminMileageUserResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminMileageUserResult.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.time.LocalDateTime;
+
+public record AdminMileageUserResult(
+        Long userId,
+        String name,
+        String email,
+        int totalMileage,
+        int totalEarnedMileage,
+        int totalUsedMileage,
+        LocalDateTime lastUpdatedAt
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaDetailResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaDetailResult.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CourseQnaDetailResult(
+        Long qnaId,
+        Long courseId,
+        Long userId,
+        Long managerId,
+        String title,
+        String question,
+        String answer,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime answeredAt,
+        List<CourseQnaComment> comments
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseReviewSummaryResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseReviewSummaryResult.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+public record CourseReviewSummaryResult(
+        Long courseId,
+        double averageRating,
+        int totalReviewCount,
+        int fiveStarCount,
+        int fourStarCount,
+        int threeStarCount,
+        int twoStarCount,
+        int oneStarCount,
+        double fiveStarRate,
+        double fourStarRate,
+        double threeStarRate,
+        double twoStarRate,
+        double oneStarRate
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseStudentResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseStudentResult.java
@@ -1,0 +1,19 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.time.LocalDateTime;
+
+public record CourseStudentResult(
+        Long userId,
+        String name,
+        String email,
+        Long courseId,
+        String courseTitle,
+        int progressRate,
+        int completedChapterCount,
+        int totalChapterCount,
+        String learningStatus,
+        boolean quizSubmitted,
+        boolean reviewWritten,
+        LocalDateTime completedAt
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/MyCouponResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/MyCouponResult.java
@@ -1,0 +1,19 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.time.LocalDateTime;
+
+public record MyCouponResult(
+        Long userCouponId,
+        Long courseId,
+        String courseTitle,
+        Long couponPolicyId,
+        String couponName,
+        String discountType,
+        int discountValue,
+        String status,
+        boolean usable,
+        LocalDateTime issuedAt,
+        LocalDateTime expiredAt,
+        LocalDateTime usedAt
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/MyCourseResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/MyCourseResult.java
@@ -1,0 +1,22 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.time.LocalDateTime;
+
+public record MyCourseResult(
+        Long courseId,
+        String title,
+        String thumbnailUrl,
+        Long countryId,
+        String countryName,
+        int progressRate,
+        int completedChapterCount,
+        int totalChapterCount,
+        String learningStatus,
+        boolean quizSubmitted,
+        boolean reviewWritten,
+        boolean certificateAvailable,
+        String certificateCode,
+        String certificateDownloadUrl,
+        LocalDateTime completedAt
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/MyMileageHistoryResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/MyMileageHistoryResult.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.time.LocalDateTime;
+
+public record MyMileageHistoryResult(
+        Long mileageHistoryId,
+        Long courseId,
+        String courseTitle,
+        int amount,
+        String type,
+        String reason,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/MyMileageResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/MyMileageResult.java
@@ -1,0 +1,11 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.util.List;
+
+public record MyMileageResult(
+        int totalMileage,
+        int totalEarnedMileage,
+        int totalUsedMileage,
+        List<MyMileageHistoryResult> histories
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminChapterService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminChapterService.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.lms.application.service;
 
+import com.kidmily.algoga_server.global.port.out.FileStoragePort;
 import com.kidmily.algoga_server.lms.application.command.CreateChapterCommand;
 import com.kidmily.algoga_server.lms.application.command.UpdateChapterCommand;
 import com.kidmily.algoga_server.lms.application.usecase.AdminChapterUseCase;
@@ -8,6 +9,7 @@ import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
 import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.exception.LmsException;
+import com.kidmily.algoga_server.lms.settings.LmsStorageSettings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,9 +23,12 @@ import java.util.List;
 @Transactional
 public class AdminChapterService implements AdminChapterUseCase {
 
+    private static final int MAX_CHAPTER_COUNT = 5;
+
     private final ChapterRepository chapterRepository;
     private final CourseRepository courseRepository;
-    private static final int MAX_CHAPTER_COUNT = 5;
+    private final FileStoragePort fileStoragePort;
+    private final LmsStorageSettings storageSettings;
 
     @Override
     @Transactional(readOnly = true)
@@ -50,24 +55,30 @@ public class AdminChapterService implements AdminChapterUseCase {
         validateChapterLimit(command.courseId());
         validateDuplicatedChapterOrder(command.courseId(), command.chapterOrder());
 
-        if (command.videoUrl() == null) {
+        if (command.videoFile() == null || command.videoFile().isEmpty()) {
             log.warn("[Chapter Command] 챕터 등록 실패. 영상 파일이 없습니다. courseId={}",
                     command.courseId());
             throw new LmsException(LmsErrorCode.CHAPTER_VIDEO_REQUIRED);
         }
 
+        String videoUrl = fileStoragePort.uploadFile(
+                command.videoFile(),
+                storageSettings.getBucketName(),
+                storageSettings.getChapterVideoDirectory()
+        );
+
         Chapter chapter = Chapter.create(
                 command.courseId(),
                 command.title(),
-                command.videoUrl(),
+                videoUrl,
                 command.durationSeconds(),
                 command.chapterOrder()
         );
 
         Chapter savedChapter = chapterRepository.save(chapter);
 
-        log.info("[Chapter Command] 챕터 등록 완료. courseId={}, chapterId={}",
-                savedChapter.getCourseId(), savedChapter.getId());
+        log.info("[Chapter Command] 챕터 등록 완료. courseId={}, chapterId={}, videoUrl={}",
+                savedChapter.getCourseId(), savedChapter.getId(), savedChapter.getVideoUrl());
 
         return savedChapter;
     }
@@ -85,11 +96,35 @@ public class AdminChapterService implements AdminChapterUseCase {
         validateChapterOrder(command.chapterOrder());
         validateDuplicatedChapterOrderForUpdate(courseId, command.chapterOrder(), chapterId);
 
+        Chapter chapter = chapterRepository.findByIdAndCourseId(chapterId, courseId)
+                .orElseThrow(() -> {
+                    log.warn("[Chapter Command] 챕터 수정 실패. 존재하지 않거나 삭제된 챕터입니다. courseId={}, chapterId={}",
+                            courseId, chapterId);
+                    return new LmsException(LmsErrorCode.CHAPTER_NOT_FOUND);
+                });
+
+        String targetVideoUrl = chapter.getVideoUrl();
+
+        if (command.videoFile() != null && !command.videoFile().isEmpty()) {
+            if (targetVideoUrl != null && !targetVideoUrl.isBlank()) {
+                fileStoragePort.deleteFile(
+                        storageSettings.getBucketName(),
+                        targetVideoUrl
+                );
+            }
+
+            targetVideoUrl = fileStoragePort.uploadFile(
+                    command.videoFile(),
+                    storageSettings.getBucketName(),
+                    storageSettings.getChapterVideoDirectory()
+            );
+        }
+
         Chapter updatedChapter = chapterRepository.updateBasicInfo(
                 chapterId,
                 courseId,
                 command.title(),
-                command.videoUrl(),
+                targetVideoUrl,
                 command.durationSeconds(),
                 command.chapterOrder()
         ).orElseThrow(() -> {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminChapterService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminChapterService.java
@@ -23,6 +23,7 @@ public class AdminChapterService implements AdminChapterUseCase {
 
     private final ChapterRepository chapterRepository;
     private final CourseRepository courseRepository;
+    private static final int MAX_CHAPTER_COUNT = 5;
 
     @Override
     @Transactional(readOnly = true)
@@ -46,6 +47,8 @@ public class AdminChapterService implements AdminChapterUseCase {
 
         validateCourse(command.courseId(), "챕터 등록");
         validateChapterOrder(command.chapterOrder());
+        validateChapterLimit(command.courseId());
+        validateDuplicatedChapterOrder(command.courseId(), command.chapterOrder());
 
         if (command.videoUrl() == null) {
             log.warn("[Chapter Command] 챕터 등록 실패. 영상 파일이 없습니다. courseId={}",
@@ -80,6 +83,7 @@ public class AdminChapterService implements AdminChapterUseCase {
 
         validateCourse(courseId, "챕터 수정");
         validateChapterOrder(command.chapterOrder());
+        validateDuplicatedChapterOrderForUpdate(courseId, command.chapterOrder(), chapterId);
 
         Chapter updatedChapter = chapterRepository.updateBasicInfo(
                 chapterId,
@@ -128,10 +132,44 @@ public class AdminChapterService implements AdminChapterUseCase {
     }
 
     private void validateChapterOrder(int chapterOrder) {
-        if (chapterOrder < 1) {
+        if (chapterOrder < 1 || chapterOrder > MAX_CHAPTER_COUNT) {
             log.warn("[Chapter Command] 유효하지 않은 챕터 순서입니다. chapterOrder={}",
                     chapterOrder);
             throw new LmsException(LmsErrorCode.INVALID_CHAPTER_ORDER);
+        }
+    }
+
+    private void validateChapterLimit(Long courseId) {
+        long chapterCount = chapterRepository.countByCourseId(courseId);
+
+        if (chapterCount >= MAX_CHAPTER_COUNT) {
+            log.warn("[Chapter Command] 챕터 등록 실패. 챕터 최대 개수를 초과했습니다. courseId={}, count={}",
+                    courseId, chapterCount);
+            throw new LmsException(LmsErrorCode.CHAPTER_LIMIT_EXCEEDED);
+        }
+    }
+
+    private void validateDuplicatedChapterOrder(Long courseId, int chapterOrder) {
+        if (chapterRepository.existsByCourseIdAndChapterOrder(courseId, chapterOrder)) {
+            log.warn("[Chapter Command] 챕터 등록 실패. 이미 사용 중인 챕터 순서입니다. courseId={}, chapterOrder={}",
+                    courseId, chapterOrder);
+            throw new LmsException(LmsErrorCode.DUPLICATED_CHAPTER_ORDER);
+        }
+    }
+
+    private void validateDuplicatedChapterOrderForUpdate(
+            Long courseId,
+            int chapterOrder,
+            Long chapterId
+    ) {
+        if (chapterRepository.existsByCourseIdAndChapterOrderAndIdNot(
+                courseId,
+                chapterOrder,
+                chapterId
+        )) {
+            log.warn("[Chapter Command] 챕터 수정 실패. 이미 사용 중인 챕터 순서입니다. courseId={}, chapterId={}, chapterOrder={}",
+                    courseId, chapterId, chapterOrder);
+            throw new LmsException(LmsErrorCode.DUPLICATED_CHAPTER_ORDER);
         }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.lms.application.service;
 
+import com.kidmily.algoga_server.global.port.out.FileStoragePort;
 import com.kidmily.algoga_server.lms.application.command.CreateCourseCommand;
 import com.kidmily.algoga_server.lms.application.command.UpdateCourseCommand;
 import com.kidmily.algoga_server.lms.application.usecase.AdminContentUseCase;
@@ -8,6 +9,7 @@ import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
 import com.kidmily.algoga_server.lms.domain.repository.MapRepository;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.exception.LmsException;
+import com.kidmily.algoga_server.lms.settings.LmsStorageSettings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -23,14 +25,34 @@ public class AdminContentService implements AdminContentUseCase {
 
     private final CourseRepository courseRepository;
     private final MapRepository mapRepository;
+    private final FileStoragePort fileStoragePort;
+    private final LmsStorageSettings storageSettings;
 
     @Override
     public Long createCourse(CreateCourseCommand command) {
-        log.info("[Course Command] 강의 생성 요청. countryId={}, managerId={}, title={}, level={}",
-                command.countryId(), command.managerId(), command.title(), command.level());
+        log.info("[Course Command] 강의 생성 요청. countryId={}, managerId={}, title={}",
+                command.countryId(), command.managerId(), command.title());
 
         validateCountry(command.countryId(), "강의 생성");
-        validateCourseLevel(command.level());
+
+        String thumbnailUrl = null;
+        String fileUrl = null;
+
+        if (command.thumbnailFile() != null && !command.thumbnailFile().isEmpty()) {
+            thumbnailUrl = fileStoragePort.uploadFile(
+                    command.thumbnailFile(),
+                    storageSettings.getBucketName(),
+                    storageSettings.getCourseThumbnailDirectory()
+            );
+        }
+
+        if (command.attachedFile() != null && !command.attachedFile().isEmpty()) {
+            fileUrl = fileStoragePort.uploadFile(
+                    command.attachedFile(),
+                    storageSettings.getBucketName(),
+                    storageSettings.getCourseFileDirectory()
+            );
+        }
 
         Course newCourse = Course.create(
                 command.countryId(),
@@ -38,14 +60,15 @@ public class AdminContentService implements AdminContentUseCase {
                 command.title(),
                 command.description(),
                 command.price(),
-                command.thumbnailUrl(),
-                command.fileUrl(),
+                thumbnailUrl,
+                fileUrl,
                 command.level()
         );
 
         Course savedCourse = courseRepository.save(newCourse);
 
-        log.info("[Course Command] 강의 생성 완료. courseId={}", savedCourse.getId());
+        log.info("[Course Command] 강의 생성 완료. courseId={}, thumbnailUrl={}, fileUrl={}, level={}",
+                savedCourse.getId(), thumbnailUrl, fileUrl, command.level());
 
         return savedCourse.getId();
     }
@@ -85,15 +108,52 @@ public class AdminContentService implements AdminContentUseCase {
         log.info("[Course Command] 강의 수정 요청. courseId={}, title={}, level={}",
                 courseId, command.title(), command.level());
 
-        validateCourseLevel(command.level());
+        Course course = courseRepository.findByIdAndDeletedFalse(courseId)
+                .orElseThrow(() -> {
+                    log.warn("[Course Command] 강의 수정 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
+                    return new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+                });
+
+        String targetThumbnailUrl = course.getThumbnailUrl();
+        String targetFileUrl = course.getFileUrl();
+
+        if (command.thumbnailFile() != null && !command.thumbnailFile().isEmpty()) {
+            if (targetThumbnailUrl != null && !targetThumbnailUrl.isBlank()) {
+                fileStoragePort.deleteFile(
+                        storageSettings.getBucketName(),
+                        targetThumbnailUrl
+                );
+            }
+
+            targetThumbnailUrl = fileStoragePort.uploadFile(
+                    command.thumbnailFile(),
+                    storageSettings.getBucketName(),
+                    storageSettings.getCourseThumbnailDirectory()
+            );
+        }
+
+        if (command.attachedFile() != null && !command.attachedFile().isEmpty()) {
+            if (targetFileUrl != null && !targetFileUrl.isBlank()) {
+                fileStoragePort.deleteFile(
+                        storageSettings.getBucketName(),
+                        targetFileUrl
+                );
+            }
+
+            targetFileUrl = fileStoragePort.uploadFile(
+                    command.attachedFile(),
+                    storageSettings.getBucketName(),
+                    storageSettings.getCourseFileDirectory()
+            );
+        }
 
         Course updatedCourse = courseRepository.updateBasicInfo(
                 courseId,
                 command.title(),
                 command.description(),
                 command.price(),
-                command.thumbnailUrl(),
-                command.fileUrl(),
+                targetThumbnailUrl,
+                targetFileUrl,
                 command.level()
         ).orElseThrow(() -> {
             log.warn("[Course Command] 강의 수정 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
@@ -124,15 +184,6 @@ public class AdminContentService implements AdminContentUseCase {
             log.warn("[Course Command] {} 실패. 존재하지 않는 국가입니다. countryId={}",
                     action, countryId);
             throw new LmsException(LmsErrorCode.COUNTRY_NOT_FOUND);
-        }
-    }
-
-    private void validateCourseLevel(String level) {
-        if (!"BEGINNER".equals(level)
-                && !"INTERMEDIATE".equals(level)
-                && !"ADVANCED".equals(level)) {
-            log.warn("[Course Command] 유효하지 않은 강의 난이도입니다. level={}", level);
-            throw new LmsException(LmsErrorCode.INVALID_COURSE_LEVEL);
         }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
@@ -26,10 +26,11 @@ public class AdminContentService implements AdminContentUseCase {
 
     @Override
     public Long createCourse(CreateCourseCommand command) {
-        log.info("[Course Command] 강의 생성 요청. countryId={}, managerId={}, title={}",
-                command.countryId(), command.managerId(), command.title());
+        log.info("[Course Command] 강의 생성 요청. countryId={}, managerId={}, title={}, level={}",
+                command.countryId(), command.managerId(), command.title(), command.level());
 
         validateCountry(command.countryId(), "강의 생성");
+        validateCourseLevel(command.level());
 
         Course newCourse = Course.create(
                 command.countryId(),
@@ -38,7 +39,8 @@ public class AdminContentService implements AdminContentUseCase {
                 command.description(),
                 command.price(),
                 command.thumbnailUrl(),
-                command.fileUrl()
+                command.fileUrl(),
+                command.level()
         );
 
         Course savedCourse = courseRepository.save(newCourse);
@@ -80,8 +82,10 @@ public class AdminContentService implements AdminContentUseCase {
 
     @Override
     public Course updateCourse(Long courseId, UpdateCourseCommand command) {
-        log.info("[Course Command] 강의 수정 요청. courseId={}, title={}",
-                courseId, command.title());
+        log.info("[Course Command] 강의 수정 요청. courseId={}, title={}, level={}",
+                courseId, command.title(), command.level());
+
+        validateCourseLevel(command.level());
 
         Course updatedCourse = courseRepository.updateBasicInfo(
                 courseId,
@@ -89,7 +93,8 @@ public class AdminContentService implements AdminContentUseCase {
                 command.description(),
                 command.price(),
                 command.thumbnailUrl(),
-                command.fileUrl()
+                command.fileUrl(),
+                command.level()
         ).orElseThrow(() -> {
             log.warn("[Course Command] 강의 수정 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
             return new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
@@ -119,6 +124,15 @@ public class AdminContentService implements AdminContentUseCase {
             log.warn("[Course Command] {} 실패. 존재하지 않는 국가입니다. countryId={}",
                     action, countryId);
             throw new LmsException(LmsErrorCode.COUNTRY_NOT_FOUND);
+        }
+    }
+
+    private void validateCourseLevel(String level) {
+        if (!"BEGINNER".equals(level)
+                && !"INTERMEDIATE".equals(level)
+                && !"ADVANCED".equals(level)) {
+            log.warn("[Course Command] 유효하지 않은 강의 난이도입니다. level={}", level);
+            throw new LmsException(LmsErrorCode.INVALID_COURSE_LEVEL);
         }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminCourseStudentService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminCourseStudentService.java
@@ -1,0 +1,156 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.result.CourseStudentResult;
+import com.kidmily.algoga_server.lms.application.usecase.AdminCourseStudentUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.model.CourseCompletion;
+import com.kidmily.algoga_server.lms.domain.model.LearningProgress;
+import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseCompletionRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseReviewRepository;
+import com.kidmily.algoga_server.lms.domain.repository.LearningProgressRepository;
+import com.kidmily.algoga_server.lms.domain.repository.QuizSubmissionRepository;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminCourseStudentService implements AdminCourseStudentUseCase {
+
+    private final CourseRepository courseRepository;
+    private final ChapterRepository chapterRepository;
+    private final LearningProgressRepository learningProgressRepository;
+    private final CourseCompletionRepository courseCompletionRepository;
+    private final QuizSubmissionRepository quizSubmissionRepository;
+    private final CourseReviewRepository courseReviewRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public List<CourseStudentResult> getCourseStudents(Long courseId) {
+        log.info("[Admin Course Student Query] 강의 수강생 목록 조회 요청. courseId={}", courseId);
+
+        Course course = courseRepository.findByIdAndDeletedFalse(courseId)
+                .orElseThrow(() -> {
+                    log.warn("[Admin Course Student Query] 강의 수강생 목록 조회 실패. 강의를 찾을 수 없습니다. courseId={}", courseId);
+                    return new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+                });
+
+        List<Chapter> chapters = chapterRepository.findByCourseId(courseId);
+        List<LearningProgress> courseProgresses = learningProgressRepository.findByCourseId(courseId);
+
+        Set<Long> userIds = new LinkedHashSet<>();
+
+        for (LearningProgress progress : courseProgresses) {
+            userIds.add(progress.getUserId());
+        }
+
+        List<CourseStudentResult> results = userIds.stream()
+                .map(userId -> createCourseStudentResult(userId, course, chapters))
+                .flatMap(Optional::stream)
+                .sorted(Comparator.comparing(CourseStudentResult::userId))
+                .toList();
+
+        log.info("[Admin Course Student Query] 강의 수강생 목록 조회 완료. courseId={}, count={}",
+                courseId, results.size());
+
+        return results;
+    }
+
+    private Optional<CourseStudentResult> createCourseStudentResult(
+            Long userId,
+            Course course,
+            List<Chapter> chapters
+    ) {
+        Optional<User> optionalUser = userRepository.findById(userId);
+
+        if (optionalUser.isEmpty()) {
+            return Optional.empty();
+        }
+
+        User user = optionalUser.get();
+
+        List<LearningProgress> progresses = learningProgressRepository.findByUserIdAndCourseId(
+                userId,
+                course.getId()
+        );
+
+        int totalChapterCount = chapters.size();
+        int completedChapterCount = calculateCompletedChapterCount(progresses);
+        int progressRate = calculateCourseProgressRate(chapters, progresses);
+
+        Optional<CourseCompletion> optionalCompletion = courseCompletionRepository.findByUserIdAndCourseId(
+                userId,
+                course.getId()
+        );
+
+        boolean completed = optionalCompletion.isPresent();
+        boolean quizSubmitted = quizSubmissionRepository.existsByUserIdAndCourseId(userId, course.getId());
+        boolean reviewWritten = courseReviewRepository.existsByUserIdAndCourseIdAndDeletedFalse(userId, course.getId());
+
+        String learningStatus = completed ? "COMPLETED" : "IN_PROGRESS";
+
+        var completedAt = optionalCompletion
+                .map(CourseCompletion::getCompletedAt)
+                .orElse(null);
+
+        return Optional.of(new CourseStudentResult(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                course.getId(),
+                course.getTitle(),
+                progressRate,
+                completedChapterCount,
+                totalChapterCount,
+                learningStatus,
+                quizSubmitted,
+                reviewWritten,
+                completedAt
+        ));
+    }
+
+    private int calculateCompletedChapterCount(List<LearningProgress> progresses) {
+        return (int) progresses.stream()
+                .filter(LearningProgress::isCompleted)
+                .count();
+    }
+
+    private int calculateCourseProgressRate(
+            List<Chapter> chapters,
+            List<LearningProgress> progresses
+    ) {
+        if (chapters.isEmpty()) {
+            return 0;
+        }
+
+        int totalProgressRate = 0;
+
+        for (Chapter chapter : chapters) {
+            int chapterProgressRate = progresses.stream()
+                    .filter(progress -> progress.getChapterId().equals(chapter.getId()))
+                    .map(LearningProgress::getProgressRate)
+                    .findFirst()
+                    .orElse(0);
+
+            totalProgressRate += chapterProgressRate;
+        }
+
+        return Math.min(100, (int) Math.floor(totalProgressRate / (double) chapters.size()));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminMileageService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminMileageService.java
@@ -1,0 +1,275 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.command.AdminMileageTransactionCommand;
+import com.kidmily.algoga_server.lms.application.result.AdminMileageHistoryResult;
+import com.kidmily.algoga_server.lms.application.result.AdminMileageSummaryResult;
+import com.kidmily.algoga_server.lms.application.result.AdminMileageUserResult;
+import com.kidmily.algoga_server.lms.application.usecase.AdminMileageUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.model.MileageHistory;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.MileageHistoryRepository;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminMileageService implements AdminMileageUseCase {
+
+    private final MileageHistoryRepository mileageHistoryRepository;
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public AdminMileageSummaryResult getMileageUsers() {
+        log.info("[Admin Mileage Query] 사용자별 마일리지 목록 조회 요청");
+
+        List<MileageHistory> histories = mileageHistoryRepository.findAll();
+
+        Set<Long> userIds = new LinkedHashSet<>();
+        for (MileageHistory history : histories) {
+            userIds.add(history.getUserId());
+        }
+
+        List<AdminMileageUserResult> users = userIds.stream()
+                .map(this::createUserResult)
+                .flatMap(Optional::stream)
+                .sorted(Comparator.comparing(AdminMileageUserResult::userId))
+                .toList();
+
+        int totalMileage = users.stream()
+                .mapToInt(AdminMileageUserResult::totalMileage)
+                .sum();
+
+        int totalEarnedMileage = users.stream()
+                .mapToInt(AdminMileageUserResult::totalEarnedMileage)
+                .sum();
+
+        int totalUsedMileage = users.stream()
+                .mapToInt(AdminMileageUserResult::totalUsedMileage)
+                .sum();
+
+        log.info("[Admin Mileage Query] 사용자별 마일리지 목록 조회 완료. userCount={}", users.size());
+
+        return new AdminMileageSummaryResult(
+                users.size(),
+                totalMileage,
+                totalEarnedMileage,
+                totalUsedMileage,
+                users
+        );
+    }
+
+    @Override
+    public List<AdminMileageHistoryResult> getUserMileageHistories(Long userId) {
+        log.info("[Admin Mileage Query] 사용자 마일리지 상세 조회 요청. userId={}", userId);
+
+        validateUser(userId);
+
+        List<AdminMileageHistoryResult> results = mileageHistoryRepository.findByUserId(userId)
+                .stream()
+                .map(this::toHistoryResult)
+                .toList();
+
+        log.info("[Admin Mileage Query] 사용자 마일리지 상세 조회 완료. userId={}, count={}",
+                userId, results.size());
+
+        return results;
+    }
+
+    @Override
+    @Transactional
+    public AdminMileageHistoryResult earnMileage(AdminMileageTransactionCommand command) {
+        log.info("[Admin Mileage Command] 마일리지 지급 요청. userId={}, managerId={}, amount={}",
+                command.userId(), command.managerId(), command.amount());
+
+        validateUser(command.userId());
+        validateAmount(command.amount());
+
+        MileageHistory history = MileageHistory.adminEarn(
+                command.userId(),
+                command.managerId(),
+                command.amount(),
+                command.reason()
+        );
+
+        MileageHistory savedHistory = mileageHistoryRepository.save(history);
+
+        log.info("[Admin Mileage Command] 마일리지 지급 완료. mileageHistoryId={}, userId={}, amount={}",
+                savedHistory.getId(), savedHistory.getUserId(), savedHistory.getAmount());
+
+        return toHistoryResult(savedHistory);
+    }
+
+    @Override
+    @Transactional
+    public AdminMileageHistoryResult useMileage(AdminMileageTransactionCommand command) {
+        log.info("[Admin Mileage Command] 마일리지 회수 요청. userId={}, managerId={}, amount={}",
+                command.userId(), command.managerId(), command.amount());
+
+        validateUser(command.userId());
+        validateAmount(command.amount());
+
+        int currentMileage = calculateCurrentMileage(command.userId());
+
+        if (currentMileage < command.amount()) {
+            log.warn("[Admin Mileage Command] 마일리지 회수 실패. 보유 마일리지 부족. userId={}, currentMileage={}, requestAmount={}",
+                    command.userId(), currentMileage, command.amount());
+            throw new LmsException(LmsErrorCode.NOT_ENOUGH_MILEAGE);
+        }
+
+        MileageHistory history = MileageHistory.adminUse(
+                command.userId(),
+                command.managerId(),
+                command.amount(),
+                command.reason()
+        );
+
+        MileageHistory savedHistory = mileageHistoryRepository.save(history);
+
+        log.info("[Admin Mileage Command] 마일리지 회수 완료. mileageHistoryId={}, userId={}, amount={}",
+                savedHistory.getId(), savedHistory.getUserId(), savedHistory.getAmount());
+
+        return toHistoryResult(savedHistory);
+    }
+
+    private Optional<AdminMileageUserResult> createUserResult(Long userId) {
+        Optional<User> optionalUser = userRepository.findById(userId);
+
+        if (optionalUser.isEmpty()) {
+            return Optional.empty();
+        }
+
+        User user = optionalUser.get();
+        List<MileageHistory> histories = mileageHistoryRepository.findByUserId(userId);
+
+        int totalEarnedMileage = histories.stream()
+                .filter(this::isEarnType)
+                .mapToInt(MileageHistory::getAmount)
+                .sum();
+
+        int totalUsedMileage = histories.stream()
+                .filter(this::isUseType)
+                .mapToInt(MileageHistory::getAmount)
+                .sum();
+
+        int totalMileage = totalEarnedMileage - totalUsedMileage;
+
+        LocalDateTime lastUpdatedAt = histories.stream()
+                .map(MileageHistory::getCreatedAt)
+                .max(LocalDateTime::compareTo)
+                .orElse(null);
+
+        return Optional.of(new AdminMileageUserResult(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                totalMileage,
+                totalEarnedMileage,
+                totalUsedMileage,
+                lastUpdatedAt
+        ));
+    }
+
+    private AdminMileageHistoryResult toHistoryResult(MileageHistory history) {
+        Optional<User> optionalUser = userRepository.findById(history.getUserId());
+
+        String userName = optionalUser
+                .map(User::getName)
+                .orElse(null);
+
+        String userEmail = optionalUser
+                .map(User::getEmail)
+                .orElse(null);
+
+        String courseTitle = findCourseTitle(history.getCourseId());
+
+        int signedAmount = isUseType(history)
+                ? history.getAmount() * -1
+                : history.getAmount();
+
+        String processorName = history.getManagerId() == null
+                ? "시스템"
+                : "관리자";
+
+        return new AdminMileageHistoryResult(
+                history.getId(),
+                history.getUserId(),
+                userName,
+                userEmail,
+                history.getCourseId(),
+                courseTitle,
+                history.getManagerId(),
+                processorName,
+                history.getAmount(),
+                signedAmount,
+                history.getType(),
+                history.getReason(),
+                history.getCreatedAt()
+        );
+    }
+
+    private String findCourseTitle(Long courseId) {
+        if (courseId == null) {
+            return null;
+        }
+
+        return courseRepository.findByIdAndDeletedFalse(courseId)
+                .map(Course::getTitle)
+                .orElse(null);
+    }
+
+    private int calculateCurrentMileage(Long userId) {
+        List<MileageHistory> histories = mileageHistoryRepository.findByUserId(userId);
+
+        int earned = histories.stream()
+                .filter(this::isEarnType)
+                .mapToInt(MileageHistory::getAmount)
+                .sum();
+
+        int used = histories.stream()
+                .filter(this::isUseType)
+                .mapToInt(MileageHistory::getAmount)
+                .sum();
+
+        return earned - used;
+    }
+
+    private boolean isEarnType(MileageHistory history) {
+        return "EARN".equalsIgnoreCase(history.getType());
+    }
+
+    private boolean isUseType(MileageHistory history) {
+        return "USE".equalsIgnoreCase(history.getType())
+                || "USED".equalsIgnoreCase(history.getType());
+    }
+
+    private void validateUser(Long userId) {
+        if (userRepository.findById(userId).isEmpty()) {
+            log.warn("[Admin Mileage] 마일리지 처리 실패. 사용자를 찾을 수 없습니다. userId={}", userId);
+            throw new LmsException(LmsErrorCode.MILEAGE_USER_NOT_FOUND);
+        }
+    }
+
+    private void validateAmount(int amount) {
+        if (amount <= 0) {
+            log.warn("[Admin Mileage] 마일리지 금액 검증 실패. amount={}", amount);
+            throw new LmsException(LmsErrorCode.INVALID_MILEAGE_AMOUNT);
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseQnaService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseQnaService.java
@@ -2,8 +2,12 @@ package com.kidmily.algoga_server.lms.application.service;
 
 import com.kidmily.algoga_server.lms.application.command.AnswerCourseQnaCommand;
 import com.kidmily.algoga_server.lms.application.command.CreateCourseQnaCommand;
+import com.kidmily.algoga_server.lms.application.command.CreateCourseQnaCommentCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseQnaDetailResult;
 import com.kidmily.algoga_server.lms.application.usecase.CourseQnaUseCase;
 import com.kidmily.algoga_server.lms.domain.model.CourseQna;
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
+import com.kidmily.algoga_server.lms.domain.repository.CourseQnaCommentRepository;
 import com.kidmily.algoga_server.lms.domain.repository.CourseQnaRepository;
 import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
@@ -23,6 +27,7 @@ public class CourseQnaService implements CourseQnaUseCase {
 
     private final CourseRepository courseRepository;
     private final CourseQnaRepository courseQnaRepository;
+    private final CourseQnaCommentRepository courseQnaCommentRepository;
 
     @Override
     @Transactional
@@ -62,6 +67,36 @@ public class CourseQnaService implements CourseQnaUseCase {
     }
 
     @Override
+    public CourseQnaDetailResult getQnaDetail(
+            Long courseId,
+            Long qnaId
+    ) {
+        log.info("[Course Q&A Query] Q&A 상세 조회 요청. courseId={}, qnaId={}", courseId, qnaId);
+
+        validateCourse(courseId);
+
+        CourseQna qna = findQna(courseId, qnaId);
+        List<CourseQnaComment> comments = courseQnaCommentRepository.findByQnaId(qnaId);
+
+        log.info("[Course Q&A Query] Q&A 상세 조회 완료. courseId={}, qnaId={}, commentCount={}",
+                courseId, qnaId, comments.size());
+
+        return new CourseQnaDetailResult(
+                qna.getId(),
+                qna.getCourseId(),
+                qna.getUserId(),
+                qna.getManagerId(),
+                qna.getTitle(),
+                qna.getQuestion(),
+                qna.getAnswer(),
+                qna.getStatus(),
+                qna.getCreatedAt(),
+                qna.getAnsweredAt(),
+                comments
+        );
+    }
+
+    @Override
     @Transactional
     public CourseQna answerQna(AnswerCourseQnaCommand command) {
         log.info("[Course Q&A Command] Q&A 답변 등록 요청. courseId={}, qnaId={}, managerId={}",
@@ -69,14 +104,7 @@ public class CourseQnaService implements CourseQnaUseCase {
 
         validateCourse(command.courseId());
 
-        CourseQna qna = courseQnaRepository.findByIdAndCourseId(
-                command.qnaId(),
-                command.courseId()
-        ).orElseThrow(() -> {
-            log.warn("[Course Q&A Command] Q&A 답변 실패. Q&A를 찾을 수 없습니다. courseId={}, qnaId={}",
-                    command.courseId(), command.qnaId());
-            return new LmsException(LmsErrorCode.QNA_NOT_FOUND);
-        });
+        CourseQna qna = findQna(command.courseId(), command.qnaId());
 
         if ("ANSWERED".equals(qna.getStatus())) {
             log.warn("[Course Q&A Command] Q&A 답변 실패. 이미 답변이 등록되었습니다. courseId={}, qnaId={}",
@@ -97,10 +125,55 @@ public class CourseQnaService implements CourseQnaUseCase {
         return savedQna;
     }
 
+    @Override
+    @Transactional
+    public CourseQnaComment createComment(CreateCourseQnaCommentCommand command) {
+        log.info("[Course Q&A Command] Q&A 댓글 등록 요청. courseId={}, qnaId={}, writerId={}, writerType={}",
+                command.courseId(), command.qnaId(), command.writerId(), command.writerType());
+
+        validateCourse(command.courseId());
+        findQna(command.courseId(), command.qnaId());
+
+        CourseQnaComment comment;
+
+        if ("MANAGER".equals(command.writerType())) {
+            comment = CourseQnaComment.createManagerComment(
+                    command.qnaId(),
+                    command.writerId(),
+                    command.content()
+            );
+        } else {
+            comment = CourseQnaComment.createUserComment(
+                    command.qnaId(),
+                    command.writerId(),
+                    command.content()
+            );
+        }
+
+        CourseQnaComment savedComment = courseQnaCommentRepository.save(comment);
+
+        log.info("[Course Q&A Command] Q&A 댓글 등록 완료. commentId={}, qnaId={}, writerType={}",
+                savedComment.getId(), savedComment.getQnaId(), savedComment.getWriterType());
+
+        return savedComment;
+    }
+
     private void validateCourse(Long courseId) {
         if (courseRepository.findByIdAndDeletedFalse(courseId).isEmpty()) {
             log.warn("[Course Q&A] Q&A 처리 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
             throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
         }
+    }
+
+    private CourseQna findQna(
+            Long courseId,
+            Long qnaId
+    ) {
+        return courseQnaRepository.findByIdAndCourseId(qnaId, courseId)
+                .orElseThrow(() -> {
+                    log.warn("[Course Q&A] Q&A 처리 실패. Q&A를 찾을 수 없습니다. courseId={}, qnaId={}",
+                            courseId, qnaId);
+                    return new LmsException(LmsErrorCode.QNA_NOT_FOUND);
+                });
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseReviewService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseReviewService.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.lms.application.service;
 
 import com.kidmily.algoga_server.lms.application.command.CreateCourseReviewCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseReviewSummaryResult;
 import com.kidmily.algoga_server.lms.application.usecase.CourseReviewUseCase;
 import com.kidmily.algoga_server.lms.domain.model.CourseReview;
 import com.kidmily.algoga_server.lms.domain.repository.CourseCompletionRepository;
@@ -71,6 +72,84 @@ public class CourseReviewService implements CourseReviewUseCase {
                 courseId, reviews.size());
 
         return reviews;
+    }
+
+    @Override
+    public CourseReviewSummaryResult getReviewSummary(Long courseId) {
+        log.info("[Course Review Query] 리뷰 요약 조회 요청. courseId={}", courseId);
+
+        validateCourse(courseId);
+
+        List<CourseReview> reviews = courseReviewRepository.findByCourseId(courseId);
+
+        int totalReviewCount = reviews.size();
+
+        int fiveStarCount = countByRating(reviews, 5);
+        int fourStarCount = countByRating(reviews, 4);
+        int threeStarCount = countByRating(reviews, 3);
+        int twoStarCount = countByRating(reviews, 2);
+        int oneStarCount = countByRating(reviews, 1);
+
+        double averageRating = calculateAverageRating(reviews);
+
+        CourseReviewSummaryResult result = new CourseReviewSummaryResult(
+                courseId,
+                averageRating,
+                totalReviewCount,
+                fiveStarCount,
+                fourStarCount,
+                threeStarCount,
+                twoStarCount,
+                oneStarCount,
+                calculateRate(fiveStarCount, totalReviewCount),
+                calculateRate(fourStarCount, totalReviewCount),
+                calculateRate(threeStarCount, totalReviewCount),
+                calculateRate(twoStarCount, totalReviewCount),
+                calculateRate(oneStarCount, totalReviewCount)
+        );
+
+        log.info("[Course Review Query] 리뷰 요약 조회 완료. courseId={}, totalReviewCount={}, averageRating={}",
+                courseId, result.totalReviewCount(), result.averageRating());
+
+        return result;
+    }
+
+    private int countByRating(
+            List<CourseReview> reviews,
+            int rating
+    ) {
+        return (int) reviews.stream()
+                .filter(review -> review.getRating() == rating)
+                .count();
+    }
+
+    private double calculateAverageRating(List<CourseReview> reviews) {
+        if (reviews.isEmpty()) {
+            return 0.0;
+        }
+
+        double average = reviews.stream()
+                .mapToInt(CourseReview::getRating)
+                .average()
+                .orElse(0.0);
+
+        return roundToOneDecimal(average);
+    }
+
+    private double calculateRate(
+            int count,
+            int total
+    ) {
+        if (total == 0) {
+            return 0.0;
+        }
+
+        double rate = (count * 100.0) / total;
+        return roundToOneDecimal(rate);
+    }
+
+    private double roundToOneDecimal(double value) {
+        return Math.round(value * 10.0) / 10.0;
     }
 
     private void validateCourse(Long courseId) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseRewardService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseRewardService.java
@@ -2,8 +2,19 @@ package com.kidmily.algoga_server.lms.application.service;
 
 import com.kidmily.algoga_server.lms.application.command.RewardCourseCommand;
 import com.kidmily.algoga_server.lms.application.usecase.CourseRewardUseCase;
-import com.kidmily.algoga_server.lms.domain.model.*;
-import com.kidmily.algoga_server.lms.domain.repository.*;
+import com.kidmily.algoga_server.lms.domain.model.CouponPolicy;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.model.CourseReward;
+import com.kidmily.algoga_server.lms.domain.model.MileageHistory;
+import com.kidmily.algoga_server.lms.domain.model.QuizSubmission;
+import com.kidmily.algoga_server.lms.domain.model.UserCoupon;
+import com.kidmily.algoga_server.lms.domain.repository.CouponPolicyRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseCompletionRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRewardRepository;
+import com.kidmily.algoga_server.lms.domain.repository.MileageHistoryRepository;
+import com.kidmily.algoga_server.lms.domain.repository.QuizSubmissionRepository;
+import com.kidmily.algoga_server.lms.domain.repository.UserCouponRepository;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.exception.LmsException;
 import lombok.RequiredArgsConstructor;
@@ -69,10 +80,11 @@ public class CourseRewardService implements CourseRewardUseCase {
         int mileageRate = calculateMileageRate(quizSubmission.getCorrectCount());
         int mileageAmount = calculateMileageAmount(course.getPrice(), mileageRate);
 
-        MileageHistory mileageHistory = MileageHistory.earnCourseReward(
+        MileageHistory mileageHistory = MileageHistory.earn(
                 command.userId(),
                 command.courseId(),
-                mileageAmount
+                mileageAmount,
+                "강의 이수 및 퀴즈 완료 보상"
         );
 
         MileageHistory savedMileageHistory = mileageHistoryRepository.save(mileageHistory);

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
@@ -28,6 +28,14 @@ public class CourseService implements CourseUseCase {
     }
 
     @Override
+    public List<Course> getRecommendedCoursesByCountryAndLevel(Long countryId, String level) {
+        validateCountry(countryId);
+        validateCourseLevel(level);
+
+        return courseRepository.findPublishedByCountryIdAndLevel(countryId, level);
+    }
+
+    @Override
     public long countPublishedCoursesByCountry(Long countryId) {
         validateCountry(countryId);
         return courseRepository.countPublishedByCountryId(countryId);
@@ -41,5 +49,13 @@ public class CourseService implements CourseUseCase {
     private void validateCountry(Long countryId) {
         mapRepository.findActiveCountryById(countryId)
                 .orElseThrow(() -> new LmsException(LmsErrorCode.COUNTRY_NOT_FOUND));
+    }
+
+    private void validateCourseLevel(String level) {
+        if (!"BEGINNER".equals(level)
+                && !"INTERMEDIATE".equals(level)
+                && !"ADVANCED".equals(level)) {
+            throw new LmsException(LmsErrorCode.INVALID_COURSE_LEVEL);
+        }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/MyBenefitService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/MyBenefitService.java
@@ -1,0 +1,161 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.result.MyCouponResult;
+import com.kidmily.algoga_server.lms.application.result.MyMileageHistoryResult;
+import com.kidmily.algoga_server.lms.application.result.MyMileageResult;
+import com.kidmily.algoga_server.lms.application.usecase.MyBenefitUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.model.MileageHistory;
+import com.kidmily.algoga_server.lms.domain.model.UserCoupon;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.MileageHistoryRepository;
+import com.kidmily.algoga_server.lms.domain.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyBenefitService implements MyBenefitUseCase {
+
+    private final UserCouponRepository userCouponRepository;
+    private final MileageHistoryRepository mileageHistoryRepository;
+    private final CourseRepository courseRepository;
+
+    @Override
+    public List<MyCouponResult> getMyCoupons(Long userId) {
+        log.info("[My Benefit Query] 내 쿠폰함 조회 요청. userId={}", userId);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        List<MyCouponResult> results = userCouponRepository.findByUserId(userId)
+                .stream()
+                .sorted(Comparator.comparing(UserCoupon::getIssuedAt).reversed())
+                .map(userCoupon -> toMyCouponResult(userCoupon, now))
+                .toList();
+
+        log.info("[My Benefit Query] 내 쿠폰함 조회 완료. userId={}, count={}", userId, results.size());
+
+        return results;
+    }
+
+    @Override
+    public MyMileageResult getMyMileages(Long userId) {
+        log.info("[My Benefit Query] 내 마일리지 내역 조회 요청. userId={}", userId);
+
+        List<MileageHistory> histories = mileageHistoryRepository.findByUserId(userId)
+                .stream()
+                .sorted(Comparator.comparing(MileageHistory::getCreatedAt).reversed())
+                .toList();
+
+        int totalEarnedMileage = histories.stream()
+                .filter(this::isEarnType)
+                .mapToInt(MileageHistory::getAmount)
+                .sum();
+
+        int totalUsedMileage = histories.stream()
+                .filter(this::isUseType)
+                .mapToInt(MileageHistory::getAmount)
+                .sum();
+
+        int totalMileage = totalEarnedMileage - totalUsedMileage;
+
+        List<MyMileageHistoryResult> historyResults = histories.stream()
+                .map(this::toMyMileageHistoryResult)
+                .toList();
+
+        log.info("[My Benefit Query] 내 마일리지 내역 조회 완료. userId={}, totalMileage={}, count={}",
+                userId, totalMileage, historyResults.size());
+
+        return new MyMileageResult(
+                totalMileage,
+                totalEarnedMileage,
+                totalUsedMileage,
+                historyResults
+        );
+    }
+
+    private MyCouponResult toMyCouponResult(
+            UserCoupon userCoupon,
+            LocalDateTime now
+    ) {
+        String courseTitle = findCourseTitle(userCoupon.getCourseId());
+
+        String status = resolveCouponStatus(userCoupon, now);
+        boolean usable = "ISSUED".equals(status);
+
+        return new MyCouponResult(
+                userCoupon.getId(),
+                userCoupon.getCourseId(),
+                courseTitle,
+                userCoupon.getCouponPolicyId(),
+                userCoupon.getCouponName(),
+                userCoupon.getDiscountType(),
+                userCoupon.getDiscountValue(),
+                status,
+                usable,
+                userCoupon.getIssuedAt(),
+                userCoupon.getExpiredAt(),
+                userCoupon.getUsedAt()
+        );
+    }
+
+    private MyMileageHistoryResult toMyMileageHistoryResult(MileageHistory mileageHistory) {
+        String courseTitle = findCourseTitle(mileageHistory.getCourseId());
+
+        return new MyMileageHistoryResult(
+                mileageHistory.getId(),
+                mileageHistory.getCourseId(),
+                courseTitle,
+                mileageHistory.getAmount(),
+                mileageHistory.getType(),
+                mileageHistory.getReason(),
+                mileageHistory.getCreatedAt()
+        );
+    }
+
+    private String findCourseTitle(Long courseId) {
+        if (courseId == null) {
+            return null;
+        }
+
+        return courseRepository.findByIdAndDeletedFalse(courseId)
+                .map(Course::getTitle)
+                .orElse(null);
+    }
+
+    private String resolveCouponStatus(
+            UserCoupon userCoupon,
+            LocalDateTime now
+    ) {
+        if ("USED".equalsIgnoreCase(userCoupon.getStatus())) {
+            return "USED";
+        }
+
+        if ("EXPIRED".equalsIgnoreCase(userCoupon.getStatus())) {
+            return "EXPIRED";
+        }
+
+        if (userCoupon.getExpiredAt() != null && userCoupon.getExpiredAt().isBefore(now)) {
+            return "EXPIRED";
+        }
+
+        return "ISSUED";
+    }
+
+    private boolean isEarnType(MileageHistory mileageHistory) {
+        return "EARN".equalsIgnoreCase(mileageHistory.getType());
+    }
+
+    private boolean isUseType(MileageHistory mileageHistory) {
+        return "USE".equalsIgnoreCase(mileageHistory.getType())
+                || "USED".equalsIgnoreCase(mileageHistory.getType());
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/MyCourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/MyCourseService.java
@@ -1,0 +1,155 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.result.MyCourseResult;
+import com.kidmily.algoga_server.lms.application.usecase.MyCourseUseCase;
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.domain.model.Country;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.model.CourseCompletion;
+import com.kidmily.algoga_server.lms.domain.model.LearningProgress;
+import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseCompletionRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseReviewRepository;
+import com.kidmily.algoga_server.lms.domain.repository.LearningProgressRepository;
+import com.kidmily.algoga_server.lms.domain.repository.MapRepository;
+import com.kidmily.algoga_server.lms.domain.repository.QuizSubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyCourseService implements MyCourseUseCase {
+
+    private final LearningProgressRepository learningProgressRepository;
+    private final CourseRepository courseRepository;
+    private final ChapterRepository chapterRepository;
+    private final CourseCompletionRepository courseCompletionRepository;
+    private final QuizSubmissionRepository quizSubmissionRepository;
+    private final CourseReviewRepository courseReviewRepository;
+    private final MapRepository mapRepository;
+
+    @Override
+    public List<MyCourseResult> getMyCourses(Long userId) {
+        log.info("[My Course Query] 내 수강 내역 조회 요청. userId={}", userId);
+
+        List<LearningProgress> allProgresses = learningProgressRepository.findByUserId(userId);
+
+        Set<Long> courseIds = new LinkedHashSet<>();
+
+        for (LearningProgress progress : allProgresses) {
+            courseIds.add(progress.getCourseId());
+        }
+
+        List<MyCourseResult> results = courseIds.stream()
+                .map(courseId -> createMyCourseResult(userId, courseId))
+                .flatMap(Optional::stream)
+                .toList();
+
+        log.info("[My Course Query] 내 수강 내역 조회 완료. userId={}, count={}", userId, results.size());
+
+        return results;
+    }
+
+    private Optional<MyCourseResult> createMyCourseResult(
+            Long userId,
+            Long courseId
+    ) {
+        Optional<Course> optionalCourse = courseRepository.findByIdAndDeletedFalse(courseId);
+
+        if (optionalCourse.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Course course = optionalCourse.get();
+
+        List<Chapter> chapters = chapterRepository.findByCourseId(courseId);
+        List<LearningProgress> progresses = learningProgressRepository.findByUserIdAndCourseId(userId, courseId);
+
+        int totalChapterCount = chapters.size();
+        int completedChapterCount = calculateCompletedChapterCount(progresses);
+        int progressRate = calculateCourseProgressRate(chapters, progresses);
+
+        Optional<CourseCompletion> optionalCompletion = courseCompletionRepository.findByUserIdAndCourseId(userId, courseId);
+
+        boolean completed = optionalCompletion.isPresent();
+        boolean quizSubmitted = quizSubmissionRepository.existsByUserIdAndCourseId(userId, courseId);
+        boolean reviewWritten = courseReviewRepository.existsByUserIdAndCourseIdAndDeletedFalse(userId, courseId);
+
+        String learningStatus = completed ? "COMPLETED" : "IN_PROGRESS";
+
+        String certificateCode = optionalCompletion
+                .map(CourseCompletion::getCertificateCode)
+                .orElse(null);
+
+        var completedAt = optionalCompletion
+                .map(CourseCompletion::getCompletedAt)
+                .orElse(null);
+
+        boolean certificateAvailable = completed;
+
+        String certificateDownloadUrl = completed
+                ? "/api/v1/courses/" + course.getId() + "/certificate"
+                : null;
+
+        String countryName = mapRepository.findActiveCountryById(course.getCountryId())
+                .map(Country::getName)
+                .orElse(null);
+
+        return Optional.of(new MyCourseResult(
+                course.getId(),
+                course.getTitle(),
+                course.getThumbnailUrl(),
+                course.getCountryId(),
+                countryName,
+                progressRate,
+                completedChapterCount,
+                totalChapterCount,
+                learningStatus,
+                quizSubmitted,
+                reviewWritten,
+                certificateAvailable,
+                certificateCode,
+                certificateDownloadUrl,
+                completedAt
+        ));
+    }
+
+    private int calculateCompletedChapterCount(List<LearningProgress> progresses) {
+        return (int) progresses.stream()
+                .filter(LearningProgress::isCompleted)
+                .count();
+    }
+
+    private int calculateCourseProgressRate(
+            List<Chapter> chapters,
+            List<LearningProgress> progresses
+    ) {
+        if (chapters.isEmpty()) {
+            return 0;
+        }
+
+        int totalProgressRate = 0;
+
+        for (Chapter chapter : chapters) {
+            int chapterProgressRate = progresses.stream()
+                    .filter(progress -> progress.getChapterId().equals(chapter.getId()))
+                    .map(LearningProgress::getProgressRate)
+                    .findFirst()
+                    .orElse(0);
+
+            totalProgressRate += chapterProgressRate;
+        }
+
+        return Math.min(100, (int) Math.floor(totalProgressRate / (double) chapters.size()));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminCourseStudentUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminCourseStudentUseCase.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.lms.application.usecase;
+
+import com.kidmily.algoga_server.lms.application.result.CourseStudentResult;
+
+import java.util.List;
+
+public interface AdminCourseStudentUseCase {
+
+    List<CourseStudentResult> getCourseStudents(Long courseId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminMileageUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/AdminMileageUseCase.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.lms.application.usecase;
+
+import com.kidmily.algoga_server.lms.application.command.AdminMileageTransactionCommand;
+import com.kidmily.algoga_server.lms.application.result.AdminMileageHistoryResult;
+import com.kidmily.algoga_server.lms.application.result.AdminMileageSummaryResult;
+
+import java.util.List;
+
+public interface AdminMileageUseCase {
+
+    AdminMileageSummaryResult getMileageUsers();
+
+    List<AdminMileageHistoryResult> getUserMileageHistories(Long userId);
+
+    AdminMileageHistoryResult earnMileage(AdminMileageTransactionCommand command);
+
+    AdminMileageHistoryResult useMileage(AdminMileageTransactionCommand command);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseQnaUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseQnaUseCase.java
@@ -2,7 +2,10 @@ package com.kidmily.algoga_server.lms.application.usecase;
 
 import com.kidmily.algoga_server.lms.application.command.AnswerCourseQnaCommand;
 import com.kidmily.algoga_server.lms.application.command.CreateCourseQnaCommand;
+import com.kidmily.algoga_server.lms.application.command.CreateCourseQnaCommentCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseQnaDetailResult;
 import com.kidmily.algoga_server.lms.domain.model.CourseQna;
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
 
 import java.util.List;
 
@@ -12,5 +15,9 @@ public interface CourseQnaUseCase {
 
     List<CourseQna> getQnas(Long courseId);
 
+    CourseQnaDetailResult getQnaDetail(Long courseId, Long qnaId);
+
     CourseQna answerQna(AnswerCourseQnaCommand command);
+
+    CourseQnaComment createComment(CreateCourseQnaCommentCommand command);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseReviewUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseReviewUseCase.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.lms.application.usecase;
 
 import com.kidmily.algoga_server.lms.application.command.CreateCourseReviewCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseReviewSummaryResult;
 import com.kidmily.algoga_server.lms.domain.model.CourseReview;
 
 import java.util.List;
@@ -10,4 +11,6 @@ public interface CourseReviewUseCase {
     CourseReview createReview(CreateCourseReviewCommand command);
 
     List<CourseReview> getReviews(Long courseId);
+
+    CourseReviewSummaryResult getReviewSummary(Long courseId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseUseCase.java
@@ -9,6 +9,8 @@ public interface CourseUseCase {
 
     List<Course> getPublishedCoursesByCountry(Long countryId);
 
+    List<Course> getRecommendedCoursesByCountryAndLevel(Long countryId, String level);
+
     long countPublishedCoursesByCountry(Long countryId);
 
     Map<Long, Long> countPublishedCoursesByCountryIds(List<Long> countryIds);

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/MyBenefitUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/MyBenefitUseCase.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.lms.application.usecase;
+
+import com.kidmily.algoga_server.lms.application.result.MyCouponResult;
+import com.kidmily.algoga_server.lms.application.result.MyMileageResult;
+
+import java.util.List;
+
+public interface MyBenefitUseCase {
+
+    List<MyCouponResult> getMyCoupons(Long userId);
+
+    MyMileageResult getMyMileages(Long userId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/MyCourseUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/MyCourseUseCase.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.lms.application.usecase;
+
+import com.kidmily.algoga_server.lms.application.result.MyCourseResult;
+
+import java.util.List;
+
+public interface MyCourseUseCase {
+
+    List<MyCourseResult> getMyCourses(Long userId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/Course.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/Course.java
@@ -13,6 +13,7 @@ public class Course {
     private Integer price;
     private String thumbnailUrl;
     private String fileUrl;
+    private String level;
     private String status;
     private boolean deleted;
     private List<Chapter> chapters;
@@ -26,6 +27,7 @@ public class Course {
             Integer price,
             String thumbnailUrl,
             String fileUrl,
+            String level,
             String status,
             boolean deleted,
             List<Chapter> chapters
@@ -38,6 +40,7 @@ public class Course {
         this.price = price;
         this.thumbnailUrl = thumbnailUrl;
         this.fileUrl = fileUrl;
+        this.level = level;
         this.status = status;
         this.deleted = deleted;
         this.chapters = chapters != null ? chapters : new ArrayList<>();
@@ -50,7 +53,8 @@ public class Course {
             String description,
             Integer price,
             String thumbnailUrl,
-            String fileUrl
+            String fileUrl,
+            String level
     ) {
         return new Course(
                 null,
@@ -61,6 +65,7 @@ public class Course {
                 price,
                 thumbnailUrl,
                 fileUrl,
+                level,
                 "DRAFT",
                 false,
                 new ArrayList<>()
@@ -76,6 +81,7 @@ public class Course {
             Integer price,
             String thumbnailUrl,
             String fileUrl,
+            String level,
             String status,
             List<Chapter> chapters
     ) {
@@ -88,6 +94,7 @@ public class Course {
                 price,
                 thumbnailUrl,
                 fileUrl,
+                level,
                 status,
                 false,
                 chapters
@@ -103,6 +110,7 @@ public class Course {
             Integer price,
             String thumbnailUrl,
             String fileUrl,
+            String level,
             String status,
             boolean deleted,
             List<Chapter> chapters
@@ -116,6 +124,7 @@ public class Course {
                 price,
                 thumbnailUrl,
                 fileUrl,
+                level,
                 status,
                 deleted,
                 chapters
@@ -164,6 +173,10 @@ public class Course {
 
     public String getFileUrl() {
         return fileUrl;
+    }
+
+    public String getLevel() {
+        return level;
     }
 
     public String getStatus() {

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/CourseQnaComment.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/CourseQnaComment.java
@@ -1,0 +1,136 @@
+package com.kidmily.algoga_server.lms.domain.model;
+
+import java.time.LocalDateTime;
+
+public class CourseQnaComment {
+
+    private final Long id;
+    private final Long qnaId;
+    private final Long userId;
+    private final Long managerId;
+    private final String writerType;
+    private final String content;
+    private final boolean deleted;
+    private final LocalDateTime createdAt;
+
+    private CourseQnaComment(
+            Long id,
+            Long qnaId,
+            Long userId,
+            Long managerId,
+            String writerType,
+            String content,
+            boolean deleted,
+            LocalDateTime createdAt
+    ) {
+        this.id = id;
+        this.qnaId = qnaId;
+        this.userId = userId;
+        this.managerId = managerId;
+        this.writerType = writerType;
+        this.content = content;
+        this.deleted = deleted;
+        this.createdAt = createdAt;
+    }
+
+    public static CourseQnaComment createUserComment(
+            Long qnaId,
+            Long userId,
+            String content
+    ) {
+        return new CourseQnaComment(
+                null,
+                qnaId,
+                userId,
+                null,
+                "USER",
+                content,
+                false,
+                LocalDateTime.now()
+        );
+    }
+
+    public static CourseQnaComment createManagerComment(
+            Long qnaId,
+            Long managerId,
+            String content
+    ) {
+        return new CourseQnaComment(
+                null,
+                qnaId,
+                null,
+                managerId,
+                "MANAGER",
+                content,
+                false,
+                LocalDateTime.now()
+        );
+    }
+
+    public static CourseQnaComment withId(
+            Long id,
+            Long qnaId,
+            Long userId,
+            Long managerId,
+            String writerType,
+            String content,
+            boolean deleted,
+            LocalDateTime createdAt
+    ) {
+        return new CourseQnaComment(
+                id,
+                qnaId,
+                userId,
+                managerId,
+                writerType,
+                content,
+                deleted,
+                createdAt
+        );
+    }
+
+    public CourseQnaComment delete() {
+        return new CourseQnaComment(
+                this.id,
+                this.qnaId,
+                this.userId,
+                this.managerId,
+                this.writerType,
+                this.content,
+                true,
+                this.createdAt
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getQnaId() {
+        return qnaId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getManagerId() {
+        return managerId;
+    }
+
+    public String getWriterType() {
+        return writerType;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/MileageHistory.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/MileageHistory.java
@@ -7,6 +7,7 @@ public class MileageHistory {
     private final Long id;
     private final Long userId;
     private final Long courseId;
+    private final Long managerId;
     private final int amount;
     private final String type;
     private final String reason;
@@ -16,6 +17,7 @@ public class MileageHistory {
             Long id,
             Long userId,
             Long courseId,
+            Long managerId,
             int amount,
             String type,
             String reason,
@@ -24,24 +26,82 @@ public class MileageHistory {
         this.id = id;
         this.userId = userId;
         this.courseId = courseId;
+        this.managerId = managerId;
         this.amount = amount;
         this.type = type;
         this.reason = reason;
         this.createdAt = createdAt;
     }
 
-    public static MileageHistory earnCourseReward(
+    public static MileageHistory create(
             Long userId,
             Long courseId,
-            int amount
+            int amount,
+            String type,
+            String reason
     ) {
         return new MileageHistory(
                 null,
                 userId,
                 courseId,
+                null,
+                amount,
+                type,
+                reason,
+                LocalDateTime.now()
+        );
+    }
+
+    public static MileageHistory earn(
+            Long userId,
+            Long courseId,
+            int amount,
+            String reason
+    ) {
+        return create(userId, courseId, amount, "EARN", reason);
+    }
+
+    public static MileageHistory use(
+            Long userId,
+            Long courseId,
+            int amount,
+            String reason
+    ) {
+        return create(userId, courseId, amount, "USE", reason);
+    }
+
+    public static MileageHistory adminEarn(
+            Long userId,
+            Long managerId,
+            int amount,
+            String reason
+    ) {
+        return new MileageHistory(
+                null,
+                userId,
+                null,
+                managerId,
                 amount,
                 "EARN",
-                "강의 이수 및 퀴즈 완료 보상",
+                reason,
+                LocalDateTime.now()
+        );
+    }
+
+    public static MileageHistory adminUse(
+            Long userId,
+            Long managerId,
+            int amount,
+            String reason
+    ) {
+        return new MileageHistory(
+                null,
+                userId,
+                null,
+                managerId,
+                amount,
+                "USE",
+                reason,
                 LocalDateTime.now()
         );
     }
@@ -50,6 +110,7 @@ public class MileageHistory {
             Long id,
             Long userId,
             Long courseId,
+            Long managerId,
             int amount,
             String type,
             String reason,
@@ -59,6 +120,7 @@ public class MileageHistory {
                 id,
                 userId,
                 courseId,
+                managerId,
                 amount,
                 type,
                 reason,
@@ -76,6 +138,10 @@ public class MileageHistory {
 
     public Long getCourseId() {
         return courseId;
+    }
+
+    public Long getManagerId() {
+        return managerId;
     }
 
     public int getAmount() {

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/ChapterRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/ChapterRepository.java
@@ -23,4 +23,14 @@ public interface ChapterRepository {
     );
 
     boolean softDelete(Long chapterId, Long courseId);
+
+    long countByCourseId(Long courseId);
+
+    boolean existsByCourseIdAndChapterOrder(Long courseId, int chapterOrder);
+
+    boolean existsByCourseIdAndChapterOrderAndIdNot(
+            Long courseId,
+            int chapterOrder,
+            Long chapterId
+    );
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseQnaCommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseQnaCommentRepository.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.lms.domain.repository;
+
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseQnaCommentRepository {
+
+    CourseQnaComment save(CourseQnaComment comment);
+
+    Optional<CourseQnaComment> findByIdAndQnaId(Long commentId, Long qnaId);
+
+    List<CourseQnaComment> findByQnaId(Long qnaId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
@@ -24,12 +24,15 @@ public interface CourseRepository {
             String description,
             Integer price,
             String thumbnailUrl,
-            String fileUrl
+            String fileUrl,
+            String level
     );
 
     boolean softDelete(Long courseId);
 
     List<Course> findPublishedByCountryId(Long countryId);
+
+    List<Course> findPublishedByCountryIdAndLevel(Long countryId, String level);
 
     long countPublishedByCountryId(Long countryId);
 

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/LearningProgressRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/LearningProgressRepository.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.lms.domain.repository;
 
 import com.kidmily.algoga_server.lms.domain.model.LearningProgress;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LearningProgressRepository {
@@ -9,6 +10,12 @@ public interface LearningProgressRepository {
     LearningProgress save(LearningProgress learningProgress);
 
     Optional<LearningProgress> findByUserIdAndChapterId(Long userId, Long chapterId);
+
+    List<LearningProgress> findByUserId(Long userId);
+
+    List<LearningProgress> findByUserIdAndCourseId(Long userId, Long courseId);
+
+    List<LearningProgress> findByCourseId(Long courseId);
 
     boolean existsCompletedByUserIdAndChapterId(Long userId, Long chapterId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/MileageHistoryRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/MileageHistoryRepository.java
@@ -3,15 +3,12 @@ package com.kidmily.algoga_server.lms.domain.repository;
 import com.kidmily.algoga_server.lms.domain.model.MileageHistory;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface MileageHistoryRepository {
 
     MileageHistory save(MileageHistory mileageHistory);
 
-    Optional<MileageHistory> findById(Long mileageHistoryId);
+    List<MileageHistory> findAll();
 
     List<MileageHistory> findByUserId(Long userId);
-
-    List<MileageHistory> findByUserIdAndCourseId(Long userId, Long courseId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
@@ -19,7 +19,7 @@ public enum LmsErrorCode implements BaseErrorCode {
     INVALID_CONTINENT_CODE(HttpStatus.BAD_REQUEST, "LMS_008", "유효하지 않은 대륙 코드입니다."),
     CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_009", "해당 챕터를 찾을 수 없습니다."),
     CHAPTER_VIDEO_REQUIRED(HttpStatus.BAD_REQUEST, "LMS_010", "챕터 영상 파일은 필수입니다."),
-    INVALID_CHAPTER_ORDER(HttpStatus.BAD_REQUEST, "LMS_011", "유효하지 않은 챕터 순서입니다."),
+    INVALID_CHAPTER_ORDER(HttpStatus.BAD_REQUEST, "LMS_011", "챕터 순서는 1부터 5 사이여야 합니다."),
     INVALID_QUIZ_OPTION(HttpStatus.BAD_REQUEST, "LMS_012", "퀴즈 보기는 4개 모두 입력해야 합니다."),
     INVALID_QUIZ_ANSWER(HttpStatus.BAD_REQUEST, "LMS_013", "퀴즈 정답 번호는 1부터 4 사이여야 합니다."),
     CHAPTER_LOCKED(HttpStatus.BAD_REQUEST, "LMS_014", "이전 강의를 먼저 완료해주세요."),
@@ -35,9 +35,15 @@ public enum LmsErrorCode implements BaseErrorCode {
     QNA_ALREADY_ANSWERED(HttpStatus.CONFLICT, "LMS_024", "이미 답변이 등록된 Q&A입니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_025", "해당 리뷰를 찾을 수 없습니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "LMS_026", "이미 해당 강의에 리뷰를 작성했습니다."),
-    INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "LMS_027", "리뷰 평점은 1점부터 5점 사이여야 합니다.");
-
-
+    INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "LMS_027", "리뷰 평점은 1점부터 5점 사이여야 합니다."),
+    QNA_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_028", "해당 Q&A 댓글을 찾을 수 없습니다."),
+    MILEAGE_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_029", "마일리지 대상 사용자를 찾을 수 없습니다."),
+    INVALID_MILEAGE_AMOUNT(HttpStatus.BAD_REQUEST, "LMS_030", "마일리지 금액은 1 이상이어야 합니다."),
+    NOT_ENOUGH_MILEAGE(HttpStatus.BAD_REQUEST, "LMS_031", "보유 마일리지가 부족합니다."),
+    CHAPTER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "LMS_032", "챕터는 최대 5개까지만 등록할 수 있습니다."),
+    DUPLICATED_CHAPTER_ORDER(HttpStatus.BAD_REQUEST, "LMS_033", "이미 사용 중인 챕터 순서입니다."),
+    INVALID_COURSE_LEVEL(HttpStatus.BAD_REQUEST, "LMS_034", "강의 난이도는 BEGINNER, INTERMEDIATE, ADVANCED 중 하나여야 합니다."),
+    NOT_ENROLLED(HttpStatus.FORBIDDEN, "LMS_035", "수강 등록된 강의가 아닙니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/mapper/CourseMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/mapper/CourseMapper.java
@@ -7,13 +7,12 @@ import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.CourseJpa
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 public class CourseMapper {
 
     public CourseJpaEntity toEntity(Course course) {
-        CourseJpaEntity courseEntity = new CourseJpaEntity(
+        return new CourseJpaEntity(
                 course.getCountryId(),
                 course.getManagerId(),
                 course.getTitle(),
@@ -21,34 +20,19 @@ public class CourseMapper {
                 course.getPrice(),
                 course.getThumbnailUrl(),
                 course.getFileUrl(),
+                course.getLevel(),
                 course.getStatus()
         );
-
-        if (course.getChapters() != null) {
-            course.getChapters().forEach(chapter -> {
-                ChapterJpaEntity chapterEntity = new ChapterJpaEntity(
-                        chapter.getTitle(),
-                        chapter.getVideoUrl(),
-                        chapter.getDurationSeconds(),
-                        chapter.getChapterOrder()
-                );
-                courseEntity.getChapters().add(chapterEntity);
-            });
-        }
-
-        return courseEntity;
     }
 
     public Course toDomain(CourseJpaEntity entity) {
-        List<Chapter> chapters = entity.getChapters().stream()
-                .map(chEntity -> Chapter.withId(
-                        chEntity.getId(),
-                        chEntity.getTitle(),
-                        chEntity.getVideoUrl(),
-                        chEntity.getDurationSeconds(),
-                        chEntity.getOrderNum()
-                ))
-                .collect(Collectors.toList());
+        List<Chapter> chapters = entity.getChapters() == null
+                ? List.of()
+                : entity.getChapters()
+                .stream()
+                .filter(chapter -> !chapter.isDeleted())
+                .map(this::toChapterDomain)
+                .toList();
 
         return Course.withId(
                 entity.getId(),
@@ -59,9 +43,22 @@ public class CourseMapper {
                 entity.getPrice(),
                 entity.getThumbnailUrl(),
                 entity.getFileUrl(),
+                entity.getLevel(),
                 entity.getStatus(),
                 entity.isDeleted(),
                 chapters
+        );
+    }
+
+    private Chapter toChapterDomain(ChapterJpaEntity entity) {
+        return Chapter.withId(
+                entity.getId(),
+                entity.getCourseId(),
+                entity.getTitle(),
+                entity.getVideoUrl(),
+                entity.getDurationSeconds(),
+                entity.getOrderNum(),
+                entity.isDeleted()
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/ChapterRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/ChapterRepositoryAdapter.java
@@ -77,6 +77,32 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
                 .orElse(false);
     }
 
+    @Override
+    public long countByCourseId(Long courseId) {
+        return springDataChapterRepository.countByCourseIdAndDeletedFalse(courseId);
+    }
+
+    @Override
+    public boolean existsByCourseIdAndChapterOrder(Long courseId, int chapterOrder) {
+        return springDataChapterRepository.existsByCourseIdAndOrderNumAndDeletedFalse(
+                courseId,
+                chapterOrder
+        );
+    }
+
+    @Override
+    public boolean existsByCourseIdAndChapterOrderAndIdNot(
+            Long courseId,
+            int chapterOrder,
+            Long chapterId
+    ) {
+        return springDataChapterRepository.existsByCourseIdAndOrderNumAndIdNotAndDeletedFalse(
+                courseId,
+                chapterOrder,
+                chapterId
+        );
+    }
+
     private Chapter toDomain(ChapterJpaEntity entity) {
         return Chapter.withId(
                 entity.getId(),

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseQnaCommentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseQnaCommentRepositoryAdapter.java
@@ -1,0 +1,75 @@
+package com.kidmily.algoga_server.lms.infrastructure.persistence.adapter;
+
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
+import com.kidmily.algoga_server.lms.domain.repository.CourseQnaCommentRepository;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.CourseQnaCommentJpaEntity;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.SpringDataCourseQnaCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CourseQnaCommentRepositoryAdapter implements CourseQnaCommentRepository {
+
+    private final SpringDataCourseQnaCommentRepository springDataCourseQnaCommentRepository;
+
+    @Override
+    public CourseQnaComment save(CourseQnaComment comment) {
+        CourseQnaCommentJpaEntity entity = springDataCourseQnaCommentRepository.findById(
+                        comment.getId() == null ? -1L : comment.getId()
+                )
+                .map(existingEntity -> {
+                    if (comment.isDeleted()) {
+                        existingEntity.softDelete();
+                    }
+
+                    return existingEntity;
+                })
+                .orElseGet(() -> new CourseQnaCommentJpaEntity(
+                        comment.getQnaId(),
+                        comment.getUserId(),
+                        comment.getManagerId(),
+                        comment.getWriterType(),
+                        comment.getContent(),
+                        comment.isDeleted(),
+                        comment.getCreatedAt()
+                ));
+
+        CourseQnaCommentJpaEntity savedEntity = springDataCourseQnaCommentRepository.save(entity);
+
+        return toDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<CourseQnaComment> findByIdAndQnaId(
+            Long commentId,
+            Long qnaId
+    ) {
+        return springDataCourseQnaCommentRepository.findByIdAndQnaId(commentId, qnaId)
+                .map(this::toDomain);
+    }
+
+    @Override
+    public List<CourseQnaComment> findByQnaId(Long qnaId) {
+        return springDataCourseQnaCommentRepository.findByQnaIdAndDeletedFalseOrderByCreatedAtAsc(qnaId)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    private CourseQnaComment toDomain(CourseQnaCommentJpaEntity entity) {
+        return CourseQnaComment.withId(
+                entity.getId(),
+                entity.getQnaId(),
+                entity.getUserId(),
+                entity.getManagerId(),
+                entity.getWriterType(),
+                entity.getContent(),
+                entity.isDeleted(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
@@ -62,11 +62,12 @@ public class CourseRepositoryAdapter implements CourseRepository {
             String description,
             Integer price,
             String thumbnailUrl,
-            String fileUrl
+            String fileUrl,
+            String level
     ) {
         return springDataCourseRepository.findByIdAndDeletedFalse(courseId)
                 .map(entity -> {
-                    entity.updateBasicInfo(title, description, price, thumbnailUrl, fileUrl);
+                    entity.updateBasicInfo(title, description, price, thumbnailUrl, fileUrl, level);
                     return courseMapper.toDomain(entity);
                 });
     }
@@ -85,6 +86,19 @@ public class CourseRepositoryAdapter implements CourseRepository {
     public List<Course> findPublishedByCountryId(Long countryId) {
         return springDataCourseRepository
                 .findByCountryIdAndStatusAndDeletedFalseOrderByIdDesc(countryId, PUBLISHED)
+                .stream()
+                .map(courseMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Course> findPublishedByCountryIdAndLevel(Long countryId, String level) {
+        return springDataCourseRepository
+                .findByCountryIdAndLevelAndStatusAndDeletedFalseOrderByIdDesc(
+                        countryId,
+                        level,
+                        PUBLISHED
+                )
                 .stream()
                 .map(courseMapper::toDomain)
                 .toList();

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/LearningProgressRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/LearningProgressRepositoryAdapter.java
@@ -7,6 +7,7 @@ import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.Sprin
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -51,6 +52,33 @@ public class LearningProgressRepositoryAdapter implements LearningProgressReposi
     ) {
         return springDataLearningProgressRepository.findByUserIdAndChapterId(userId, chapterId)
                 .map(this::toDomain);
+    }
+
+    @Override
+    public List<LearningProgress> findByUserId(Long userId) {
+        return springDataLearningProgressRepository.findByUserId(userId)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<LearningProgress> findByUserIdAndCourseId(
+            Long userId,
+            Long courseId
+    ) {
+        return springDataLearningProgressRepository.findByUserIdAndCourseId(userId, courseId)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<LearningProgress> findByCourseId(Long courseId) {
+        return springDataLearningProgressRepository.findByCourseId(courseId)
+                .stream()
+                .map(this::toDomain)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/MileageHistoryRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/MileageHistoryRepositoryAdapter.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,6 +20,7 @@ public class MileageHistoryRepositoryAdapter implements MileageHistoryRepository
         MileageHistoryJpaEntity entity = new MileageHistoryJpaEntity(
                 mileageHistory.getUserId(),
                 mileageHistory.getCourseId(),
+                mileageHistory.getManagerId(),
                 mileageHistory.getAmount(),
                 mileageHistory.getType(),
                 mileageHistory.getReason(),
@@ -33,25 +33,16 @@ public class MileageHistoryRepositoryAdapter implements MileageHistoryRepository
     }
 
     @Override
-    public Optional<MileageHistory> findById(Long mileageHistoryId) {
-        return springDataMileageHistoryRepository.findById(mileageHistoryId)
-                .map(this::toDomain);
-    }
-
-    @Override
-    public List<MileageHistory> findByUserId(Long userId) {
-        return springDataMileageHistoryRepository.findByUserId(userId)
+    public List<MileageHistory> findAll() {
+        return springDataMileageHistoryRepository.findAllByOrderByCreatedAtDesc()
                 .stream()
                 .map(this::toDomain)
                 .toList();
     }
 
     @Override
-    public List<MileageHistory> findByUserIdAndCourseId(
-            Long userId,
-            Long courseId
-    ) {
-        return springDataMileageHistoryRepository.findByUserIdAndCourseId(userId, courseId)
+    public List<MileageHistory> findByUserId(Long userId) {
+        return springDataMileageHistoryRepository.findByUserIdOrderByCreatedAtDesc(userId)
                 .stream()
                 .map(this::toDomain)
                 .toList();
@@ -62,6 +53,7 @@ public class MileageHistoryRepositoryAdapter implements MileageHistoryRepository
                 entity.getId(),
                 entity.getUserId(),
                 entity.getCourseId(),
+                entity.getManagerId(),
                 entity.getAmount(),
                 entity.getType(),
                 entity.getReason(),

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseJpaEntity.java
@@ -44,6 +44,9 @@ public class CourseJpaEntity {
     @Column(name = "file_url", length = 500)
     private String fileUrl;
 
+    @Column(name = "level", nullable = false, length = 30)
+    private String level;
+
     @Column(nullable = false, length = 30)
     private String status;
 
@@ -70,6 +73,7 @@ public class CourseJpaEntity {
             Integer price,
             String thumbnailUrl,
             String fileUrl,
+            String level,
             String status
     ) {
         this.countryId = countryId;
@@ -79,6 +83,7 @@ public class CourseJpaEntity {
         this.price = price;
         this.thumbnailUrl = thumbnailUrl;
         this.fileUrl = fileUrl;
+        this.level = level;
         this.status = status;
         this.deleted = false;
     }
@@ -88,11 +93,13 @@ public class CourseJpaEntity {
             String description,
             Integer price,
             String thumbnailUrl,
-            String fileUrl
+            String fileUrl,
+            String level
     ) {
         this.title = title;
         this.description = description;
         this.price = price;
+        this.level = level;
 
         if (thumbnailUrl != null) {
             this.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseQnaCommentJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseQnaCommentJpaEntity.java
@@ -1,0 +1,64 @@
+package com.kidmily.algoga_server.lms.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "course_qna_comments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseQnaCommentJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(name = "qna_id", nullable = false)
+    private Long qnaId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "manager_id")
+    private Long managerId;
+
+    @Column(name = "writer_type", nullable = false, length = 20)
+    private String writerType;
+
+    @Lob
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted = false;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public CourseQnaCommentJpaEntity(
+            Long qnaId,
+            Long userId,
+            Long managerId,
+            String writerType,
+            String content,
+            boolean deleted,
+            LocalDateTime createdAt
+    ) {
+        this.qnaId = qnaId;
+        this.userId = userId;
+        this.managerId = managerId;
+        this.writerType = writerType;
+        this.content = content;
+        this.deleted = deleted;
+        this.createdAt = createdAt;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/MileageHistoryJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/MileageHistoryJpaEntity.java
@@ -21,8 +21,11 @@ public class MileageHistoryJpaEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "lecture_id", nullable = false)
+    @Column(name = "course_id")
     private Long courseId;
+
+    @Column(name = "manager_id")
+    private Long managerId;
 
     @Column(name = "amount", nullable = false)
     private int amount;
@@ -30,7 +33,7 @@ public class MileageHistoryJpaEntity {
     @Column(name = "type", nullable = false, length = 20)
     private String type;
 
-    @Column(name = "reason", nullable = false, length = 255)
+    @Column(name = "reason", nullable = false)
     private String reason;
 
     @Column(name = "created_at", nullable = false)
@@ -39,6 +42,7 @@ public class MileageHistoryJpaEntity {
     public MileageHistoryJpaEntity(
             Long userId,
             Long courseId,
+            Long managerId,
             int amount,
             String type,
             String reason,
@@ -46,6 +50,7 @@ public class MileageHistoryJpaEntity {
     ) {
         this.userId = userId;
         this.courseId = courseId;
+        this.managerId = managerId;
         this.amount = amount;
         this.type = type;
         this.reason = reason;

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataChapterRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataChapterRepository.java
@@ -11,4 +11,14 @@ public interface SpringDataChapterRepository extends JpaRepository<ChapterJpaEnt
     List<ChapterJpaEntity> findByCourseIdAndDeletedFalseOrderByOrderNumAsc(Long courseId);
 
     Optional<ChapterJpaEntity> findByIdAndCourseIdAndDeletedFalse(Long id, Long courseId);
+
+    long countByCourseIdAndDeletedFalse(Long courseId);
+
+    boolean existsByCourseIdAndOrderNumAndDeletedFalse(Long courseId, int orderNum);
+
+    boolean existsByCourseIdAndOrderNumAndIdNotAndDeletedFalse(
+            Long courseId,
+            int orderNum,
+            Long id
+    );
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseQnaCommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseQnaCommentRepository.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.lms.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.CourseQnaCommentJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringDataCourseQnaCommentRepository extends JpaRepository<CourseQnaCommentJpaEntity, Long> {
+
+    Optional<CourseQnaCommentJpaEntity> findByIdAndQnaId(Long id, Long qnaId);
+
+    List<CourseQnaCommentJpaEntity> findByQnaIdAndDeletedFalseOrderByCreatedAtAsc(Long qnaId);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseRepository.java
@@ -21,6 +21,12 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
             String status
     );
 
+    List<CourseJpaEntity> findByCountryIdAndLevelAndStatusAndDeletedFalseOrderByIdDesc(
+            Long countryId,
+            String level,
+            String status
+    );
+
     long countByCountryIdAndStatusAndDeletedFalse(
             Long countryId,
             String status

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataLearningProgressRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataLearningProgressRepository.java
@@ -3,11 +3,18 @@ package com.kidmily.algoga_server.lms.infrastructure.persistence.repository;
 import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.LearningProgressJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpringDataLearningProgressRepository extends JpaRepository<LearningProgressJpaEntity, Long> {
 
     Optional<LearningProgressJpaEntity> findByUserIdAndChapterId(Long userId, Long chapterId);
+
+    List<LearningProgressJpaEntity> findByUserId(Long userId);
+
+    List<LearningProgressJpaEntity> findByUserIdAndCourseId(Long userId, Long courseId);
+
+    List<LearningProgressJpaEntity> findByCourseId(Long courseId);
 
     boolean existsByUserIdAndChapterIdAndCompletedTrue(Long userId, Long chapterId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataMileageHistoryRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataMileageHistoryRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface SpringDataMileageHistoryRepository extends JpaRepository<MileageHistoryJpaEntity, Long> {
 
-    List<MileageHistoryJpaEntity> findByUserId(Long userId);
+    List<MileageHistoryJpaEntity> findAllByOrderByCreatedAtDesc();
 
-    List<MileageHistoryJpaEntity> findByUserIdAndCourseId(Long userId, Long courseId);
+    List<MileageHistoryJpaEntity> findByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseQnaController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseQnaController.java
@@ -3,13 +3,17 @@ package com.kidmily.algoga_server.lms.presentation.api;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
-import com.kidmily.algoga_server.lms.application.command.AnswerCourseQnaCommand;
 import com.kidmily.algoga_server.lms.application.command.CreateCourseQnaCommand;
+import com.kidmily.algoga_server.lms.application.command.CreateCourseQnaCommentCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseQnaDetailResult;
 import com.kidmily.algoga_server.lms.application.usecase.CourseQnaUseCase;
 import com.kidmily.algoga_server.lms.domain.model.CourseQna;
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
-import com.kidmily.algoga_server.lms.presentation.request.AnswerCourseQnaRequest;
+import com.kidmily.algoga_server.lms.presentation.request.CreateCourseQnaCommentRequest;
 import com.kidmily.algoga_server.lms.presentation.request.CreateCourseQnaRequest;
+import com.kidmily.algoga_server.lms.presentation.response.CourseQnaCommentResponse;
+import com.kidmily.algoga_server.lms.presentation.response.CourseQnaDetailResponse;
 import com.kidmily.algoga_server.lms.presentation.response.CourseQnaResponse;
 import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,7 +28,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "강의 Q&A", description = "강의 Q&A 등록, 조회, 답변 API")
+@Tag(name = "강의 Q&A", description = "강의 Q&A 등록, 조회, 상세, 댓글 API")
 @RestController
 @RequestMapping("/api/v1/courses/{courseId}/qnas")
 @RequiredArgsConstructor
@@ -91,42 +95,70 @@ public class CourseQnaController {
     }
 
     @Operation(
-            summary = "강의 Q&A 답변 등록",
-            description = "콘텐츠 매니저가 특정 Q&A에 답변을 등록합니다."
+            summary = "강의 Q&A 상세 조회",
+            description = "특정 Q&A의 질문, 답변, 댓글 목록을 조회합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "COURSE_NOT_FOUND",
+            "QNA_NOT_FOUND"
+    })
+    @GetMapping("/{qnaId}")
+    public ResponseEntity<ApiResponse<CourseQnaDetailResponse>> getQnaDetail(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "Q&A ID", example = "1")
+            @PathVariable Long qnaId
+    ) {
+        CourseQnaDetailResult result = courseQnaUseCase.getQnaDetail(courseId, qnaId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COURSE_QNA_FOUND",
+                        "Q&A 상세 조회에 성공했습니다.",
+                        CourseQnaDetailResponse.from(result)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "강의 Q&A 사용자 댓글 등록",
+            description = "로그인한 사용자가 특정 Q&A에 댓글을 등록합니다."
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
             "COURSE_NOT_FOUND",
-            "QNA_NOT_FOUND",
-            "QNA_ALREADY_ANSWERED"
+            "QNA_NOT_FOUND"
     })
-    @PostMapping("/{qnaId}/answer")
-    public ResponseEntity<ApiResponse<CourseQnaResponse>> answerQna(
+    @PostMapping("/{qnaId}/comments")
+    public ResponseEntity<ApiResponse<CourseQnaCommentResponse>> createUserComment(
             @Parameter(description = "강의 ID", example = "3")
             @PathVariable Long courseId,
 
             @Parameter(description = "Q&A ID", example = "1")
             @PathVariable Long qnaId,
 
-            @Valid @RequestBody AnswerCourseQnaRequest request
-    ) {
-        Long currentManagerId = 1L;
+            @Valid @RequestBody CreateCourseQnaCommentRequest request,
 
-        AnswerCourseQnaCommand command = new AnswerCourseQnaCommand(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails.getUser().getId();
+
+        CreateCourseQnaCommentCommand command = new CreateCourseQnaCommentCommand(
                 courseId,
                 qnaId,
-                currentManagerId,
-                request.answer()
+                currentUserId,
+                "USER",
+                request.content()
         );
 
-        CourseQna qna = courseQnaUseCase.answerQna(command);
+        CourseQnaComment comment = courseQnaUseCase.createComment(command);
 
-        return ResponseEntity.ok(
-                ApiResponse.success(
-                        "COURSE_QNA_ANSWERED",
-                        "Q&A 답변 등록에 성공했습니다.",
-                        CourseQnaResponse.from(qna)
-                )
-        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        "COURSE_QNA_COMMENT_CREATED",
+                        "Q&A 댓글 등록에 성공했습니다.",
+                        CourseQnaCommentResponse.from(comment)
+                ));
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseReviewController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseReviewController.java
@@ -4,11 +4,13 @@ import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
 import com.kidmily.algoga_server.lms.application.command.CreateCourseReviewCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseReviewSummaryResult;
 import com.kidmily.algoga_server.lms.application.usecase.CourseReviewUseCase;
 import com.kidmily.algoga_server.lms.domain.model.CourseReview;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.presentation.request.CreateCourseReviewRequest;
 import com.kidmily.algoga_server.lms.presentation.response.CourseReviewResponse;
+import com.kidmily.algoga_server.lms.presentation.response.CourseReviewSummaryResponse;
 import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "강의 리뷰", description = "강의 리뷰 등록 및 조회 API")
+@Tag(name = "강의 리뷰", description = "강의 리뷰 등록, 조회, 요약 API")
 @RestController
 @RequestMapping("/api/v1/courses/{courseId}/reviews")
 @RequiredArgsConstructor
@@ -89,6 +91,27 @@ public class CourseReviewController {
                         "COURSE_REVIEWS_FOUND",
                         "리뷰 목록 조회에 성공했습니다.",
                         response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "강의 리뷰 요약 조회",
+            description = "특정 강의의 평균 평점, 전체 리뷰 수, 별점별 리뷰 수와 비율을 조회합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResponse<CourseReviewSummaryResponse>> getReviewSummary(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId
+    ) {
+        CourseReviewSummaryResult result = courseReviewUseCase.getReviewSummary(courseId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COURSE_REVIEW_SUMMARY_FOUND",
+                        "리뷰 요약 조회에 성공했습니다.",
+                        CourseReviewSummaryResponse.from(result)
                 )
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/DiagnosisController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/DiagnosisController.java
@@ -1,0 +1,118 @@
+package com.kidmily.algoga_server.lms.presentation.api;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.lms.application.usecase.CourseUseCase;
+import com.kidmily.algoga_server.lms.presentation.request.DiagnosisResultRequest;
+import com.kidmily.algoga_server.lms.presentation.response.CourseListResponse;
+import com.kidmily.algoga_server.lms.presentation.response.DiagnosisResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Diagnosis", description = "진단평가 추천 API")
+@RestController
+@RequestMapping("/api/v1/diagnosis")
+@RequiredArgsConstructor
+public class DiagnosisController {
+
+    private final CourseUseCase courseUseCase;
+
+    @Operation(
+            summary = "진단평가 나라/level별 추천 강의 조회",
+            description = "사용자가 선택한 나라와 진단평가 결과 level에 맞는 공개 강의 목록을 추천합니다."
+    )
+    @GetMapping("/recommendations")
+    public ResponseEntity<ApiResponse<List<CourseListResponse>>> getRecommendedCourses(
+            @RequestParam Long countryId,
+            @RequestParam String level
+    ) {
+        List<CourseListResponse> response = courseUseCase
+                .getRecommendedCoursesByCountryAndLevel(countryId, level)
+                .stream()
+                .map(CourseListResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "DIAGNOSIS_RECOMMENDED_COURSES_FOUND",
+                        "진단평가 추천 강의 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "진단평가 결과 계산 및 추천 강의 조회",
+            description = "정답 개수와 전체 문항 수로 level을 계산하고, 선택한 나라의 해당 level 강의를 추천합니다."
+    )
+    @PostMapping("/result")
+    public ResponseEntity<ApiResponse<DiagnosisResultResponse>> getDiagnosisResult(
+            @Valid @RequestBody DiagnosisResultRequest request
+    ) {
+        validateCorrectCount(request.correctCount(), request.totalCount());
+
+        int score = calculateScore(request.correctCount(), request.totalCount());
+        String level = calculateLevel(score);
+        String levelName = toLevelName(level);
+
+        List<CourseListResponse> recommendedCourses = courseUseCase
+                .getRecommendedCoursesByCountryAndLevel(request.countryId(), level)
+                .stream()
+                .map(CourseListResponse::from)
+                .toList();
+
+        DiagnosisResultResponse response = new DiagnosisResultResponse(
+                request.countryId(),
+                request.correctCount(),
+                request.totalCount(),
+                score,
+                level,
+                levelName,
+                recommendedCourses
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "DIAGNOSIS_RESULT_FOUND",
+                        "진단평가 결과 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+
+    private void validateCorrectCount(Integer correctCount, Integer totalCount) {
+        if (correctCount > totalCount) {
+            throw new IllegalArgumentException("정답 개수는 전체 문항 수보다 클 수 없습니다.");
+        }
+    }
+
+    private int calculateScore(Integer correctCount, Integer totalCount) {
+        return correctCount * 100 / totalCount;
+    }
+
+    private String calculateLevel(int score) {
+        if (score <= 40) {
+            return "BEGINNER";
+        }
+
+        if (score <= 70) {
+            return "INTERMEDIATE";
+        }
+
+        return "ADVANCED";
+    }
+
+    private String toLevelName(String level) {
+        return switch (level) {
+            case "BEGINNER" -> "초급";
+            case "INTERMEDIATE" -> "중급";
+            case "ADVANCED" -> "고급";
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyBenefitController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyBenefitController.java
@@ -1,0 +1,71 @@
+package com.kidmily.algoga_server.lms.presentation.api;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.lms.application.usecase.MyBenefitUseCase;
+import com.kidmily.algoga_server.lms.presentation.response.MyCouponResponse;
+import com.kidmily.algoga_server.lms.presentation.response.MyMileageResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "마이페이지 혜택", description = "마이페이지 쿠폰함, 마일리지 내역 조회 API")
+@RestController
+@RequestMapping("/api/v1/my")
+@RequiredArgsConstructor
+public class MyBenefitController {
+
+    private final MyBenefitUseCase myBenefitUseCase;
+
+    @Operation(
+            summary = "내 쿠폰함 조회",
+            description = "로그인한 사용자가 보유한 쿠폰 목록을 조회합니다."
+    )
+    @GetMapping("/coupons")
+    public ResponseEntity<ApiResponse<List<MyCouponResponse>>> getMyCoupons(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails.getUser().getId();
+
+        List<MyCouponResponse> response = myBenefitUseCase.getMyCoupons(currentUserId)
+                .stream()
+                .map(MyCouponResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "MY_COUPONS_FOUND",
+                        "내 쿠폰함 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "내 마일리지 내역 조회",
+            description = "로그인한 사용자의 현재 보유 마일리지와 마일리지 적립/사용 내역을 조회합니다."
+    )
+    @GetMapping("/mileages")
+    public ResponseEntity<ApiResponse<MyMileageResponse>> getMyMileages(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails.getUser().getId();
+
+        MyMileageResponse response = MyMileageResponse.from(
+                myBenefitUseCase.getMyMileages(currentUserId)
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "MY_MILEAGES_FOUND",
+                        "내 마일리지 내역 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
@@ -1,0 +1,50 @@
+package com.kidmily.algoga_server.lms.presentation.api;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.lms.application.usecase.MyCourseUseCase;
+import com.kidmily.algoga_server.lms.presentation.response.MyCourseResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "마이페이지 수강 내역", description = "마이페이지 수강 강의 조회 API")
+@RestController
+@RequestMapping("/api/v1/my/courses")
+@RequiredArgsConstructor
+public class MyCourseController {
+
+    private final MyCourseUseCase myCourseUseCase;
+
+    @Operation(
+            summary = "내 수강 강의 목록 조회",
+            description = """
+                    로그인한 사용자가 진도율을 기록한 강의 목록을 조회합니다.
+                    결제 기능은 제외하고, learning_progresses 기록 기준으로 수강 내역을 구성합니다.
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MyCourseResponse>>> getMyCourses(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails.getUser().getId();
+
+        List<MyCourseResponse> response = myCourseUseCase.getMyCourses(currentUserId)
+                .stream()
+                .map(MyCourseResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "MY_COURSES_FOUND",
+                        "내 수강 강의 목록 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
@@ -20,14 +20,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Tag(name = "챕터 관리", description = "콘텐츠 매니저 챕터 관리 API")
+@Tag(name = "Admin Chapter", description = "콘텐츠 매니저 챕터 관리 API")
 @RestController
-@RequestMapping("/api/v1/courses/{courseId}/chapters")
+@RequestMapping("/api/v1/admin/courses/{courseId}/chapters")
 @RequiredArgsConstructor
 public class AdminChapterController {
 
@@ -36,9 +37,10 @@ public class AdminChapterController {
 
     @Operation(
             summary = "챕터 목록 조회",
-            description = "특정 강의에 등록된 챕터 목록을 노출 순서대로 조회합니다."
+            description = "특정 강의에 등록된 챕터 목록을 조회합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<List<AdminChapterResponse>>> getChapters(
             @Parameter(description = "강의 ID", example = "1")
@@ -60,10 +62,16 @@ public class AdminChapterController {
 
     @Operation(
             summary = "챕터 등록",
-            description = "특정 강의에 챕터 영상과 기본 정보를 등록합니다. 영상 파일은 필수입니다."
+            description = "콘텐츠 매니저가 특정 강의에 챕터를 등록합니다."
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
-    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "FILE_UPLOAD_FAILED", "CHAPTER_VIDEO_REQUIRED", "INVALID_CHAPTER_ORDER"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "COURSE_NOT_FOUND",
+            "FILE_UPLOAD_FAILED",
+            "CHAPTER_VIDEO_REQUIRED",
+            "INVALID_CHAPTER_ORDER"
+    })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<AdminChapterResponse>> createChapter(
             @Parameter(description = "강의 ID", example = "1")
@@ -100,7 +108,13 @@ public class AdminChapterController {
             description = "특정 강의의 챕터 제목, 영상, 재생 시간, 노출 순서를 수정합니다. 영상 파일을 보내지 않으면 기존 영상 경로를 유지합니다."
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
-    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "CHAPTER_NOT_FOUND", "FILE_UPLOAD_FAILED", "INVALID_CHAPTER_ORDER"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "COURSE_NOT_FOUND",
+            "CHAPTER_NOT_FOUND",
+            "FILE_UPLOAD_FAILED",
+            "INVALID_CHAPTER_ORDER"
+    })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @PutMapping(value = "/{chapterId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<AdminChapterResponse>> updateChapter(
             @Parameter(description = "강의 ID", example = "1")
@@ -124,11 +138,7 @@ public class AdminChapterController {
                 request.chapterOrder()
         );
 
-        Chapter updatedChapter = adminChapterUseCase.updateChapter(
-                courseId,
-                chapterId,
-                command
-        );
+        Chapter updatedChapter = adminChapterUseCase.updateChapter(courseId, chapterId, command);
 
         return ResponseEntity.ok(
                 ApiResponse.success(
@@ -144,6 +154,7 @@ public class AdminChapterController {
             description = "특정 강의의 챕터를 실제 삭제하지 않고 Soft Delete 처리합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "CHAPTER_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @DeleteMapping("/{chapterId}")
     public ResponseEntity<ApiResponse<Void>> deleteChapter(
             @Parameter(description = "강의 ID", example = "1")

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
@@ -34,7 +34,6 @@ public class AdminChapterController {
 
     private final AdminChapterUseCase adminChapterUseCase;
     private final LocalFileStorageManager fileStorageManager;
-
     @Operation(
             summary = "챕터 목록 조회",
             description = "특정 강의에 등록된 챕터 목록을 조회합니다."
@@ -83,12 +82,11 @@ public class AdminChapterController {
             @Parameter(description = "챕터 영상 파일", example = "chapter-video.mp4")
             @RequestPart(value = "video") MultipartFile videoFile
     ) {
-        String videoUrl = fileStorageManager.uploadFile(videoFile, "videos");
 
         CreateChapterCommand command = new CreateChapterCommand(
                 courseId,
                 request.title(),
-                videoUrl,
+                videoFile,
                 request.durationSeconds(),
                 request.chapterOrder()
         );
@@ -129,11 +127,10 @@ public class AdminChapterController {
             @Parameter(description = "변경할 챕터 영상 파일. 선택값입니다.", example = "chapter-video-new.mp4")
             @RequestPart(value = "video", required = false) MultipartFile videoFile
     ) {
-        String videoUrl = fileStorageManager.uploadFile(videoFile, "videos");
 
         UpdateChapterCommand command = new UpdateChapterCommand(
                 request.title(),
-                videoUrl,
+                videoFile,
                 request.durationSeconds(),
                 request.chapterOrder()
         );

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCouponController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCouponController.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.lms.presentation.api.admin;
 
+import com.kidmily.algoga_server.admin.settings.annotation.CurrentManager;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
@@ -16,13 +17,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Tag(name = "Admin Coupon", description = "콘텐츠 매니저 강의별 쿠폰 정책 관리 API")
 @RestController
-@RequestMapping("/api/v1/courses/{courseId}/coupon-policies")
+@RequestMapping("/api/v1/admin/courses/{courseId}/coupon-policies")
 @RequiredArgsConstructor
 public class AdminCouponController {
 
@@ -40,18 +42,19 @@ public class AdminCouponController {
             "COURSE_NOT_FOUND",
             "INVALID_COUPON_POLICY"
     })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @PostMapping
     public ResponseEntity<ApiResponse<CouponPolicyResponse>> createCouponPolicy(
             @Parameter(description = "강의 ID", example = "3")
             @PathVariable Long courseId,
 
-            @Valid @RequestBody CreateCouponPolicyRequest request
-    ) {
-        Long currentManagerId = 1L;
+            @Valid @RequestBody CreateCouponPolicyRequest request,
 
+            @CurrentManager Long managerId
+    ) {
         CreateCouponPolicyCommand command = new CreateCouponPolicyCommand(
                 courseId,
-                currentManagerId,
+                managerId,
                 request.couponName(),
                 request.discountType(),
                 request.discountValue(),
@@ -73,6 +76,7 @@ public class AdminCouponController {
             description = "특정 강의에 등록된 쿠폰 정책 목록을 조회합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<List<CouponPolicyResponse>>> getCouponPolicies(
             @Parameter(description = "강의 ID", example = "3")

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
@@ -10,7 +10,6 @@ import com.kidmily.algoga_server.lms.application.command.UpdateCourseCommand;
 import com.kidmily.algoga_server.lms.application.usecase.AdminContentUseCase;
 import com.kidmily.algoga_server.lms.domain.model.Course;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
-import com.kidmily.algoga_server.lms.infrastructure.document.LocalFileStorageManager;
 import com.kidmily.algoga_server.lms.presentation.request.admin.CreateCourseRequest;
 import com.kidmily.algoga_server.lms.presentation.request.admin.UpdateCourseRequest;
 import com.kidmily.algoga_server.lms.presentation.response.AdminCourseResponse;
@@ -36,7 +35,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class AdminCourseController {
 
     private final AdminContentUseCase adminContentUseCase;
-    private final LocalFileStorageManager fileStorageManager;
 
     @Operation(
             summary = "어드민 강의 생성",
@@ -58,18 +56,15 @@ public class AdminCourseController {
 
             @CurrentManager Long managerId
     ) {
-        String thumbnailUrl = fileStorageManager.uploadFile(thumbnailFile, "thumbnails");
-        String fileUrl = fileStorageManager.uploadFile(attachedFile, "documents");
-
         CreateCourseCommand command = new CreateCourseCommand(
                 request.countryId(),
                 managerId,
                 request.title(),
                 request.description(),
                 request.price(),
-                thumbnailUrl,
-                fileUrl,
-                request.level()
+                request.level(),
+                thumbnailFile,
+                attachedFile
         );
 
         Long savedCourseId = adminContentUseCase.createCourse(command);
@@ -127,7 +122,7 @@ public class AdminCourseController {
 
     @Operation(
             summary = "어드민 강의 수정",
-            description = "강의 제목, 설명, 가격, 썸네일, 첨부파일을 수정합니다. 파일을 보내지 않으면 기존 파일 경로를 유지합니다."
+            description = "강의 제목, 설명, 가격, 난이도, 썸네일, 첨부파일을 수정합니다. 파일을 보내지 않으면 기존 파일 경로를 유지합니다."
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "FILE_UPLOAD_FAILED"})
@@ -146,16 +141,13 @@ public class AdminCourseController {
             @Parameter(description = "변경할 첨부파일. 선택값입니다.", example = "osaka-guide-new.pdf")
             @RequestPart(value = "file", required = false) MultipartFile attachedFile
     ) {
-        String thumbnailUrl = fileStorageManager.uploadFile(thumbnailFile, "thumbnails");
-        String fileUrl = fileStorageManager.uploadFile(attachedFile, "documents");
-
         UpdateCourseCommand command = new UpdateCourseCommand(
                 request.title(),
                 request.description(),
                 request.price(),
-                thumbnailUrl,
-                fileUrl,
-                request.level()
+                request.level(),
+                thumbnailFile,
+                attachedFile
         );
 
         Course updatedCourse = adminContentUseCase.updateCourse(courseId, command);

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.lms.presentation.api.admin;
 
+import com.kidmily.algoga_server.admin.settings.annotation.CurrentManager;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.global.common.api.response.PageResponse;
@@ -24,12 +25,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Admin Course", description = "콘텐츠 매니저 강의 관리 API")
 @RestController
-@RequestMapping("/api/v1/courses")
+@RequestMapping("/api/v1/admin/courses")
 @RequiredArgsConstructor
 public class AdminCourseController {
 
@@ -42,6 +44,7 @@ public class AdminCourseController {
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COUNTRY_NOT_FOUND", "FILE_UPLOAD_FAILED"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createCourse(
             @Parameter(description = "강의 생성 요청 JSON")
@@ -51,21 +54,22 @@ public class AdminCourseController {
             @RequestPart(value = "thumbnail") MultipartFile thumbnailFile,
 
             @Parameter(description = "강의 첨부파일. 선택값입니다.", example = "osaka-guide.pdf")
-            @RequestPart(value = "file", required = false) MultipartFile attachedFile
-    ) {
-        Long currentManagerId = 1L;
+            @RequestPart(value = "file", required = false) MultipartFile attachedFile,
 
+            @CurrentManager Long managerId
+    ) {
         String thumbnailUrl = fileStorageManager.uploadFile(thumbnailFile, "thumbnails");
         String fileUrl = fileStorageManager.uploadFile(attachedFile, "documents");
 
         CreateCourseCommand command = new CreateCourseCommand(
                 request.countryId(),
-                currentManagerId,
+                managerId,
                 request.title(),
                 request.description(),
                 request.price(),
                 thumbnailUrl,
-                fileUrl
+                fileUrl,
+                request.level()
         );
 
         Long savedCourseId = adminContentUseCase.createCourse(command);
@@ -78,31 +82,11 @@ public class AdminCourseController {
                 ));
     }
 
-    // global.common.api.response.PageResponse 추가하기 전.
-//    @Operation(
-//            summary = "어드민 강의 목록 조회",
-//            description = "삭제되지 않은 강의 목록을 최신순으로 조회합니다."
-//    )
-//    @GetMapping
-//    public ResponseEntity<ApiResponse<Page<AdminCourseResponse>>> getCourses(
-//            @ParameterObject Pageable pageable
-//    ) {
-//        Page<AdminCourseResponse> response = adminContentUseCase.getCourses(pageable)
-//                .map(AdminCourseResponse::from);
-//
-//        return ResponseEntity.ok(
-//                ApiResponse.success(
-//                        "ADMIN_COURSES_FOUND",
-//                        "어드민 강의 목록 조회에 성공했습니다.",
-//                        response
-//                )
-//        );
-//    }
-
     @Operation(
             summary = "어드민 강의 목록 조회",
             description = "삭제되지 않은 강의 목록을 최신순으로 조회합니다."
     )
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<AdminCourseResponse>>> getCourses(
             @ParameterObject Pageable pageable
@@ -124,6 +108,7 @@ public class AdminCourseController {
             description = "강의 ID를 기준으로 삭제되지 않은 강의 상세 정보를 조회합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping("/{courseId}")
     public ResponseEntity<ApiResponse<AdminCourseResponse>> getCourse(
             @Parameter(description = "강의 ID", example = "1")
@@ -142,10 +127,11 @@ public class AdminCourseController {
 
     @Operation(
             summary = "어드민 강의 수정",
-            description = "강의 제목, 설명, 썸네일, 첨부파일을 수정합니다. 파일을 보내지 않으면 기존 파일 경로를 유지합니다."
+            description = "강의 제목, 설명, 가격, 썸네일, 첨부파일을 수정합니다. 파일을 보내지 않으면 기존 파일 경로를 유지합니다."
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "FILE_UPLOAD_FAILED"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @PutMapping(value = "/{courseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<AdminCourseResponse>> updateCourse(
             @Parameter(description = "강의 ID", example = "1")
@@ -168,7 +154,8 @@ public class AdminCourseController {
                 request.description(),
                 request.price(),
                 thumbnailUrl,
-                fileUrl
+                fileUrl,
+                request.level()
         );
 
         Course updatedCourse = adminContentUseCase.updateCourse(courseId, command);
@@ -187,6 +174,7 @@ public class AdminCourseController {
             description = "강의를 실제 삭제하지 않고 Soft Delete 처리합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @DeleteMapping("/{courseId}")
     public ResponseEntity<ApiResponse<Void>> deleteCourse(
             @Parameter(description = "강의 ID", example = "1")

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseQnaController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseQnaController.java
@@ -1,0 +1,115 @@
+package com.kidmily.algoga_server.lms.presentation.api.admin;
+
+import com.kidmily.algoga_server.admin.settings.annotation.CurrentManager;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
+import com.kidmily.algoga_server.lms.application.command.AnswerCourseQnaCommand;
+import com.kidmily.algoga_server.lms.application.command.CreateCourseQnaCommentCommand;
+import com.kidmily.algoga_server.lms.application.usecase.CourseQnaUseCase;
+import com.kidmily.algoga_server.lms.domain.model.CourseQna;
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.presentation.request.AnswerCourseQnaRequest;
+import com.kidmily.algoga_server.lms.presentation.request.CreateCourseQnaCommentRequest;
+import com.kidmily.algoga_server.lms.presentation.response.CourseQnaCommentResponse;
+import com.kidmily.algoga_server.lms.presentation.response.CourseQnaResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin Course Q&A", description = "콘텐츠 매니저 강의 Q&A 답변 및 댓글 API")
+@RestController
+@RequestMapping("/api/v1/admin/courses/{courseId}/qnas")
+@RequiredArgsConstructor
+public class AdminCourseQnaController {
+
+    private final CourseQnaUseCase courseQnaUseCase;
+
+    @Operation(
+            summary = "강의 Q&A 답변 등록",
+            description = "콘텐츠 매니저가 특정 Q&A에 답변을 등록합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "COURSE_NOT_FOUND",
+            "QNA_NOT_FOUND",
+            "QNA_ALREADY_ANSWERED"
+    })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @PostMapping("/{qnaId}/answer")
+    public ResponseEntity<ApiResponse<CourseQnaResponse>> answerQna(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "Q&A ID", example = "1")
+            @PathVariable Long qnaId,
+
+            @Valid @RequestBody AnswerCourseQnaRequest request,
+
+            @CurrentManager Long managerId
+    ) {
+        AnswerCourseQnaCommand command = new AnswerCourseQnaCommand(
+                courseId,
+                qnaId,
+                managerId,
+                request.answer()
+        );
+
+        CourseQna qna = courseQnaUseCase.answerQna(command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COURSE_QNA_ANSWERED",
+                        "Q&A 답변 등록에 성공했습니다.",
+                        CourseQnaResponse.from(qna)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "강의 Q&A 관리자 댓글 등록",
+            description = "콘텐츠 매니저가 특정 Q&A에 댓글을 등록합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "COURSE_NOT_FOUND",
+            "QNA_NOT_FOUND"
+    })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @PostMapping("/{qnaId}/comments")
+    public ResponseEntity<ApiResponse<CourseQnaCommentResponse>> createManagerComment(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId,
+
+            @Parameter(description = "Q&A ID", example = "1")
+            @PathVariable Long qnaId,
+
+            @Valid @RequestBody CreateCourseQnaCommentRequest request,
+
+            @CurrentManager Long managerId
+    ) {
+        CreateCourseQnaCommentCommand command = new CreateCourseQnaCommentCommand(
+                courseId,
+                qnaId,
+                managerId,
+                "MANAGER",
+                request.content()
+        );
+
+        CourseQnaComment comment = courseQnaUseCase.createComment(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        "COURSE_QNA_MANAGER_COMMENT_CREATED",
+                        "Q&A 관리자 댓글 등록에 성공했습니다.",
+                        CourseQnaCommentResponse.from(comment)
+                ));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseStudentController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseStudentController.java
@@ -1,0 +1,53 @@
+package com.kidmily.algoga_server.lms.presentation.api.admin;
+
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.lms.application.usecase.AdminCourseStudentUseCase;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.presentation.response.CourseStudentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Admin Course Student", description = "콘텐츠 매니저 강의 수강생 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/courses/{courseId}/students")
+@RequiredArgsConstructor
+public class AdminCourseStudentController {
+
+    private final AdminCourseStudentUseCase adminCourseStudentUseCase;
+
+    @Operation(
+            summary = "강의 수강생 목록 조회",
+            description = """
+                    특정 강의에 진도율 기록이 있는 사용자 목록을 조회합니다.
+                    결제 기능은 제외하고 learning_progresses 기록 기준으로 수강생을 구성합니다.
+                    """
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CourseStudentResponse>>> getCourseStudents(
+            @Parameter(description = "강의 ID", example = "3")
+            @PathVariable Long courseId
+    ) {
+        List<CourseStudentResponse> response = adminCourseStudentUseCase.getCourseStudents(courseId)
+                .stream()
+                .map(CourseStudentResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COURSE_STUDENTS_FOUND",
+                        "강의 수강생 목록 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminMileageController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminMileageController.java
@@ -1,0 +1,151 @@
+package com.kidmily.algoga_server.lms.presentation.api.admin;
+
+import com.kidmily.algoga_server.admin.settings.annotation.CurrentManager;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
+import com.kidmily.algoga_server.lms.application.command.AdminMileageTransactionCommand;
+import com.kidmily.algoga_server.lms.application.result.AdminMileageHistoryResult;
+import com.kidmily.algoga_server.lms.application.usecase.AdminMileageUseCase;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.presentation.request.AdminMileageTransactionRequest;
+import com.kidmily.algoga_server.lms.presentation.response.AdminMileageHistoryResponse;
+import com.kidmily.algoga_server.lms.presentation.response.AdminMileageSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Admin Mileage", description = "콘텐츠 매니저 마일리지 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/mileages")
+@RequiredArgsConstructor
+public class AdminMileageController {
+
+    private final AdminMileageUseCase adminMileageUseCase;
+
+    @Operation(
+            summary = "사용자별 마일리지 목록 조회",
+            description = "마일리지 내역이 있는 사용자들의 현재 보유 마일리지, 총 적립, 총 사용 금액을 조회합니다."
+    )
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<AdminMileageSummaryResponse>> getMileageUsers() {
+        AdminMileageSummaryResponse response = AdminMileageSummaryResponse.from(
+                adminMileageUseCase.getMileageUsers()
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_MILEAGES_FOUND",
+                        "관리자 마일리지 목록 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "사용자 마일리지 상세 내역 조회",
+            description = "특정 사용자의 마일리지 적립/사용/회수 내역을 조회합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"MILEAGE_USER_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @GetMapping("/users/{userId}/histories")
+    public ResponseEntity<ApiResponse<List<AdminMileageHistoryResponse>>> getUserMileageHistories(
+            @Parameter(description = "사용자 ID", example = "1")
+            @PathVariable Long userId
+    ) {
+        List<AdminMileageHistoryResponse> response = adminMileageUseCase.getUserMileageHistories(userId)
+                .stream()
+                .map(AdminMileageHistoryResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_MILEAGE_HISTORIES_FOUND",
+                        "사용자 마일리지 상세 내역 조회에 성공했습니다.",
+                        response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "마일리지 지급",
+            description = "콘텐츠 매니저가 특정 사용자에게 마일리지를 지급합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "MILEAGE_USER_NOT_FOUND",
+            "INVALID_MILEAGE_AMOUNT"
+    })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @PostMapping("/users/{userId}/earn")
+    public ResponseEntity<ApiResponse<AdminMileageHistoryResponse>> earnMileage(
+            @Parameter(description = "사용자 ID", example = "1")
+            @PathVariable Long userId,
+
+            @Valid @RequestBody AdminMileageTransactionRequest request,
+
+            @CurrentManager Long managerId
+    ) {
+        AdminMileageTransactionCommand command = new AdminMileageTransactionCommand(
+                userId,
+                managerId,
+                request.amount(),
+                request.reason()
+        );
+
+        AdminMileageHistoryResult result = adminMileageUseCase.earnMileage(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        "ADMIN_MILEAGE_EARNED",
+                        "마일리지 지급에 성공했습니다.",
+                        AdminMileageHistoryResponse.from(result)
+                ));
+    }
+
+    @Operation(
+            summary = "마일리지 회수",
+            description = "콘텐츠 매니저가 특정 사용자의 마일리지를 회수합니다."
+    )
+    @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "MILEAGE_USER_NOT_FOUND",
+            "INVALID_MILEAGE_AMOUNT",
+            "NOT_ENOUGH_MILEAGE"
+    })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @PostMapping("/users/{userId}/use")
+    public ResponseEntity<ApiResponse<AdminMileageHistoryResponse>> useMileage(
+            @Parameter(description = "사용자 ID", example = "1")
+            @PathVariable Long userId,
+
+            @Valid @RequestBody AdminMileageTransactionRequest request,
+
+            @CurrentManager Long managerId
+    ) {
+        AdminMileageTransactionCommand command = new AdminMileageTransactionCommand(
+                userId,
+                managerId,
+                request.amount(),
+                request.reason()
+        );
+
+        AdminMileageHistoryResult result = adminMileageUseCase.useMileage(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        "ADMIN_MILEAGE_USED",
+                        "마일리지 회수에 성공했습니다.",
+                        AdminMileageHistoryResponse.from(result)
+                ));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminQuizController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminQuizController.java
@@ -18,13 +18,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "퀴즈 관리", description = "콘텐츠 매니저 퀴즈 관리 API")
+@Tag(name = "Admin Quiz", description = "콘텐츠 매니저 퀴즈 관리 API")
 @RestController
-@RequestMapping("/api/v1/courses/{courseId}/quizzes")
+@RequestMapping("/api/v1/admin/courses/{courseId}/quizzes")
 @RequiredArgsConstructor
 public class AdminQuizController {
 
@@ -35,6 +36,7 @@ public class AdminQuizController {
             description = "특정 강의에 등록된 퀴즈 목록을 조회합니다. 콘텐츠 매니저용 API이므로 정답과 해설도 함께 반환합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<List<AdminQuizResponse>>> getQuizzes(
             @Parameter(description = "강의 ID", example = "3")
@@ -60,6 +62,7 @@ public class AdminQuizController {
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "INVALID_QUIZ_OPTION", "INVALID_QUIZ_ANSWER"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @PostMapping
     public ResponseEntity<ApiResponse<AdminQuizResponse>> createQuiz(
             @Parameter(description = "강의 ID", example = "3")
@@ -94,6 +97,7 @@ public class AdminQuizController {
     )
     @ApiErrorCodeExample(domain = GlobalErrorCode.class, value = {"INVALID_REQUEST"})
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "QUIZ_NOT_FOUND", "INVALID_QUIZ_OPTION", "INVALID_QUIZ_ANSWER"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @PutMapping("/{quizId}")
     public ResponseEntity<ApiResponse<AdminQuizResponse>> updateQuiz(
             @Parameter(description = "강의 ID", example = "3")
@@ -130,6 +134,7 @@ public class AdminQuizController {
             description = "특정 강의의 퀴즈를 실제 삭제하지 않고 Soft Delete 처리합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "QUIZ_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @DeleteMapping("/{quizId}")
     public ResponseEntity<ApiResponse<Void>> deleteQuiz(
             @Parameter(description = "강의 ID", example = "3")

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/CouponStatisticsController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/CouponStatisticsController.java
@@ -11,11 +11,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Admin Coupon Statistics", description = "쿠폰 발급/사용/만료 통계 API")
 @RestController
-@RequestMapping("/api/v1/coupon-statistics")
+@RequestMapping("/api/v1/admin/coupon-statistics")
 @RequiredArgsConstructor
 public class CouponStatisticsController {
 
@@ -33,6 +34,7 @@ public class CouponStatisticsController {
             "COURSE_NOT_FOUND",
             "COUNTRY_NOT_FOUND"
     })
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<CouponStatisticsResponse>> getCouponStatistics(
             @Parameter(description = "강의 ID 필터", example = "3")

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/01-auth-map.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/01-auth-map.http
@@ -27,8 +27,63 @@ Accept: application/json
 }
 
 
-### 로그인
-### 실행하면 accessToken, refreshToken이 IntelliJ 전역 변수로 저장됨
+### ==========================================================
+### 관리자/매니저 로그인
+### ==========================================================
+
+### 슈퍼 관리자 로그인
+POST http://localhost:15000/api/v1/admin/auth/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "loginId": "super_admin",
+  "password": "password123!"
+}
+
+> {%
+    if (response.status === 200) {
+        client.global.set("adminToken", response.body.data.accessToken);
+        client.global.set("managerAccessToken", response.body.data.accessToken);
+        client.log("Admin Token 저장 완료: " + client.global.get("adminToken"));
+        client.log("Manager Token 저장 완료: " + client.global.get("managerAccessToken"));
+    }
+%}
+
+### 콘텐츠 매니저 계정 생성
+POST http://localhost:15000/api/v1/admin/managers
+Content-Type: application/json
+Authorization: Bearer {{adminToken}}
+
+{
+  "loginId": "content_manager_01",
+  "password": "password123!",
+  "name": "콘텐츠매니저",
+  "phone": "010-9999-9999",
+  "email": "content_manager_01@algoga.com",
+  "role": "CONTENT_MANAGER"
+}
+
+
+### 콘텐츠 매니저 로그인
+POST http://localhost:15000/api/v1/admin/auth/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "loginId": "content_manager_01",
+  "password": "password123!"
+}
+
+> {%
+    if (response.status === 200) {
+        client.global.set("managerAccessToken", response.body.data.accessToken);
+        client.log("Manager Token 저장 완료: " + client.global.get("managerAccessToken"));
+    }
+%}
+
+
+### 일반 사용자 로그인
 POST http://localhost:15000/api/v1/auth/login
 Content-Type: application/json
 Accept: application/json
@@ -40,29 +95,28 @@ Accept: application/json
 
 > {%
     if (response.status === 200) {
-        client.global.set("accessToken", response.body.data.accessToken);
-        client.global.set("refreshToken", response.body.data.refreshToken);
-        client.log("Access Token 저장 완료: " + client.global.get("accessToken"));
+        client.global.set("userAccessToken", response.body.data.accessToken);
+        client.global.set("userRefreshToken", response.body.data.refreshToken);
+        client.log("User Access Token 저장 완료: " + client.global.get("userAccessToken"));
     }
 %}
-
 
 ### ----------------------------------------------------------
 ### 지도 - 대륙 목록 조회
 GET http://localhost:15000/api/v1/maps/continents
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 지도 - 아시아 국가 목록 조회
 GET http://localhost:15000/api/v1/maps/continents/ASIA/countries
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 지도 - 유럽 국가 목록 조회
 GET http://localhost:15000/api/v1/maps/continents/EUROPE/countries
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 국가별 강의 목록 조회 - 일본
 GET http://localhost:15000/api/v1/courses/countries/1
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/02-admin-course.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/02-admin-course.http
@@ -16,9 +16,9 @@ Content-Type: application/json
 
 {
   "countryId": 1,
-  "title": "몽골 핵심 가이드",
-  "description": "이 강의는 request.http 파일을 통해 생성된 강의입니다.",
-  "price": 97000,
+  "title": "s3 테스트 강의",
+  "description": "s3 업로드 확인용 강의.",
+  "price": 50000,
   "level": "BEGINNER"
 }
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/02-admin-course.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/02-admin-course.http
@@ -6,8 +6,8 @@
 
 
 ### 어드민 - 강의 생성
-POST http://localhost:15000/api/v1/courses
-Authorization: Bearer {{accessToken}}
+POST http://localhost:15000/api/v1/admin/courses
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -16,9 +16,10 @@ Content-Type: application/json
 
 {
   "countryId": 1,
-  "title": "멕시코 핵심 가이드",
+  "title": "몽골 핵심 가이드",
   "description": "이 강의는 request.http 파일을 통해 생성된 강의입니다.",
-  "price": 87000
+  "price": 97000,
+  "level": "BEGINNER"
 }
 
 --boundary
@@ -37,20 +38,20 @@ Content-Type: application/pdf
 
 
 ### 어드민 - 강의 목록 조회
-GET http://localhost:15000/api/v1/courses?page=0&size=10
-Authorization: Bearer {{accessToken}}
+GET http://localhost:15000/api/v1/admin/courses?page=0&size=10
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 어드민 - 강의 상세 조회
 ### courseId를 실제 강의 ID로 변경
-GET http://localhost:15000/api/v1/courses/3
-Authorization: Bearer {{accessToken}}
+GET http://localhost:15000/api/v1/admin/courses/3
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 어드민 - 강의 수정
 ### courseId를 실제 강의 ID로 변경
-PUT http://localhost:15000/api/v1/courses/3
-Authorization: Bearer {{accessToken}}
+PUT http://localhost:15000/api/v1/admin/courses/3
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -60,7 +61,8 @@ Content-Type: application/json
 {
   "title": "오사카 여행 준비 마스터 수정본",
   "description": "오사카 여행 전 필요한 교통, 환전, 입국 정보를 수정 반영한 강의입니다.",
-  "price": 120000
+  "price": 120000,
+  "level": "INTERMEDIATE"
 }
 
 --boundary
@@ -80,5 +82,12 @@ Content-Type: application/pdf
 
 ### 어드민 - 강의 삭제
 ### 삭제 테스트가 필요할 때만 실행
-DELETE http://localhost:15000/api/v1/courses/3
-Authorization: Bearer {{accessToken}}
+DELETE http://localhost:15000/api/v1/admin/courses/3
+Authorization: Bearer {{managerAccessToken}}
+
+
+### ----------------------------------------------------------
+### 관리자 - 강의 수강생 목록 조회
+### 관리자/매니저 토큰 필요
+GET http://localhost:15000/api/v1/admin/courses/3/students
+Authorization: Bearer {{managerAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/03-admin-chapter.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/03-admin-chapter.http
@@ -6,14 +6,14 @@
 
 
 ### 챕터 관리 - 챕터 목록 조회
-GET http://localhost:15000/api/v1/courses/3/chapters
-Authorization: Bearer {{accessToken}}
+GET http://localhost:15000/api/v1/admin/courses/3/chapters
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 챕터 관리 - 챕터 등록
 ### 응답의 data.chapterId를 수정/삭제 테스트에 사용
-POST http://localhost:15000/api/v1/courses/3/chapters
-Authorization: Bearer {{accessToken}}
+POST http://localhost:15000/api/v1/admin/courses/12/chapters
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -21,9 +21,9 @@ Content-Disposition: form-data; name="request"; filename="request.json"
 Content-Type: application/json
 
 {
-  "title": "1강. 여행 전 필수 준비",
-  "durationSeconds": 600,
-  "chapterOrder": 1
+  "title": "5강. 여행 전 필수 준비",
+  "durationSeconds": 700,
+  "chapterOrder": 6
 }
 
 --boundary
@@ -36,14 +36,14 @@ Content-Type: video/mp4
 
 
 ### 챕터 관리 - 챕터 등록 후 목록 조회
-GET http://localhost:15000/api/v1/courses/3/chapters
-Authorization: Bearer {{accessToken}}
+GET http://localhost:15000/api/v1/admin/courses/12/chapters
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 챕터 관리 - 챕터 수정
 ### 아래 chapterId를 실제 챕터 ID로 변경
-PUT http://localhost:15000/api/v1/courses/3/chapters/4
-Authorization: Bearer {{accessToken}}
+PUT http://localhost:15000/api/v1/admin/courses/3/chapters/4
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -67,10 +67,10 @@ Content-Type: video/mp4
 
 ### 챕터 관리 - 챕터 삭제
 ### 삭제 테스트가 필요할 때만 실행
-DELETE http://localhost:15000/api/v1/courses/3/chapters/4
-Authorization: Bearer {{accessToken}}
+DELETE http://localhost:15000/api/v1/admin/courses/3/chapters/4
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 챕터 관리 - 삭제 후 목록 조회
-GET http://localhost:15000/api/v1/courses/3/chapters
-Authorization: Bearer {{accessToken}}
+GET http://localhost:15000/api/v1/admin/courses/3/chapters
+Authorization: Bearer {{managerAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/03-admin-chapter.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/03-admin-chapter.http
@@ -12,7 +12,7 @@ Authorization: Bearer {{managerAccessToken}}
 
 ### 챕터 관리 - 챕터 등록
 ### 응답의 data.chapterId를 수정/삭제 테스트에 사용
-POST http://localhost:15000/api/v1/admin/courses/12/chapters
+POST http://localhost:15000/api/v1/admin/courses/13/chapters
 Authorization: Bearer {{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
@@ -21,9 +21,9 @@ Content-Disposition: form-data; name="request"; filename="request.json"
 Content-Type: application/json
 
 {
-  "title": "5강. 여행 전 필수 준비",
+  "title": "s3강. 여행 전 필수 준비",
   "durationSeconds": 700,
-  "chapterOrder": 6
+  "chapterOrder": 1
 }
 
 --boundary

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/04-admin-quiz.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/04-admin-quiz.http
@@ -5,13 +5,13 @@
 
 
 ### 퀴즈 관리 - 퀴즈 목록 조회
-GET http://localhost:15000/api/v1/courses/3/quizzes
+GET http://localhost:15000/api/v1/admin/courses/3/quizzes
 Authorization: Bearer {{accessToken}}
 
 
 ### 퀴즈 관리 - 퀴즈 등록
 ### 응답의 data.quizId 값을 수정/삭제 테스트에 사용
-POST http://localhost:15000/api/v1/courses/3/quizzes
+POST http://localhost:15000/api/v1/admin/courses/3/quizzes
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -27,13 +27,13 @@ Content-Type: application/json
 
 
 ### 퀴즈 관리 - 등록 후 목록 조회
-GET http://localhost:15000/api/v1/courses/3/quizzes
+GET http://localhost:15000/api/v1/admin/courses/3/quizzes
 Authorization: Bearer {{accessToken}}
 
 
 ### 퀴즈 관리 - 퀴즈 수정
 ### quizId를 실제 값으로 변경
-PUT http://localhost:15000/api/v1/courses/3/quizzes/3
+PUT http://localhost:15000/api/v1/admin/courses/3/quizzes/3
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -50,10 +50,10 @@ Content-Type: application/json
 
 ### 퀴즈 관리 - 퀴즈 삭제
 ### 삭제 테스트가 필요할 때만 실행
-DELETE http://localhost:15000/api/v1/courses/3/quizzes/3
+DELETE http://localhost:15000/api/v1/admin/courses/3/quizzes/3
 Authorization: Bearer {{accessToken}}
 
 
 ### 퀴즈 관리 - 삭제 후 목록 조회
-GET http://localhost:15000/api/v1/courses/3/quizzes
+GET http://localhost:15000/api/v1/admin/courses/3/quizzes
 Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/05-learning-progress.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/05-learning-progress.http
@@ -1,0 +1,42 @@
+### ==========================================================
+### 05. 강의 수강 / 챕터 진도율
+### 먼저 01-auth-map.http에서 로그인 실행 후 사용
+### chapterId는 실제 3번 강의에 속한 챕터 ID로 변경
+### ==========================================================
+
+
+### 챕터 목록 조회 - 진도율 업데이트 전에 chapterId 확인
+GET http://localhost:15000/api/v1/courses/3/chapters
+Authorization: Bearer {{accessToken}}
+
+
+### 강의 수강 - 챕터 진도율 업데이트
+POST http://localhost:15000/api/v1/courses/3/chapters/6/progress
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "watchedSeconds": 300
+}
+
+
+### 강의 수강 - 챕터 진도율 100% 업데이트
+### chapter durationSeconds 이상으로 보내면 100% 완료 처리
+POST http://localhost:15000/api/v1/courses/3/chapters/6/progress
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "watchedSeconds": 9999
+}
+
+
+### 강의 수강 - 진도율 감소 방지 테스트
+### 이미 100% 완료된 뒤 더 작은 값을 보내도 progressRate는 감소하지 않아야 함
+POST http://localhost:15000/api/v1/courses/3/chapters/6/progress
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "watchedSeconds": 10
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/06-user-quiz-completion.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/06-user-quiz-completion.http
@@ -1,59 +1,103 @@
 ### ==========================================================
-### 04. 어드민 퀴즈 관리
+### 06. 사용자 퀴즈 풀이 + 강의 이수 완료 핵심 플로우
 ### 먼저 01-auth-map.http에서 로그인 실행 후 사용
+###
+### 실행 순서:
+### 1) 챕터 목록 조회
+### 2) 3번 강의의 모든 챕터를 100% 완료
+### 3) 사용자 퀴즈 조회
+### 4) quizId를 확인해서 퀴즈 제출
+### 5) 강의 이수 완료
 ### ==========================================================
 
 
-### 퀴즈 관리 - 퀴즈 목록 조회
-GET http://localhost:15000/api/v1/courses/3/quizzes
+### 1. 챕터 목록 조회
+GET http://localhost:15000/api/v1/courses/3/chapters
 Authorization: Bearer {{accessToken}}
 
 
-### 퀴즈 관리 - 퀴즈 등록
-### 응답의 data.quizId 값을 수정/삭제 테스트에 사용
-POST http://localhost:15000/api/v1/courses/3/quizzes
-Authorization: Bearer {{accessToken}}
-Content-Type: application/json
-
-{
-  "question": "일본 오사카 여행 전 준비물로 가장 적절한 것은?",
-  "option1": "여권",
-  "option2": "두꺼운 겨울 패딩",
-  "option3": "국제운전면허증만",
-  "option4": "현지 주민등록증",
-  "correctOption": 1,
-  "explanation": "해외여행 시 여권은 필수 준비물입니다."
-}
-
-
-### 퀴즈 관리 - 등록 후 목록 조회
-GET http://localhost:15000/api/v1/courses/3/quizzes
-Authorization: Bearer {{accessToken}}
-
-
-### 퀴즈 관리 - 퀴즈 수정
-### quizId를 실제 값으로 변경
-PUT http://localhost:15000/api/v1/courses/3/quizzes/3
+### 2-1. 챕터 5 완료 처리
+POST http://localhost:15000/api/v1/courses/3/chapters/5/progress
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
 {
-  "question": "오사카 여행 전 반드시 확인해야 하는 서류는?",
-  "option1": "여권",
-  "option2": "호텔 키",
-  "option3": "국내 학생증",
-  "option4": "주민센터 서류",
-  "correctOption": 1,
-  "explanation": "해외 입국을 위해 여권은 필수입니다."
+  "watchedSeconds": 9999
 }
 
 
-### 퀴즈 관리 - 퀴즈 삭제
-### 삭제 테스트가 필요할 때만 실행
-DELETE http://localhost:15000/api/v1/courses/3/quizzes/3
+### 2-2. 챕터 6 완료 처리
+POST http://localhost:15000/api/v1/courses/3/chapters/6/progress
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "watchedSeconds": 9999
+}
+
+
+### 2-3. 챕터 7 완료 처리
+POST http://localhost:15000/api/v1/courses/3/chapters/7/progress
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "watchedSeconds": 9999
+}
+
+
+### 2-4. 챕터 8 완료 처리
+POST http://localhost:15000/api/v1/courses/3/chapters/8/progress
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "watchedSeconds": 9999
+}
+
+
+### 3. 사용자 퀴즈 조회
+### 모든 챕터 완료 후 실행해야 함
+GET http://localhost:15000/api/v1/courses/3/quiz
 Authorization: Bearer {{accessToken}}
 
 
-### 퀴즈 관리 - 삭제 후 목록 조회
-GET http://localhost:15000/api/v1/courses/3/quizzes
+### 4. 사용자 퀴즈 제출 및 채점
+### quizId는 위 퀴즈 조회 응답의 data[].quizId 값으로 변경
+POST http://localhost:15000/api/v1/courses/3/quiz/submit
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "answers": [
+    {
+      "quizId": 3,
+      "selectedOption": 1
+    }
+  ]
+}
+
+
+### 5. 강의 이수 완료 처리
+### 조건:
+### - 해당 강의의 모든 챕터 completed=true
+### - 해당 강의 퀴즈 제출 내역이 quiz_submissions에 존재
+POST http://localhost:15000/api/v1/courses/3/complete
+Authorization: Bearer {{accessToken}}
+
+
+### ----------------------------------------------------------
+### 6. 마이페이지 - 내 수강 강의 목록 조회
+GET http://localhost:15000/api/v1/my/courses
+Authorization: Bearer {{accessToken}}
+
+
+### ----------------------------------------------------------
+### 7. 마이페이지 - 내 쿠폰함 조회
+GET http://localhost:15000/api/v1/my/coupons
+Authorization: Bearer {{accessToken}}
+
+
+### 8. 마이페이지 - 내 마일리지 내역 조회
+GET http://localhost:15000/api/v1/my/mileages
 Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/07-coupon-reward.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/07-coupon-reward.http
@@ -2,17 +2,14 @@
 ### 07. 쿠폰 정책 + 보상 지급
 ### 먼저 01-auth-map.http에서 로그인 실행 후 사용
 ###
-### 보상 지급 조건:
-### 1) 챕터 전체 완료
-### 2) 퀴즈 제출 완료
-### 3) 강의 이수 완료
-### 4) 쿠폰 정책 등록 완료
+### 쿠폰 정책 등록/조회는 관리자 API라서 매니저 토큰 필요
+### 보상 지급은 사용자 API라서 사용자 토큰 필요
 ### ==========================================================
 
 
-### 쿠폰 정책 등록
+### 쿠폰 정책 등록 - 관리자 API
 ### 이미 같은 강의에 같은 couponName으로 등록했다면 중복 에러가 날 수 있음
-POST http://localhost:15000/api/v1/courses/3/coupon-policies
+POST http://localhost:15000/api/v1/admin/courses/3/coupon-policies
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -24,12 +21,12 @@ Content-Type: application/json
 }
 
 
-### 쿠폰 정책 목록 조회
-GET http://localhost:15000/api/v1/courses/3/coupon-policies
+### 쿠폰 정책 목록 조회 - 관리자 API
+GET http://localhost:15000/api/v1/admin/courses/3/coupon-policies
 Authorization: Bearer {{accessToken}}
 
 
-### 보상 지급 - 쿠폰 및 마일리지 지급
+### 보상 지급 - 사용자 API
 POST http://localhost:15000/api/v1/courses/3/rewards
 Authorization: Bearer {{accessToken}}
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/09-qna.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/09-qna.http
@@ -1,6 +1,9 @@
 ### ==========================================================
 ### 09. 강의 Q&A
 ### 먼저 01-auth-map.http에서 로그인 실행 후 사용
+###
+### 질문 등록/목록 조회는 사용자 API
+### 답변 등록은 관리자 API라서 매니저 토큰 필요
 ### ==========================================================
 
 
@@ -20,9 +23,9 @@ GET http://localhost:15000/api/v1/courses/3/qnas
 Authorization: Bearer {{accessToken}}
 
 
-### 강의 Q&A - 답변 등록
+### 강의 Q&A - 답변 등록 - 관리자 API
 ### qnaId는 질문 등록 응답의 data.qnaId 값으로 변경
-POST http://localhost:15000/api/v1/courses/3/qnas/1/answer
+POST http://localhost:15000/api/v1/admin/courses/3/qnas/1/answer
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -33,4 +36,40 @@ Content-Type: application/json
 
 ### 강의 Q&A - 답변 후 목록 조회
 GET http://localhost:15000/api/v1/courses/3/qnas
+Authorization: Bearer {{accessToken}}
+
+
+
+
+### --------------------------------------------------
+### 강의 Q&A - 상세 조회
+### qnaId는 실제 Q&A ID로 변경
+GET http://localhost:15000/api/v1/courses/3/qnas/1
+Authorization: Bearer {{accessToken}}
+
+
+### 강의 Q&A - 사용자 댓글 등록
+### qnaId는 실제 Q&A ID로 변경
+POST http://localhost:15000/api/v1/courses/3/qnas/1/comments
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "content": "추가로 궁금한 점이 있습니다."
+}
+
+
+### 강의 Q&A - 관리자 댓글 등록
+### 관리자/매니저 토큰 필요
+POST http://localhost:15000/api/v1/admin/courses/3/qnas/1/comments
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "content": "추가 안내드립니다. 관리자 댓글입니다."
+}
+
+
+### 강의 Q&A - 댓글 등록 후 상세 조회
+GET http://localhost:15000/api/v1/courses/3/qnas/1
 Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/10-review.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/10-review.http
@@ -23,3 +23,8 @@ Content-Type: application/json
 ### 강의 리뷰 - 리뷰 목록 조회
 GET http://localhost:15000/api/v1/courses/3/reviews
 Authorization: Bearer {{accessToken}}
+
+
+### 강의 리뷰 - 리뷰 요약 조회
+GET http://localhost:15000/api/v1/courses/3/reviews/summary
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/11-couppon-statistics.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/11-couppon-statistics.http
@@ -1,24 +1,25 @@
 ### ==========================================================
 ### 11. 쿠폰 통계
-### 먼저 01-auth-map.http에서 로그인 실행 후 사용
+### 먼저 01-auth-map.http에서 매니저 로그인 실행 후 사용
+### 관리자 API라서 매니저 토큰 필요
 ### ==========================================================
 
 
 ### 쿠폰 통계 - 전체 조회
-GET http://localhost:15000/api/v1/coupon-statistics
+GET http://localhost:15000/api/v1/admin/coupon-statistics
 Authorization: Bearer {{accessToken}}
 
 
 ### 쿠폰 통계 - 강의별 필터
-GET http://localhost:15000/api/v1/coupon-statistics?courseId=3
+GET http://localhost:15000/api/v1/admin/coupon-statistics?courseId=3
 Authorization: Bearer {{accessToken}}
 
 
 ### 쿠폰 통계 - 국가별 필터
-GET http://localhost:15000/api/v1/coupon-statistics?countryId=1
+GET http://localhost:15000/api/v1/admin/coupon-statistics?countryId=1
 Authorization: Bearer {{accessToken}}
 
 
 ### 쿠폰 통계 - 강의 + 국가 필터
-GET http://localhost:15000/api/v1/coupon-statistics?courseId=3&countryId=1
+GET http://localhost:15000/api/v1/admin/coupon-statistics?courseId=3&countryId=1
 Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/12_admin-mileage.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/12_admin-mileage.http
@@ -1,0 +1,52 @@
+### ==========================================================
+### 12. 관리자 마일리지 관리
+### 사용 전 준비:
+### 1) 01-auth-map.http 에서 콘텐츠 매니저 로그인 실행
+### 2) managerAccessToken 저장 확인
+### 3) 아래 요청 실행
+### ==========================================================
+
+
+### 관리자 - 마일리지 목록 조회
+GET http://localhost:15000/api/v1/admin/mileages
+Authorization: Bearer {{managerAccessToken}}
+
+
+### 관리자 - 사용자 마일리지 상세 내역 조회
+### userId는 실제 사용자 ID로 변경
+GET http://localhost:15000/api/v1/admin/mileages/users/1/histories
+Authorization: Bearer {{managerAccessToken}}
+
+
+### 관리자 - 마일리지 지급
+### userId는 실제 사용자 ID로 변경
+POST http://localhost:15000/api/v1/admin/mileages/users/1/earn
+Authorization: Bearer {{managerAccessToken}}
+Content-Type: application/json
+
+{
+  "amount": 1000,
+  "reason": "이벤트 참여 보상"
+}
+
+
+### 관리자 - 마일리지 회수
+### userId는 실제 사용자 ID로 변경
+POST http://localhost:15000/api/v1/admin/mileages/users/1/use
+Authorization: Bearer {{managerAccessToken}}
+Content-Type: application/json
+
+{
+  "amount": 500,
+  "reason": "오지급 회수"
+}
+
+
+### 관리자 - 지급/회수 후 마일리지 목록 조회
+GET http://localhost:15000/api/v1/admin/mileages
+Authorization: Bearer {{managerAccessToken}}
+
+
+### 관리자 - 지급/회수 후 사용자 마일리지 상세 내역 조회
+GET http://localhost:15000/api/v1/admin/mileages/users/1/histories
+Authorization: Bearer {{managerAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/13-diagnosis-recommendation.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/13-diagnosis-recommendation.http
@@ -1,0 +1,71 @@
+### ==========================================================
+### 13. 진단평가 선택 나라 + level별 추천 강의 조회
+### 먼저 01-auth-map.http에서 일반 사용자 로그인 실행 후 사용
+### ==========================================================
+
+
+### 진단평가 - 일본 + 초급 추천 강의 조회
+GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=1&level=BEGINNER
+Authorization: Bearer {{userAccessToken}}
+
+
+### 진단평가 - 일본 + 중급 추천 강의 조회
+GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=1&level=INTERMEDIATE
+Authorization: Bearer {{userAccessToken}}
+
+
+### 진단평가 - 일본 + 고급 추천 강의 조회
+GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=1&level=ADVANCED
+Authorization: Bearer {{userAccessToken}}
+
+
+### 진단평가 - 없는 나라 테스트
+GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=999&level=BEGINNER
+Authorization: Bearer {{userAccessToken}}
+
+
+### 진단평가 - 잘못된 level 테스트
+GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=1&level=SUPER
+Authorization: Bearer {{userAccessToken}}
+
+
+### ==========================================================
+### 14. 진단평가 결과 계산 + 추천 강의 조회
+### 먼저 01-auth-map.http에서 일반 사용자 로그인 실행 후 사용
+### ==========================================================
+
+
+### 진단평가 결과 - 초급
+POST http://localhost:15000/api/v1/diagnosis/result
+Authorization: Bearer {{userAccessToken}}
+Content-Type: application/json
+
+{
+  "countryId": 1,
+  "correctCount": 2,
+  "totalCount": 5
+}
+
+
+### 진단평가 결과 - 중급
+POST http://localhost:15000/api/v1/diagnosis/result
+Authorization: Bearer {{userAccessToken}}
+Content-Type: application/json
+
+{
+  "countryId": 1,
+  "correctCount": 3,
+  "totalCount": 5
+}
+
+
+### 진단평가 결과 - 고급
+POST http://localhost:15000/api/v1/diagnosis/result
+Authorization: Bearer {{userAccessToken}}
+Content-Type: application/json
+
+{
+  "countryId": 1,
+  "correctCount": 5,
+  "totalCount": 5
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/99-exception-test.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/99-exception-test.http
@@ -16,17 +16,17 @@ Authorization: Bearer {{accessToken}}
 
 
 ### 어드민 - 존재하지 않는 강의 상세 조회
-GET http://localhost:15000/api/v1/courses/9999
+GET http://localhost:15000/api/v1/admin/courses/9999
 Authorization: Bearer {{accessToken}}
 
 
 ### 챕터 관리 - 존재하지 않는 강의의 챕터 목록 조회
-GET http://localhost:15000/api/v1/courses/9999/chapters
+GET http://localhost:15000/api/v1/admin/courses/9999/chapters
 Authorization: Bearer {{accessToken}}
 
 
 ### 챕터 관리 - 존재하지 않는 챕터 수정
-PUT http://localhost:15000/api/v1/courses/3/chapters/9999
+PUT http://localhost:15000/api/v1/admin/courses/3/chapters/9999
 Authorization: Bearer {{accessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
@@ -44,7 +44,7 @@ Content-Type: application/json
 
 
 ### 강의 수강 - 존재하지 않는 강의
-POST http://localhost:15000/api/v1/courses/9999/chapters/6/progress
+POST http://localhost:15000/api/v1/admin/courses/9999/chapters/6/progress
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -54,7 +54,7 @@ Content-Type: application/json
 
 
 ### 강의 수강 - 존재하지 않는 챕터
-POST http://localhost:15000/api/v1/courses/3/chapters/9999/progress
+POST http://localhost:15000/api/v1/admin/courses/3/chapters/9999/progress
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -74,12 +74,12 @@ Content-Type: application/json
 
 
 ### 퀴즈 관리 - 존재하지 않는 강의의 퀴즈 목록 조회
-GET http://localhost:15000/api/v1/courses/9999/quizzes
+GET http://localhost:15000/api/v1/admin/courses/9999/quizzes
 Authorization: Bearer {{accessToken}}
 
 
 ### 퀴즈 관리 - 존재하지 않는 퀴즈 수정
-PUT http://localhost:15000/api/v1/courses/3/quizzes/9999
+PUT http://localhost:15000/api/v1/admin/courses/3/quizzes/9999
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -95,7 +95,7 @@ Content-Type: application/json
 
 
 ### 퀴즈 관리 - 정답 번호 오류
-POST http://localhost:15000/api/v1/courses/3/quizzes
+POST http://localhost:15000/api/v1/admin/courses/3/quizzes
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -111,7 +111,7 @@ Content-Type: application/json
 
 
 ### 퀴즈 관리 - 보기 누락
-POST http://localhost:15000/api/v1/courses/3/quizzes
+POST http://localhost:15000/api/v1/admin/courses/3/quizzes
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -204,7 +204,7 @@ Content-Type: application/json
 
 
 ### Q&A - 존재하지 않는 Q&A 답변 등록
-POST http://localhost:15000/api/v1/courses/3/qnas/9999/answer
+POST http://localhost:15000/api/v1/admin/courses/3/qnas/9999/answer
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -215,7 +215,7 @@ Content-Type: application/json
 
 ### Q&A - 이미 답변된 Q&A 재답변
 ### qnaId를 이미 답변 등록 성공한 값으로 변경
-POST http://localhost:15000/api/v1/courses/3/qnas/1/answer
+POST http://localhost:15000/api/v1/admin/courses/3/qnas/1/answer
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/AdminMileageTransactionRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/AdminMileageTransactionRequest.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.lms.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "관리자 마일리지 지급/회수 요청")
+public record AdminMileageTransactionRequest(
+
+        @Schema(description = "마일리지 금액", example = "1000")
+        @Min(value = 1, message = "마일리지 금액은 1 이상이어야 합니다.")
+        int amount,
+
+        @Schema(description = "지급/회수 사유", example = "이벤트 참여 보상")
+        @NotBlank(message = "사유는 필수입니다.")
+        String reason
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/CreateCourseQnaCommentRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/CreateCourseQnaCommentRequest.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.lms.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "강의 Q&A 댓글 등록 요청")
+public record CreateCourseQnaCommentRequest(
+
+        @Schema(description = "댓글 내용", example = "추가로 궁금한 점이 있습니다.")
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/DiagnosisResultRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/DiagnosisResultRequest.java
@@ -1,0 +1,24 @@
+package com.kidmily.algoga_server.lms.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "진단평가 결과 요청")
+public record DiagnosisResultRequest(
+
+        @Schema(description = "사용자가 선택한 국가 ID", example = "1")
+        @NotNull(message = "국가 ID는 필수입니다.")
+        Long countryId,
+
+        @Schema(description = "정답 개수", example = "3")
+        @NotNull(message = "정답 개수는 필수입니다.")
+        @Min(value = 0, message = "정답 개수는 0 이상이어야 합니다.")
+        Integer correctCount,
+
+        @Schema(description = "전체 문항 수", example = "5")
+        @NotNull(message = "전체 문항 수는 필수입니다.")
+        @Min(value = 1, message = "전체 문항 수는 1 이상이어야 합니다.")
+        Integer totalCount
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateChapterRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateChapterRequest.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.lms.presentation.request.admin;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +21,7 @@ public record CreateChapterRequest(
         @Schema(description = "챕터 노출 순서", example = "1")
         @NotNull(message = "챕터 순서는 필수입니다.")
         @Min(value = 1, message = "챕터 순서는 1 이상이어야 합니다.")
+        @Max(value = 5, message = "챕터 순서는 5 이하여야 합니다.")
         Integer chapterOrder
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateCourseRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateCourseRequest.java
@@ -23,6 +23,14 @@ public record CreateCourseRequest(
         @Schema(description = "강의 가격", example = "100000")
         @NotNull(message = "강의 가격은 필수입니다.")
         @Positive(message = "강의 가격은 0보다 커야 합니다.")
-        Integer price
+        Integer price,
+
+        @Schema(
+                description = "강의 난이도. BEGINNER=초급, INTERMEDIATE=중급, ADVANCED=고급",
+                example = "BEGINNER",
+                allowableValues = {"BEGINNER", "INTERMEDIATE", "ADVANCED"}
+        )
+        @NotBlank(message = "강의 난이도는 필수입니다.")
+        String level
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateChapterRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateChapterRequest.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.lms.presentation.request.admin;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,9 +18,10 @@ public record UpdateChapterRequest(
         @Min(value = 1, message = "영상 재생 시간은 1초 이상이어야 합니다.")
         Integer durationSeconds,
 
-        @Schema(description = "수정할 챕터 노출 순서", example = "1")
+        @Schema(description = "챕터 노출 순서", example = "1")
         @NotNull(message = "챕터 순서는 필수입니다.")
         @Min(value = 1, message = "챕터 순서는 1 이상이어야 합니다.")
+        @Max(value = 5, message = "챕터 순서는 5 이하여야 합니다.")
         Integer chapterOrder
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateCourseRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateCourseRequest.java
@@ -19,6 +19,14 @@ public record UpdateCourseRequest(
         @Schema(description = "수정할 강의 가격", example = "120000")
         @NotNull(message = "강의 가격은 필수입니다.")
         @Positive(message = "강의 가격은 0보다 커야 합니다.")
-        Integer price
+        Integer price,
+
+        @Schema(
+                description = "강의 난이도. BEGINNER=초급, INTERMEDIATE=중급, ADVANCED=고급",
+                example = "INTERMEDIATE",
+                allowableValues = {"BEGINNER", "INTERMEDIATE", "ADVANCED"}
+        )
+        @NotBlank(message = "강의 난이도는 필수입니다.")
+        String level
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseResponse.java
@@ -24,11 +24,17 @@ public record AdminCourseResponse(
         @Schema(description = "강의 가격", example = "100000")
         Integer price,
 
-        @Schema(description = "썸네일 URL", example = "thumbnails/550e8400-e29b-41d4-a716-446655440000.png")
+        @Schema(description = "썸네일 URL")
         String thumbnailUrl,
 
-        @Schema(description = "첨부파일 경로", example = "documents/550e8400-e29b-41d4-a716-446655440000.pdf")
+        @Schema(description = "첨부파일 경로")
         String fileUrl,
+
+        @Schema(description = "강의 난이도 코드", example = "BEGINNER")
+        String level,
+
+        @Schema(description = "강의 난이도 이름", example = "초급")
+        String levelName,
 
         @Schema(description = "강의 상태", example = "DRAFT")
         String status
@@ -44,7 +50,18 @@ public record AdminCourseResponse(
                 course.getPrice(),
                 course.getThumbnailUrl(),
                 course.getFileUrl(),
+                course.getLevel(),
+                toLevelName(course.getLevel()),
                 course.getStatus()
         );
+    }
+
+    private static String toLevelName(String level) {
+        return switch (level) {
+            case "BEGINNER" -> "초급";
+            case "INTERMEDIATE" -> "중급";
+            case "ADVANCED" -> "고급";
+            default -> "";
+        };
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminMileageHistoryResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminMileageHistoryResponse.java
@@ -1,0 +1,68 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.AdminMileageHistoryResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 마일리지 내역 응답")
+public record AdminMileageHistoryResponse(
+
+        @Schema(description = "마일리지 내역 ID", example = "1")
+        Long mileageHistoryId,
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "사용자 이름", example = "김여행")
+        String userName,
+
+        @Schema(description = "사용자 이메일", example = "kim@algoga.com")
+        String userEmail,
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "강의명", example = "오사카 여행 준비 마스터")
+        String courseTitle,
+
+        @Schema(description = "처리 매니저 ID", example = "5")
+        Long managerId,
+
+        @Schema(description = "처리자 이름", example = "관리자")
+        String processorName,
+
+        @Schema(description = "원본 마일리지 금액", example = "1000")
+        int amount,
+
+        @Schema(description = "부호 포함 금액. 적립은 양수, 사용/회수는 음수", example = "-1000")
+        int signedAmount,
+
+        @Schema(description = "타입. EARN 또는 USE", example = "EARN")
+        String type,
+
+        @Schema(description = "사유", example = "이벤트 참여 보상")
+        String reason,
+
+        @Schema(description = "처리 일시", example = "2026-05-27T10:30:00")
+        LocalDateTime createdAt
+) {
+
+    public static AdminMileageHistoryResponse from(AdminMileageHistoryResult result) {
+        return new AdminMileageHistoryResponse(
+                result.mileageHistoryId(),
+                result.userId(),
+                result.userName(),
+                result.userEmail(),
+                result.courseId(),
+                result.courseTitle(),
+                result.managerId(),
+                result.processorName(),
+                result.amount(),
+                result.signedAmount(),
+                result.type(),
+                result.reason(),
+                result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminMileageSummaryResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminMileageSummaryResponse.java
@@ -1,0 +1,39 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.AdminMileageSummaryResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "관리자 마일리지 목록/요약 응답")
+public record AdminMileageSummaryResponse(
+
+        @Schema(description = "마일리지 내역이 있는 사용자 수", example = "3")
+        int totalUserCount,
+
+        @Schema(description = "전체 사용자 보유 마일리지 합계", example = "46800")
+        int totalMileage,
+
+        @Schema(description = "전체 총 적립 마일리지", example = "58000")
+        int totalEarnedMileage,
+
+        @Schema(description = "전체 총 사용/회수 마일리지", example = "11200")
+        int totalUsedMileage,
+
+        @Schema(description = "사용자별 마일리지 목록")
+        List<AdminMileageUserResponse> users
+) {
+
+    public static AdminMileageSummaryResponse from(AdminMileageSummaryResult result) {
+        return new AdminMileageSummaryResponse(
+                result.totalUserCount(),
+                result.totalMileage(),
+                result.totalEarnedMileage(),
+                result.totalUsedMileage(),
+                result.users()
+                        .stream()
+                        .map(AdminMileageUserResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminMileageUserResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminMileageUserResponse.java
@@ -1,0 +1,44 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.AdminMileageUserResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 마일리지 사용자 목록 응답")
+public record AdminMileageUserResponse(
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "사용자 이름", example = "김여행")
+        String name,
+
+        @Schema(description = "사용자 이메일", example = "kim@algoga.com")
+        String email,
+
+        @Schema(description = "현재 보유 마일리지", example = "16000")
+        int totalMileage,
+
+        @Schema(description = "총 적립 마일리지", example = "21000")
+        int totalEarnedMileage,
+
+        @Schema(description = "총 사용 마일리지", example = "5000")
+        int totalUsedMileage,
+
+        @Schema(description = "최근 업데이트 일시", example = "2026-05-27T10:30:00")
+        LocalDateTime lastUpdatedAt
+) {
+
+    public static AdminMileageUserResponse from(AdminMileageUserResult result) {
+        return new AdminMileageUserResponse(
+                result.userId(),
+                result.name(),
+                result.email(),
+                result.totalMileage(),
+                result.totalEarnedMileage(),
+                result.totalUsedMileage(),
+                result.lastUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseListResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseListResponse.java
@@ -10,6 +10,8 @@ public record CourseListResponse(
         Integer price,
         String thumbnailUrl,
         String fileUrl,
+        String level,
+        String levelName,
         String status
 ) {
 
@@ -22,7 +24,18 @@ public record CourseListResponse(
                 course.getPrice(),
                 course.getThumbnailUrl(),
                 course.getFileUrl(),
+                course.getLevel(),
+                toLevelName(course.getLevel()),
                 course.getStatus()
         );
+    }
+
+    private static String toLevelName(String level) {
+        return switch (level) {
+            case "BEGINNER" -> "초급";
+            case "INTERMEDIATE" -> "중급";
+            case "ADVANCED" -> "고급";
+            default -> "";
+        };
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaCommentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaCommentResponse.java
@@ -1,0 +1,44 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.domain.model.CourseQnaComment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "강의 Q&A 댓글 응답")
+public record CourseQnaCommentResponse(
+
+        @Schema(description = "댓글 ID", example = "1")
+        Long commentId,
+
+        @Schema(description = "Q&A ID", example = "1")
+        Long qnaId,
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "매니저 ID", example = "1")
+        Long managerId,
+
+        @Schema(description = "작성자 타입. USER 또는 MANAGER", example = "USER")
+        String writerType,
+
+        @Schema(description = "댓글 내용", example = "추가로 궁금한 점이 있습니다.")
+        String content,
+
+        @Schema(description = "댓글 작성일시", example = "2026-05-27T01:30:00")
+        LocalDateTime createdAt
+) {
+
+    public static CourseQnaCommentResponse from(CourseQnaComment comment) {
+        return new CourseQnaCommentResponse(
+                comment.getId(),
+                comment.getQnaId(),
+                comment.getUserId(),
+                comment.getManagerId(),
+                comment.getWriterType(),
+                comment.getContent(),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaDetailResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaDetailResponse.java
@@ -1,0 +1,64 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.CourseQnaDetailResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "강의 Q&A 상세 응답")
+public record CourseQnaDetailResponse(
+
+        @Schema(description = "Q&A ID", example = "1")
+        Long qnaId,
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "질문 작성자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "답변 작성 매니저 ID", example = "1")
+        Long managerId,
+
+        @Schema(description = "질문 제목", example = "오사카 교통패스 관련 질문입니다.")
+        String title,
+
+        @Schema(description = "질문 내용", example = "오사카 주유패스와 간사이 패스 중 어떤 것을 선택해야 하나요?")
+        String question,
+
+        @Schema(description = "답변 내용", example = "오사카 시내 관광 위주라면 오사카 주유패스를 추천드립니다.")
+        String answer,
+
+        @Schema(description = "Q&A 상태", example = "ANSWERED")
+        String status,
+
+        @Schema(description = "질문 작성일시", example = "2026-05-26T15:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "답변 작성일시", example = "2026-05-26T16:00:00")
+        LocalDateTime answeredAt,
+
+        @Schema(description = "댓글 목록")
+        List<CourseQnaCommentResponse> comments
+) {
+
+    public static CourseQnaDetailResponse from(CourseQnaDetailResult result) {
+        return new CourseQnaDetailResponse(
+                result.qnaId(),
+                result.courseId(),
+                result.userId(),
+                result.managerId(),
+                result.title(),
+                result.question(),
+                result.answer(),
+                result.status(),
+                result.createdAt(),
+                result.answeredAt(),
+                result.comments()
+                        .stream()
+                        .map(CourseQnaCommentResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseReviewSummaryResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseReviewSummaryResponse.java
@@ -1,0 +1,66 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.CourseReviewSummaryResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "강의 리뷰 요약 응답")
+public record CourseReviewSummaryResponse(
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "평균 평점", example = "4.6")
+        double averageRating,
+
+        @Schema(description = "전체 리뷰 수", example = "25")
+        int totalReviewCount,
+
+        @Schema(description = "5점 리뷰 수", example = "15")
+        int fiveStarCount,
+
+        @Schema(description = "4점 리뷰 수", example = "6")
+        int fourStarCount,
+
+        @Schema(description = "3점 리뷰 수", example = "3")
+        int threeStarCount,
+
+        @Schema(description = "2점 리뷰 수", example = "1")
+        int twoStarCount,
+
+        @Schema(description = "1점 리뷰 수", example = "0")
+        int oneStarCount,
+
+        @Schema(description = "5점 비율. 퍼센트 단위", example = "60.0")
+        double fiveStarRate,
+
+        @Schema(description = "4점 비율. 퍼센트 단위", example = "24.0")
+        double fourStarRate,
+
+        @Schema(description = "3점 비율. 퍼센트 단위", example = "12.0")
+        double threeStarRate,
+
+        @Schema(description = "2점 비율. 퍼센트 단위", example = "4.0")
+        double twoStarRate,
+
+        @Schema(description = "1점 비율. 퍼센트 단위", example = "0.0")
+        double oneStarRate
+) {
+
+    public static CourseReviewSummaryResponse from(CourseReviewSummaryResult result) {
+        return new CourseReviewSummaryResponse(
+                result.courseId(),
+                result.averageRating(),
+                result.totalReviewCount(),
+                result.fiveStarCount(),
+                result.fourStarCount(),
+                result.threeStarCount(),
+                result.twoStarCount(),
+                result.oneStarCount(),
+                result.fiveStarRate(),
+                result.fourStarRate(),
+                result.threeStarRate(),
+                result.twoStarRate(),
+                result.oneStarRate()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseStudentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseStudentResponse.java
@@ -1,0 +1,64 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.CourseStudentResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 강의 수강생 응답")
+public record CourseStudentResponse(
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "사용자 이름", example = "윤라프")
+        String name,
+
+        @Schema(description = "사용자 이메일", example = "testuser88@algoga.com")
+        String email,
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "강의 제목", example = "오사카 여행 준비 마스터")
+        String courseTitle,
+
+        @Schema(description = "전체 진도율", example = "100")
+        int progressRate,
+
+        @Schema(description = "완료한 챕터 수", example = "4")
+        int completedChapterCount,
+
+        @Schema(description = "전체 챕터 수", example = "4")
+        int totalChapterCount,
+
+        @Schema(description = "학습 상태. IN_PROGRESS 또는 COMPLETED", example = "COMPLETED")
+        String learningStatus,
+
+        @Schema(description = "퀴즈 제출 여부", example = "true")
+        boolean quizSubmitted,
+
+        @Schema(description = "리뷰 작성 여부", example = "false")
+        boolean reviewWritten,
+
+        @Schema(description = "수료 일시", example = "2026-05-26T15:30:00")
+        LocalDateTime completedAt
+) {
+
+    public static CourseStudentResponse from(CourseStudentResult result) {
+        return new CourseStudentResponse(
+                result.userId(),
+                result.name(),
+                result.email(),
+                result.courseId(),
+                result.courseTitle(),
+                result.progressRate(),
+                result.completedChapterCount(),
+                result.totalChapterCount(),
+                result.learningStatus(),
+                result.quizSubmitted(),
+                result.reviewWritten(),
+                result.completedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/DiagnosisResultResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/DiagnosisResultResponse.java
@@ -1,0 +1,31 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "진단평가 결과 응답")
+public record DiagnosisResultResponse(
+
+        @Schema(description = "사용자가 선택한 국가 ID", example = "1")
+        Long countryId,
+
+        @Schema(description = "정답 개수", example = "3")
+        Integer correctCount,
+
+        @Schema(description = "전체 문항 수", example = "5")
+        Integer totalCount,
+
+        @Schema(description = "점수", example = "60")
+        Integer score,
+
+        @Schema(description = "강의 난이도 코드", example = "INTERMEDIATE")
+        String level,
+
+        @Schema(description = "강의 난이도 이름", example = "중급")
+        String levelName,
+
+        @Schema(description = "추천 강의 목록")
+        List<CourseListResponse> recommendedCourses
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyCouponResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyCouponResponse.java
@@ -1,0 +1,64 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.MyCouponResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "마이페이지 쿠폰함 응답")
+public record MyCouponResponse(
+
+        @Schema(description = "사용자 쿠폰 ID", example = "1")
+        Long userCouponId,
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "강의명", example = "오사카 여행 준비 마스터")
+        String courseTitle,
+
+        @Schema(description = "쿠폰 정책 ID", example = "1")
+        Long couponPolicyId,
+
+        @Schema(description = "쿠폰명", example = "오사카 강의 수료 할인 쿠폰")
+        String couponName,
+
+        @Schema(description = "할인 타입. RATE 또는 AMOUNT", example = "RATE")
+        String discountType,
+
+        @Schema(description = "할인 값", example = "10")
+        int discountValue,
+
+        @Schema(description = "쿠폰 상태. ISSUED, USED, EXPIRED", example = "ISSUED")
+        String status,
+
+        @Schema(description = "사용 가능 여부", example = "true")
+        boolean usable,
+
+        @Schema(description = "발급 일시", example = "2026-05-26T15:30:00")
+        LocalDateTime issuedAt,
+
+        @Schema(description = "만료 일시", example = "2026-06-25T15:30:00")
+        LocalDateTime expiredAt,
+
+        @Schema(description = "사용 일시", example = "2026-05-27T12:00:00")
+        LocalDateTime usedAt
+) {
+
+    public static MyCouponResponse from(MyCouponResult result) {
+        return new MyCouponResponse(
+                result.userCouponId(),
+                result.courseId(),
+                result.courseTitle(),
+                result.couponPolicyId(),
+                result.couponName(),
+                result.discountType(),
+                result.discountValue(),
+                result.status(),
+                result.usable(),
+                result.issuedAt(),
+                result.expiredAt(),
+                result.usedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyCourseResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyCourseResponse.java
@@ -1,0 +1,76 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.MyCourseResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "마이페이지 수강 강의 응답")
+public record MyCourseResponse(
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "강의 제목", example = "오사카 여행 준비 마스터")
+        String title,
+
+        @Schema(description = "썸네일 URL", example = "thumbnails/sample.png")
+        String thumbnailUrl,
+
+        @Schema(description = "국가 ID", example = "1")
+        Long countryId,
+
+        @Schema(description = "국가명", example = "일본")
+        String countryName,
+
+        @Schema(description = "전체 진도율", example = "100")
+        int progressRate,
+
+        @Schema(description = "완료한 챕터 수", example = "4")
+        int completedChapterCount,
+
+        @Schema(description = "전체 챕터 수", example = "4")
+        int totalChapterCount,
+
+        @Schema(description = "학습 상태. IN_PROGRESS 또는 COMPLETED", example = "COMPLETED")
+        String learningStatus,
+
+        @Schema(description = "퀴즈 제출 여부", example = "true")
+        boolean quizSubmitted,
+
+        @Schema(description = "리뷰 작성 여부", example = "true")
+        boolean reviewWritten,
+
+        @Schema(description = "수료증 보기 버튼 노출 가능 여부", example = "true")
+        boolean certificateAvailable,
+
+        @Schema(description = "수료 코드", example = "ALG-2026-CERT-123456")
+        String certificateCode,
+
+        @Schema(description = "수료증 PDF 다운로드 API URL", example = "/api/v1/courses/3/certificate")
+        String certificateDownloadUrl,
+
+        @Schema(description = "수료 일시", example = "2026-05-26T15:30:00")
+        LocalDateTime completedAt
+) {
+
+    public static MyCourseResponse from(MyCourseResult result) {
+        return new MyCourseResponse(
+                result.courseId(),
+                result.title(),
+                result.thumbnailUrl(),
+                result.countryId(),
+                result.countryName(),
+                result.progressRate(),
+                result.completedChapterCount(),
+                result.totalChapterCount(),
+                result.learningStatus(),
+                result.quizSubmitted(),
+                result.reviewWritten(),
+                result.certificateAvailable(),
+                result.certificateCode(),
+                result.certificateDownloadUrl(),
+                result.completedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyMileageHistoryResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyMileageHistoryResponse.java
@@ -1,0 +1,44 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.MyMileageHistoryResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "마이페이지 마일리지 상세 내역 응답")
+public record MyMileageHistoryResponse(
+
+        @Schema(description = "마일리지 내역 ID", example = "1")
+        Long mileageHistoryId,
+
+        @Schema(description = "강의 ID", example = "3")
+        Long courseId,
+
+        @Schema(description = "강의명", example = "오사카 여행 준비 마스터")
+        String courseTitle,
+
+        @Schema(description = "마일리지 금액", example = "10000")
+        int amount,
+
+        @Schema(description = "마일리지 타입. EARN 또는 USE", example = "EARN")
+        String type,
+
+        @Schema(description = "사유", example = "강의 이수 및 퀴즈 완료 보상")
+        String reason,
+
+        @Schema(description = "생성 일시", example = "2026-05-26T15:30:00")
+        LocalDateTime createdAt
+) {
+
+    public static MyMileageHistoryResponse from(MyMileageHistoryResult result) {
+        return new MyMileageHistoryResponse(
+                result.mileageHistoryId(),
+                result.courseId(),
+                result.courseTitle(),
+                result.amount(),
+                result.type(),
+                result.reason(),
+                result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyMileageResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyMileageResponse.java
@@ -1,0 +1,35 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.MyMileageResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "마이페이지 마일리지 내역 응답")
+public record MyMileageResponse(
+
+        @Schema(description = "현재 보유 마일리지", example = "10000")
+        int totalMileage,
+
+        @Schema(description = "총 적립 마일리지", example = "10000")
+        int totalEarnedMileage,
+
+        @Schema(description = "총 사용 마일리지", example = "0")
+        int totalUsedMileage,
+
+        @Schema(description = "마일리지 상세 내역")
+        List<MyMileageHistoryResponse> histories
+) {
+
+    public static MyMileageResponse from(MyMileageResult result) {
+        return new MyMileageResponse(
+                result.totalMileage(),
+                result.totalEarnedMileage(),
+                result.totalUsedMileage(),
+                result.histories()
+                        .stream()
+                        .map(MyMileageHistoryResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/settings/LmsStorageSettings.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/settings/LmsStorageSettings.java
@@ -1,0 +1,25 @@
+package com.kidmily.algoga_server.lms.settings;
+
+import com.kidmily.algoga_server.global.port.out.StorageSettings;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class LmsStorageSettings implements StorageSettings {
+
+    private final String bucketName = "algoga-lms";
+
+    private final String courseThumbnailDirectory = "lms/course-thumbnails";
+
+    private final String courseFileDirectory = "lms/course-files";
+
+    private final String chapterVideoDirectory = "lms/chapter-videos";
+
+    private final String certificateDirectory = "lms/certificates";
+
+    @Override
+    public String getDirectory() {
+        return "lms";
+    }
+}


### PR DESCRIPTION
## 설명
LMS 강의 관리 및 진단평가 기반 추천 기능을 개선했습니다.

- 관리자 강의/챕터 관리 기능 보강
  - 챕터 최대 5개 등록 제한 추가
  - 챕터 순서 1~5 범위 검증
  - 동일 강의 내 챕터 순서 중복 방지
- 강의 난이도 기능 추가
  - 강의 level 저장 기능 추가
  - BEGINNER / INTERMEDIATE / ADVANCED 기준 적용
  - 강의 목록 및 상세 응답에 level, levelName 포함
- 진단평가 기능 구현
  - 진단평가 점수 계산
  - 정답 개수 기준 level 산정
    - 0~2개: 초급
    - 3~4개: 중급
    - 5개: 고급
  - 선택한 국가와 진단평가 결과 level 기반 추천 강의 응답
  - 추천 level과 별개로 초급/중급/고급 강의 목록 응답
- 관리자 수강생 관리 기능 추가
  - 강의별 수강생 목록 조회
  - 진도율, 수료 여부, 퀴즈 제출 여부, 리뷰 작성 여부 응답
- 관리자 마일리지 관리 기능 추가
  - 사용자별 마일리지 목록 조회
  - 사용자 마일리지 상세 내역 조회
  - 관리자 마일리지 지급/회수 기능 추가
- S3 파일 저장 방식 반영
  - 강의 썸네일/첨부파일 업로드 처리
  - 챕터 영상 업로드 처리
  - LMS 전용 StorageSettings를 통해 업로드 경로 관리

## 🔗 Issue
Closes #118

---

## 확인할 사항
- [ ] 콘텐츠 매니저 또는 슈퍼 관리자 토큰으로 관리자 API 접근이 가능한지 확인
- [ ] 강의 등록 시 level, 썸네일, 첨부파일이 정상 저장되는지 확인
- [ ] 강의 목록/상세 응답에 level, levelName이 정상 포함되는지 확인
- [ ] 챕터 등록 시 최대 5개 제한, 순서 범위, 순서 중복 검증이 정상 동작하는지 확인
- [ ] 진단평가 제출 시 정답 개수에 따라 초급/중급/고급 level이 정상 계산되는지 확인
- [ ] 진단평가 결과에서 선택 국가 기준 추천 강의 목록이 정상 응답되는지 확인
- [ ] 관리자 수강생 목록에서 진도율, 수료 여부, 퀴즈 제출 여부, 리뷰 작성 여부가 정상 응답되는지 확인
- [ ] 관리자 마일리지 지급/회수 후 목록 및 상세 내역에 정상 반영되는지 확인
- [ ] 강의 썸네일/첨부파일 및 챕터 영상 URL이 S3 경로로 저장되는지 확인