### PR TITLE
캘린더 - 강의 시작일, 만료일 둘 다 뜨게 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/calendar/application/port/LecturePort.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/port/LecturePort.java
@@ -1,5 +1,9 @@
 package com.kidmily.algoga_server.calendar.application.port;
 
+import java.time.LocalDate;
+
 public interface LecturePort {
     String getLectureName(Long lectureId);
+    LocalDate getLectureStartDate(Long lectureId);
+    LocalDate getLectureEndDate(Long lectureId);
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/service/CalendarQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/service/CalendarQueryService.java
@@ -38,7 +38,7 @@ public class CalendarQueryService implements CalendarQueryUseCase {
         List<Calendar> calendars = calendarRepository.findByUserIdAndDateRange(userId, startDate, endDate);
 
         List<ScheduleResponse> schedules = calendars.stream()
-                .map(this::toScheduleResponse)
+                .flatMap(calendar -> toScheduleResponses(calendar).stream())
                 .sorted((a, b) -> a.eventDate().compareTo(b.eventDate()))
                 .toList();
 
@@ -61,10 +61,24 @@ public class CalendarQueryService implements CalendarQueryUseCase {
     private String resolveTitle(Calendar calendar) {
         if (calendar.getType() == CalendarType.TRIP) {
             return accommodationPort.getAccommodationName(calendar.getReferenceId());
-        } else if (calendar.getType() == CalendarType.LECTURE) {
-            return lecturePort.getLectureName(calendar.getReferenceId());
         }
         return "D-day";
+    }
+
+    private List<ScheduleResponse> toScheduleResponses(Calendar calendar) {
+        if (calendar.getType() == CalendarType.LECTURE) {
+            String title = lecturePort.getLectureName(calendar.getReferenceId());
+            LocalDate startDate = lecturePort.getLectureStartDate(calendar.getReferenceId());
+            LocalDate endDate = lecturePort.getLectureEndDate(calendar.getReferenceId());
+
+            return List.of(
+                    new ScheduleResponse(calendar.getCalendarId(), title,
+                            CalendarType.LECTURE_START, startDate, calculateDDay(startDate)),
+                    new ScheduleResponse(calendar.getCalendarId(), title,
+                            CalendarType.LECTURE_END, endDate, calculateDDay(endDate))
+            );
+        }
+        return List.of(toScheduleResponse(calendar));
     }
 
     private String calculateDDay(LocalDate eventDate) {

--- a/src/main/java/com/kidmily/algoga_server/calendar/domain/model/CalendarType.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/domain/model/CalendarType.java
@@ -1,7 +1,9 @@
 package com.kidmily.algoga_server.calendar.domain.model;
 
 public enum CalendarType {
-    LECTURE,   // 강의
+    LECTURE,
+    LECTURE_START,  // 강의 시작일
+    LECTURE_END,    // 강의 만료일
     TRIP,      // 여행
     D_DAY      // D-day
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/LecturePortAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/LecturePortAdapter.java
@@ -3,6 +3,8 @@ package com.kidmily.algoga_server.calendar.infrastructure.adapter;
 import com.kidmily.algoga_server.calendar.application.port.LecturePort;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 // TODO: 강의 도메인 합쳐지면 실제 구현으로 교체
 @Component
 public class LecturePortAdapter implements LecturePort {
@@ -10,5 +12,15 @@ public class LecturePortAdapter implements LecturePort {
     @Override
     public String getLectureName(Long lectureId) {
         return "임시 강의명";
+    }
+
+    @Override
+    public LocalDate getLectureStartDate(Long lectureId) {
+        return LocalDate.of(2026, 5, 10); // 임시
+    }
+
+    @Override
+    public LocalDate getLectureEndDate(Long lectureId) {
+        return LocalDate.of(2026, 5, 15); // 임시
     }
 }


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
캘린더에 수강 강의의 시작일과 만료일이 표시될 수 있도록 데이터를 주는 것으로 수정

결제 로직 완성되면 연동 예정. 현재는 더미데이터로 테스트

## 🔗 Issue
Closes #

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 캘린더 조회 시 수강 강의의 시작일과 만료일이 표시되는가 

