### PR TITLE
featurea/accommodationimage 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/accommodation/application/command/CreateAccommodationCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/accommodation/application/command/CreateAccommodationCommand.java
@@ -1,10 +1,12 @@
 package com.kidmily.algoga_server.accommodation.application.command;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record CreateAccommodationCommand(
         Long countryId,
         String name,
         String address,
-        String imageUrl,
+        MultipartFile image,
         int pricePerNight,
         int nights,
         String description

--- a/src/main/java/com/kidmily/algoga_server/accommodation/application/command/UpdateAccommodationCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/accommodation/application/command/UpdateAccommodationCommand.java
@@ -1,9 +1,11 @@
 package com.kidmily.algoga_server.accommodation.application.command;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record UpdateAccommodationCommand(
         String name,
         String address,
-        String imageUrl,
+        MultipartFile image,
         int pricePerNight,
         int nights,
         String description

--- a/src/main/java/com/kidmily/algoga_server/accommodation/application/service/AccommodationCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/accommodation/application/service/AccommodationCommandService.java
@@ -6,7 +6,9 @@ import com.kidmily.algoga_server.accommodation.application.usecase.Accommodation
 import com.kidmily.algoga_server.accommodation.domain.model.Accommodation;
 import com.kidmily.algoga_server.accommodation.domain.repository.AccommodationRepository;
 import com.kidmily.algoga_server.accommodation.exception.AccommodationErrorCode;
+import com.kidmily.algoga_server.accommodation.settings.AccommodationStorageSettings;
 import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.global.port.out.FileStoragePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,13 +21,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class AccommodationCommandService implements AccommodationCommandUseCase {
 
     private final AccommodationRepository accommodationRepository;
+    private final FileStoragePort fileStoragePort;
+    private final AccommodationStorageSettings storageSettings;
 
     @Override
     public Long create(CreateAccommodationCommand command) {
         log.info("[AccommodationCommandService] 숙소 생성 - name: {}", command.name());
+
+        String imageUrl = fileStoragePort.uploadFile(
+                command.image(),
+                storageSettings.getBucketName(),
+                storageSettings.getImageDirectory()
+        );
+
         Accommodation accommodation = Accommodation.create(
                 command.countryId(), command.name(), command.address(),
-                command.imageUrl(), command.pricePerNight(), command.nights(),
+                imageUrl, command.pricePerNight(), command.nights(),
                 command.description()
         );
         Accommodation saved = accommodationRepository.save(accommodation);
@@ -38,7 +49,19 @@ public class AccommodationCommandService implements AccommodationCommandUseCase 
         log.info("[AccommodationCommandService] 숙소 수정 - id: {}", accommodationId);
         Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new BusinessException(AccommodationErrorCode.ACCOMMODATION_NOT_FOUND));
-        accommodation.update(command.name(), command.address(), command.imageUrl(),
+
+        String targetImageUrl = accommodation.getImageUrl();
+
+        if (command.image() != null && !command.image().isEmpty()) {
+            fileStoragePort.deleteFile(storageSettings.getBucketName(), accommodation.getImageUrl());
+            targetImageUrl = fileStoragePort.uploadFile(
+                    command.image(),
+                    storageSettings.getBucketName(),
+                    storageSettings.getImageDirectory()
+            );
+        }
+
+        accommodation.update(command.name(), command.address(), targetImageUrl,
                 command.pricePerNight(), command.nights(), command.description());
         accommodationRepository.save(accommodation);
     }
@@ -46,8 +69,9 @@ public class AccommodationCommandService implements AccommodationCommandUseCase 
     @Override
     public void delete(Long accommodationId) {
         log.info("[AccommodationCommandService] 숙소 삭제 - id: {}", accommodationId);
-        accommodationRepository.findById(accommodationId)
+        Accommodation accommodation = accommodationRepository.findById(accommodationId)
                 .orElseThrow(() -> new BusinessException(AccommodationErrorCode.ACCOMMODATION_NOT_FOUND));
+        fileStoragePort.deleteFile(storageSettings.getBucketName(), accommodation.getImageUrl());
         accommodationRepository.deleteById(accommodationId);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/accommodation/presentation/api/AccommodationController.java
+++ b/src/main/java/com/kidmily/algoga_server/accommodation/presentation/api/AccommodationController.java
@@ -12,12 +12,14 @@ import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -48,28 +50,34 @@ public class AccommodationController {
         return ResponseEntity.ok(ApiResponse.success("ACCOMMODATION_FOUND", "숙소 조회에 성공했습니다.", response));
     }
 
-    @PostMapping("/api/v1/admin/accommodations")
+    @PostMapping(value = "/api/v1/admin/accommodations", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "[어드민] 숙소 등록")
     public ResponseEntity<ApiResponse<Long>> create(
-            @Valid @RequestBody CreateAccommodationRequest request
+            @RequestPart("data")
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            CreateAccommodationRequest request,
+            @RequestPart("image") MultipartFile image
     ) {
         Long id = accommodationCommandUseCase.create(new CreateAccommodationCommand(
                 request.countryId(), request.name(), request.address(),
-                request.imageUrl(), request.pricePerNight(), request.nights(), request.description()
+                image, request.pricePerNight(), request.nights(), request.description()
         ));
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("ACCOMMODATION_CREATED", "숙소가 등록됐습니다.", id));
     }
 
-    @PutMapping("/api/v1/admin/accommodations/{accommodationId}")
+    @PutMapping(value = "/api/v1/admin/accommodations/{accommodationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "[어드민] 숙소 수정")
     @ApiErrorCodeExample(domain = AccommodationErrorCode.class, value = {"ACCOMMODATION_NOT_FOUND"})
     public ResponseEntity<ApiResponse<Void>> update(
             @PathVariable Long accommodationId,
-            @Valid @RequestBody UpdateAccommodationRequest request
+            @RequestPart("data")
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            UpdateAccommodationRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image
     ) {
         accommodationCommandUseCase.update(accommodationId, new UpdateAccommodationCommand(
-                request.name(), request.address(), request.imageUrl(),
+                request.name(), request.address(), image,
                 request.pricePerNight(), request.nights(), request.description()
         ));
         return ResponseEntity.ok(ApiResponse.success("ACCOMMODATION_UPDATED", "숙소가 수정됐습니다."));

--- a/src/main/java/com/kidmily/algoga_server/accommodation/presentation/api/request/CreateAccommodationRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/accommodation/presentation/api/request/CreateAccommodationRequest.java
@@ -8,7 +8,6 @@ public record CreateAccommodationRequest(
         @NotNull Long countryId,
         @NotBlank String name,
         @NotBlank String address,
-        String imageUrl,
         @Positive int pricePerNight,
         @Positive int nights,
         String description

--- a/src/main/java/com/kidmily/algoga_server/accommodation/presentation/api/request/UpdateAccommodationRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/accommodation/presentation/api/request/UpdateAccommodationRequest.java
@@ -2,11 +2,12 @@ package com.kidmily.algoga_server.accommodation.presentation.api.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import org.springframework.web.multipart.MultipartFile;
 
 public record UpdateAccommodationRequest(
         @NotBlank String name,
         @NotBlank String address,
-        String imageUrl,
+        MultipartFile image,
         @Positive int pricePerNight,
         @Positive int nights,
         String description

--- a/src/main/java/com/kidmily/algoga_server/accommodation/settings/AccommodationStorageSettings.java
+++ b/src/main/java/com/kidmily/algoga_server/accommodation/settings/AccommodationStorageSettings.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.accommodation.settings;
+
+import com.kidmily.algoga_server.global.port.out.StorageSettings;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class AccommodationStorageSettings implements StorageSettings {
+
+    private final String bucketName = "algoga-accommodation";
+    private final String imageDirectory = "accommodation/images";
+
+    @Override
+    public String getDirectory() {
+        return "accommodation";
+    }
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
숙소 등록/수정 시 이미지 파일을 S3(MinIO)에 업로드하는 기능을 추가했습니다.
기존에 imageUrl 문자열을 직접 입력받던 방식에서 MultipartFile로 이미지를 받아 업로드 후 URL을 저장하는 방식으로 변경했습니다.

## 🔗 Issue
Closes #142 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 숙소 등록 시 이미지 파일 업로드 후 S3 URL이 DB에 저장되는지 확인
- [ ] 숙소 수정 시 이미지 변경하면 기존 이미지 삭제 후 새 이미지 업로드되는지 확인
- [ ] 이미지 없이 수정 요청 시 기존 이미지 URL 유지되는지 확인
- [ ] 숙소 삭제 시 S3 이미지도 함께 삭제되는지 확인