### PR TITLE
[Feat] AOP 전역 로깅 고도화 (유저 정보 추가 및 Service 로깅 분리 적용)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/aop/ApiLoggingAop.java
+++ b/src/main/java/com/kidmily/algoga_server/global/aop/ApiLoggingAop.java
@@ -5,10 +5,10 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-
 import jakarta.servlet.http.HttpServletRequest;
 
 @Slf4j
@@ -16,39 +16,85 @@ import jakarta.servlet.http.HttpServletRequest;
 @Component
 public class ApiLoggingAop {
 
-    // 클린 아키텍처 구조에 맞게 presentation 계층의 모든 Controller를 타겟팅합니다.
-    // (만약 Controller 패키지 구조가 다르면 아래 경로를 수정하세요)
+    // ==========================================
+    // 1. Pointcut 정의
+    // ==========================================
+
+    // Presentation 계층 (Controller)
     @Pointcut("execution(* com.kidmily.algoga_server.*..presentation..*Controller.*(..))")
     private void controllerPointcut() {}
 
+    // Application 계층 (Service, UseCase)
+    // 하연님 구조에 맞춰 Service와 UseCase를 모두 포함하도록 정규식 작성
+    @Pointcut("execution(* com.kidmily.algoga_server.*..application..*Service.*(..)) || " +
+            "execution(* com.kidmily.algoga_server.*..application..*UseCase.*(..))")
+    private void applicationPointcut() {}
+
+
+    // ==========================================
+    // 2. Controller 로깅 (HTTP 요청/응답 전문)
+    // ==========================================
     @Around("controllerPointcut()")
-    public Object logApi(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object logController(ProceedingJoinPoint joinPoint) throws Throwable {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String userId = "Anonymous";
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
+            userId = auth.getName();
+        }
 
         String method = request.getMethod();
         String requestUri = request.getRequestURI();
         String controllerName = joinPoint.getSignature().getDeclaringType().getSimpleName();
         String methodName = joinPoint.getSignature().getName();
 
-        // 1. 요청 로그
-        log.info("[API Request] {} {} | Controller: {}.{}()", method, requestUri, controllerName, methodName);
+        log.info("[API Request] User: {} | {} {} | Controller: {}.{}()",
+                userId, method, requestUri, controllerName, methodName);
 
         long startTime = System.currentTimeMillis();
-
         try {
-            // 2. 실제 컨트롤러 로직 실행
             Object result = joinPoint.proceed();
-
-            // 3. 성공 응답 로그 및 실행 시간 측정
             long executionTime = System.currentTimeMillis() - startTime;
             log.info("[API Response] {} {} | Time: {}ms", method, requestUri, executionTime);
-
             return result;
         } catch (Exception e) {
-            // 4. 예외 발생 시 로그 (GlobalExceptionHandler로 넘어가기 전)
             long executionTime = System.currentTimeMillis() - startTime;
-            log.warn("[API Error] {} {} | Time: {}ms | Exception: {}", method, requestUri, executionTime, e.getClass().getSimpleName());
-            throw e; // 예외를 던져서 GlobalExceptionHandler가 처리하게 함
+            log.error("[API Error] {} {} | Time: {}ms | Exception: {}", method, requestUri, executionTime, e.getClass().getSimpleName());
+            throw e;
+        }
+    }
+
+
+    // ==========================================
+    // 3. Service 로깅 (비즈니스 로직 중심, HTTP 몰라도 됨)
+    // ==========================================
+    @Around("applicationPointcut()")
+    public Object logService(ProceedingJoinPoint joinPoint) throws Throwable {
+        String serviceName = joinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = joinPoint.getSignature().getName();
+        Object[] args = joinPoint.getArgs();
+
+        // 서비스는 HTTP URI가 없으므로 클래스.메서드명과 파라미터만 찍습니다.
+        log.info("[Service Start] {}.{}() | Args: {}", serviceName, methodName, args);
+
+        long startTime = System.currentTimeMillis();
+        try {
+            Object result = joinPoint.proceed();
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            // 성능 경고 (비즈니스 로직이 1초 이상 걸리면 경고)
+            if (executionTime > 1000) {
+                log.warn("[Performance Warning] {}.{}() 실행 시간이 {}ms로 느립니다!", serviceName, methodName, executionTime);
+            } else {
+                log.info("[Service End] {}.{}() | Time: {}ms", serviceName, methodName, executionTime);
+            }
+            return result;
+        } catch (Exception e) {
+            long executionTime = System.currentTimeMillis() - startTime;
+            log.error("[Service Error] {}.{}() | Time: {}ms | Exception: {} | Msg: {}",
+                    serviceName, methodName, executionTime, e.getClass().getSimpleName(), e.getMessage());
+            throw e;
         }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -58,6 +58,8 @@ public class AuthService {
                 .termsMarketingAgreed(request.termsMarketingAgreed())
                 .build();
         userRepository.save(user);
+
+        log.info("신규 회원가입 완료 [아이디: {}, 이메일: {}]", user.getUsername(), user.getEmail());
     }
 
     // 2. 로그인
@@ -66,17 +68,30 @@ public class AuthService {
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
 
         if (user.isDeleted()) throw new UserException(UserErrorCode.DELETED_USER);
-        if (user.isAccountLocked()) throw new UserException(UserErrorCode.ACCOUNT_LOCKED);
+        if (user.isAccountLocked()) {
+            log.warn("잠긴 계정에 로그인 시도 발생 [아이디: {}]", user.getUsername());
+            throw new UserException(UserErrorCode.ACCOUNT_LOCKED);
+        }
+
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             user.increaseLoginFailure();
             userRepository.save(user);
+
+            if (user.isAccountLocked()) {
+                log.warn("비밀번호 5회 연속 오류로 계정 잠금 처리됨 [아이디: {}]", user.getUsername());
+            } else {
+                log.warn("비밀번호 입력 오류 [아이디: {}, 누적 실패: {}/5]", user.getUsername(), user.getLoginFailCount());
+            }
             throw new UserException(UserErrorCode.INVALID_PASSWORD);
         }
+
         user.resetLoginFailure();
         userRepository.save(user);
 
         String accessToken = globalJwtProvider.createUserAccessToken(user.getEmail());
         String refreshToken = globalJwtProvider.createUserRefreshToken(user.getEmail());
+
+        log.info("로그인 성공 [아이디: {}]", user.getUsername());
 
         return new AuthTokenResponse(accessToken, refreshToken, user.getRequiresPasswordChange());
     }
@@ -87,13 +102,15 @@ public class AuthService {
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
 
         String username = user.getUsername();
+        String maskedId = maskId(username);
 
-        return new FindIdResponse(maskId(username));
+        log.info("아이디 찾기 완료 [요청 이메일: {}, 마스킹된 아이디 반환: {}]", request.email(), maskedId);
+
+        return new FindIdResponse(maskedId);
     }
 
     // 4. 비밀번호 찾기
     public void findPassword(FindPasswordRequest request) {
-        // ⭐️ findByNameAndEmail -> findByUsernameAndEmail로 변경
         User user = userRepository.findByUsernameAndEmail(request.username(), request.email().toLowerCase())
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
 
@@ -101,14 +118,12 @@ public class AuthService {
         user.setTemporaryPassword(passwordEncoder.encode(tempPassword));
         userRepository.save(user);
 
-        // 이메일 전송 내용 작성
         String subject = "[ALGOGA] 임시 비밀번호 발급 안내";
         String body = "안녕하세요, ALGOGA입니다.\n\n"
                 + "요청하신 임시 비밀번호는 다음과 같습니다.\n"
                 + "임시 비밀번호 : " + tempPassword + "\n\n"
                 + "로그인 후 반드시 비밀번호를 변경해 주세요.";
 
-        // 인터페이스를 통해 메일 전송 명령
         emailSender.sendEmail(user.getEmail(), subject, body);
 
         log.info("임시 비밀번호 발급 및 메일 전송 완료. [요청 이메일: {}]", user.getEmail());
@@ -119,33 +134,25 @@ public class AuthService {
         return id.substring(0, 3) + "*".repeat(id.length() - 3);
     }
 
-    // 5. 비밀번호 강제 변경 (임시 비밀번호로 로그인한 유저 대상)
+    // 비밀번호 강제 변경 (임시 비밀번호로 로그인한 유저 대상)
     public void resetPassword(String email, ResetPasswordRequest request) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
 
-        // 만약 임시 비밀번호로 로그인한 상태가 아니라면 에러 발생! (보안 방어)
         if (!user.getRequiresPasswordChange()) {
-            throw new UserException(UserErrorCode.INVALID_PASSWORD); // "정상적인 변경 요청이 아닙니다" 등으로 에러코드 추가해도 좋음!
+            log.warn("비정상적인 비밀번호 강제 변경 시도 탐지 (변경 대상이 아님) [이메일: {}]", email);
+            throw new UserException(UserErrorCode.INVALID_PASSWORD);
         }
-        // 1. 새 비밀번호 암호화
+
         String encodedNewPassword = passwordEncoder.encode(request.newPassword());
-
-        // 2. User 엔티티의 changePassword 메서드 호출 (비번 변경 + 플래그 false 처리)
         user.changePassword(encodedNewPassword);
-
-        userRepository.save(user); // 3. 저장
+        userRepository.save(user);
 
         log.info("비밀번호 강제 변경 완료 [이메일: {}]", email);
     }
 
-    // 6. 로그아웃
+    // 로그아웃
     public void logout(String email) {
-        // 현재 Redis를 사용하지 않으므로, 백엔드에서는 로그만 남깁니다.
-        // (실제 토큰 무효화는 클라이언트가 localStorage에서 토큰을 지우는 것으로 완료됩니다.)
         log.info("로그아웃 처리 완료 [접속 종료 이메일: {}]", email);
     }
-
-
-
 }

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
@@ -29,11 +29,11 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final GlobalJwtProvider globalJwtProvider;
 
-    // 🌟 S3 스토리지 공통 포트 및 유저 세팅 인프라 빈 주입
+    // S3 스토리지 공통 포트 및 유저 세팅 인프라 빈 주입
     private final FileStoragePort fileStoragePort;
     private final UserStorageSettings storageSettings;
 
-    // 1. 내 프로필 조회
+    // 내 프로필 조회
     @Transactional(readOnly = true)
     public UserProfileResponse getMyProfile(String email) {
         User user = userRepository.findByEmailAndIsDeletedFalse(email)
@@ -41,18 +41,21 @@ public class UserService {
         return UserProfileResponse.from(user);
     }
 
-    // 2. 정보 수정 진입 전 비밀번호 검증
+    // 정보 수정 진입 전 비밀번호 검증
     @Transactional(readOnly = true)
     public void verifyPassword(String email, VerifyPasswordRequest request) {
         User user = userRepository.findByEmailAndIsDeletedFalse(email)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new UserException(UserErrorCode.INVALID_PASSWORD); // "비밀번호가 일치하지 않습니다" 에러
+            log.warn("정보 수정 진입 전 비밀번호 검증 실패 [이메일: {}]", email);
+            throw new UserException(UserErrorCode.INVALID_PASSWORD);
         }
+
+        log.info("정보 수정 진입 전 비밀번호 검증 성공 [이메일: {}]", email);
     }
 
-    // 3. 내 프로필 수정
+    // 내 프로필 수정
     @Transactional
     public AuthTokenResponse updateProfile(String email, UpdateProfileRequest request) {
         User user = userRepository.findByEmailAndIsDeletedFalse(email)
@@ -63,32 +66,36 @@ public class UserService {
         // 이메일 변경 시 중복 체크
         if (!newEmail.equals(user.getEmail())) {
             if (userRepository.existsByEmail(newEmail)) {
+
+                log.warn("프로필 수정 중 이메일 중복 발생 [기존: {}, 변경 시도: {}]", user.getEmail(), newEmail);
                 throw new UserException(UserErrorCode.ALREADY_EXISTS_EMAIL);
             }
+
+            log.info("회원 이메일 변경 진행 [기존: {} -> 새 이메일: {}]", user.getEmail(), newEmail);
         }
 
-        // 🌟 S3 이미지 스토리지 업로드 분기 처리 로직
+        // S3 이미지 스토리지 업로드 분기 처리 로직
         String targetImageUrl = user.getProfileImageUrl();
         MultipartFile imageFile = request.profileImage();
 
         if (imageFile != null && !imageFile.isEmpty()) {
-            // 기존 등록된 이미지가 존재하면 S3 버킷에서 선제적으로 안전하게 무효화(삭제)
             if (targetImageUrl != null && !targetImageUrl.isBlank()) {
                 fileStoragePort.deleteFile(storageSettings.getBucketName(), targetImageUrl);
             }
-            // 새로운 멀티파트 파일을 지정 버킷 및 디렉토리에 전송 후 엔드포인트 URL 추출
             targetImageUrl = fileStoragePort.uploadFile(
                     imageFile,
                     storageSettings.getBucketName(),
                     storageSettings.getDirectory()
             );
+            log.info("회원 프로필 이미지 S3 업로드 완료 [이메일: {}]", newEmail);
         }
 
         // Entity 내부 값 업데이트 (Dirty Checking 유도)
         user.updateProfile(request.nickname(), request.phone(), targetImageUrl, newEmail);
 
-        // 새로운 식별정보를 기반으로 신규 세션 토큰 재발급
         String newToken = globalJwtProvider.createUserAccessToken(newEmail);
+
+        log.info("프로필 정보 수정 완료 [이메일: {}]", newEmail);
 
         return new AuthTokenResponse(
                 newToken,
@@ -97,7 +104,7 @@ public class UserService {
         );
     }
 
-    // 4. 비밀번호 변경
+    // 비밀번호 변경
     @Transactional
     public void updatePassword(String email, UpdatePasswordRequest request) {
         User user = userRepository.findByEmailAndIsDeletedFalse(email)
@@ -105,19 +112,23 @@ public class UserService {
 
         // 기존 비밀번호가 맞는지 확인
         if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            log.warn("비밀번호 변경 실패: 현재 비밀번호 불일치 [이메일: {}]", email);
             throw new UserException(UserErrorCode.INVALID_PASSWORD);
         }
 
         // 새 비밀번호 암호화 후 변경
         user.updatePassword(passwordEncoder.encode(request.newPassword()));
+
+        log.info("회원 비밀번호 변경 완료 [이메일: {}]", email);
     }
 
-    // 1. 회원 탈퇴 (Soft Delete)
+    // 회원 탈퇴 (Soft Delete)
     public void withdraw(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
 
         if (user.isDeleted()) {
+            log.warn("비정상적 접근: 이미 탈퇴한 계정에 탈퇴 요청 [이메일: {}]", email);
             throw new UserException(UserErrorCode.DELETED_USER);
         }
 
@@ -126,6 +137,4 @@ public class UserService {
         // @Transactional 안에서 엔티티 값이 변경되면 JPA가 알아서 DB에 UPDATE 쿼리를 날립니다! (더티 체킹)
         log.info("회원 탈퇴 처리 완료 [이메일: {}]", email);
     }
-
-
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
@@ -68,14 +68,14 @@ public class AuthController {
     @Operation(summary = "비밀번호 찾기", description = "아이디와 이메일 일치 시 임시 비밀번호를 발급합니다.")
     @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"NOT_FOUND_USER"})
     @PostMapping("/find-password")
-    public ApiResponse<Void> findPassword(@RequestBody @Valid FindPasswordRequest request) { // ⭐️ FindIdRequest -> FindPasswordRequest로 변경
+    public ApiResponse<Void> findPassword(@RequestBody @Valid FindPasswordRequest request) {
         authService.findPassword(request);
         return ApiResponse.success("AUTH_FIND_PW_SUCCESS", "임시 비밀번호가 이메일로 발송되었습니다.");
     }
 
     // 임시비번 발급 후 비밀번호 강제 변경
     @Operation(summary = "비밀번호 강제 변경", description = "임시 비밀번호로 로그인한 후, 새 비밀번호로 강제 변경합니다.")
-    @PatchMapping("/reset-password") // ⭐️ POST 대신 리소스를 부분 수정하는 PATCH 사용!
+    @PatchMapping("/reset-password")
     public ApiResponse<Void> resetPassword(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid ResetPasswordRequest request) {

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/UpdateProfileRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/UpdateProfileRequest.java
@@ -12,7 +12,7 @@ public record UpdateProfileRequest(
         @Schema(description = "전화번호", example = "010-1234-5678")
         String phone,
 
-        // 🌟 MultipartFile에는 @Parameter를 붙여서 스웨거가 파일로 인식하게 합니다.
+        // MultipartFile에는 @Parameter를 붙여서 스웨거가 파일로 인식하게 합니다.
         @Parameter(description = "프로필 이미지 파일")
         MultipartFile profileImage,
 


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
1. 상세 디버깅 정보 추가
   - Controller 로그에 인증된 `userId`와 입력받은 파라미터(`args`)가 함께 기록된다.
2. Service / UseCase 로깅 영역 확장 및 분리
   - application패키지 하위의 서비스 로직들도 AOP 로깅 대상에 추가했습니다.
   - Service 로깅 시에는 HttpServletRequest를 꺼내지 않도록 별도의 @Around 메서드로 분리하여, 내부 배치/비동기 작업 시 발생할 수 있는 에러를 원천 차단했다.
3. Slow Logic 탐지 기능 추가
   - 비즈니스 로직 실행이 1000ms 초과 시 [Performance Warning] 로그를 남기도록 개선했다.
4. 에러 로깅 고도화
   - 기존의 클래스명만 찍히던 에러 로그에 e.getMessage()를 추가하고 에러 레벨을 error로 변경했습니다.

## 🔗 Issue
Closes #144 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- 컨트롤러와 서비스 영역의 로그 포맷이 역할에 맞게 다르게 찍힌다. 
- 향후 기능 개발 시, 일반적인 시작/종료 로그는 AOP에 맡기시고 중요 비즈니스 사건에만 직접 로그를 작성해 주시면 된다.

