### PR TITLE
[Feat] Redis 기반 이메일 인증 및 Refresh Token 관리 시스템 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 // 이메일
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // Redis 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/kidmily/algoga_server/global/config/RedisConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.kidmily.algoga_server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // 데이터가 깨져 보이지 않게 String(문자열)으로 직렬화해주는 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -6,6 +6,8 @@ import com.kidmily.algoga_server.user.domain.Gender;
 import com.kidmily.algoga_server.user.domain.SocialType;
 import com.kidmily.algoga_server.user.domain.User;
 import com.kidmily.algoga_server.user.domain.UserRepository;
+import com.kidmily.algoga_server.user.exception.AuthErrorCode;
+import com.kidmily.algoga_server.user.exception.AuthException;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
 import com.kidmily.algoga_server.user.exception.UserException;
 import com.kidmily.algoga_server.user.presentation.request.*;
@@ -13,12 +15,14 @@ import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
 import com.kidmily.algoga_server.user.presentation.response.FindIdResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -30,15 +34,69 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final GlobalJwtProvider globalJwtProvider;
     private final EmailSender emailSender;
+    private final RedisTemplate<String, String> redisTemplate; // Redis 도구 주입!
 
-    // 1. 회원가입
-    public void signup(AuthSignupRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
-            throw new UserException(UserErrorCode.ALREADY_EXISTS_EMAIL);
+    // 이메일 인증번호 발송
+    public void sendVerificationCode(SendEmailCodeRequest request) {
+        String email = request.email().toLowerCase();
+
+        if (userRepository.existsByEmail(email)) {
+            throw new AuthException(AuthErrorCode.DUPLICATE_EMAIL);
         }
+
+        // 6자리 랜덤 난수 생성
+        String code = String.valueOf((int) (Math.random() * 899999) + 100000);
+
+        // Redis에 저장 (키: "AUTH_CODE:이메일", 값: 인증번호, 만료시간: 3분)
+        redisTemplate.opsForValue().set("AUTH_CODE:" + email, code, 3, TimeUnit.MINUTES);
+
+        // 이메일 발송
+        String subject = "[ALGOGA] 회원가입 이메일 인증번호";
+        String body = "안녕하세요, ALGOGA입니다.\n\n"
+                + "요청하신 회원가입 인증번호는 다음과 같습니다.\n"
+                + "인증번호 : [" + code + "]\n\n"
+                + "3분 이내에 입력해 주세요.";
+
+        emailSender.sendEmail(email, subject, body);
+        log.info("회원가입 인증번호 발송 완료 [요청 이메일: {}]", email);
+    }
+
+    // 이메일 인증번호 확인
+    public void verifyEmailCode(VerifyEmailCodeRequest request) {
+        String email = request.email().toLowerCase();
+
+        // 1. Redis에서 해당 이메일의 인증번호 꺼내기
+        String savedCode = redisTemplate.opsForValue().get("AUTH_CODE:" + email);
+
+        // 2. 검증 (포스트잇이 없거나, 번호가 다르면 에러!)
+        if (savedCode == null || !savedCode.equals(request.code())) {
+            throw new AuthException(AuthErrorCode.EMAIL_AUTH_CODE_MISMATCH);
+        }
+
+        // 3. 인증 성공 시: 기존 포스트잇 떼서 버리고, "인증 완료" 포스트잇을 30분짜리로 새로 붙임
+        redisTemplate.delete("AUTH_CODE:" + email);
+        redisTemplate.opsForValue().set("AUTH_SUCCESS:" + email, "true", 30, TimeUnit.MINUTES);
+
+        log.info("이메일 인증 성공 [이메일: {}]", email);
+    }
+
+    // 최종 회원가입
+    public void signup(AuthSignupRequest request) {
+        String email = request.email().toLowerCase();
+
+        if (userRepository.existsByEmail(email)) {
+            throw new AuthException(AuthErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 가입 직전에 Redis에 "인증 완료" 포스트잇이 있는지 확인!
+        String isVerified = redisTemplate.opsForValue().get("AUTH_SUCCESS:" + email);
+        if (isVerified == null || !isVerified.equals("true")) {
+            throw new AuthException(AuthErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
         User user = User.builder()
                 .username(request.username())
-                .email(request.email().toLowerCase())
+                .email(email)
                 .password(passwordEncoder.encode(request.password()))
                 .name(request.name())
                 .phone(request.phone())
@@ -59,10 +117,13 @@ public class AuthService {
                 .build();
         userRepository.save(user);
 
+        // 가입이 성공적으로 끝났으니, "인증 완료" 포스트잇도 떼서 버립니다! (청소)
+        redisTemplate.delete("AUTH_SUCCESS:" + email);
+
         log.info("신규 회원가입 완료 [아이디: {}, 이메일: {}]", user.getUsername(), user.getEmail());
     }
 
-    // 2. 로그인
+    // 4. 로그인
     public AuthTokenResponse login(AuthLoginRequest request) {
         User user = userRepository.findByUsername(request.username())
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
@@ -91,12 +152,20 @@ public class AuthService {
         String accessToken = globalJwtProvider.createUserAccessToken(user.getEmail());
         String refreshToken = globalJwtProvider.createUserRefreshToken(user.getEmail());
 
+        // Redis에 Refresh Token 저장 (만료시간 7일)
+        redisTemplate.opsForValue().set(
+                "RT:" + user.getEmail(),
+                refreshToken,
+                604800000,
+                TimeUnit.MILLISECONDS
+        );
+
         log.info("로그인 성공 [아이디: {}]", user.getUsername());
 
         return new AuthTokenResponse(accessToken, refreshToken, user.getRequiresPasswordChange());
     }
 
-    // 3. 아이디 찾기 (아이디를 가져와서 마스킹하도록 수정)
+    // 5. 아이디 찾기
     public FindIdResponse findId(FindIdRequest request) {
         User user = userRepository.findByNameAndEmail(request.name(), request.email().toLowerCase())
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
@@ -109,7 +178,7 @@ public class AuthService {
         return new FindIdResponse(maskedId);
     }
 
-    // 4. 비밀번호 찾기
+    // 6. 비밀번호 찾기
     public void findPassword(FindPasswordRequest request) {
         User user = userRepository.findByUsernameAndEmail(request.username(), request.email().toLowerCase())
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
@@ -134,7 +203,7 @@ public class AuthService {
         return id.substring(0, 3) + "*".repeat(id.length() - 3);
     }
 
-    // 비밀번호 강제 변경 (임시 비밀번호로 로그인한 유저 대상)
+    // 7. 비밀번호 강제 변경
     public void resetPassword(String email, ResetPasswordRequest request) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
@@ -151,8 +220,21 @@ public class AuthService {
         log.info("비밀번호 강제 변경 완료 [이메일: {}]", email);
     }
 
-    // 로그아웃
+    // 8. 로그아웃 (Redis에서 토큰 삭제 로직 추가됨)
     public void logout(String email) {
+        // Redis에서 해당 유저의 Refresh Token 삭제
+        redisTemplate.delete("RT:" + email);
         log.info("로그아웃 처리 완료 [접속 종료 이메일: {}]", email);
+    }
+
+    // 토큰 재발급을 위한 검증 메서드 (이게 있어야 재발급이 됩니다!)
+    public String refreshAccessToken(String email, String refreshToken) {
+        String savedRefreshToken = redisTemplate.opsForValue().get("RT:" + email);
+
+        if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        return globalJwtProvider.createUserAccessToken(email);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/exception/AuthErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/user/exception/AuthErrorCode.java
@@ -8,11 +8,28 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements BaseErrorCode {
+    // 1. 회원가입 관련
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH_001", "이미 사용 중인 이메일입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH_002", "비밀번호는 영문, 숫자 조합 8자 이상이어야 합니다."),
-    INVALID_USER_INFO(HttpStatus.BAD_REQUEST, "AUTH_003", "필수 회원 정보가 누락되었습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 계정입니다.");
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "AUTH_002", "이미 사용 중인 아이디입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "AUTH_003", "이미 사용 중인 닉네임입니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_004", "비밀번호는 영문, 숫자 조합 8자 이상이어야 합니다."),
 
+    // 2. 로그인 및 인증 관련
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_005", "존재하지 않는 계정입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_006", "아이디 또는 비밀번호가 틀렸습니다."),
+    ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "AUTH_007", "비밀번호 5회 오류로 인해 5분간 계정이 잠겼습니다."),
+    DELETED_USER(HttpStatus.FORBIDDEN, "AUTH_008", "탈퇴한 계정입니다."),
+
+    // 3. 토큰 관련 (가장 많이 쓰임!)
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_009", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_010", "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_011", "로그아웃되었거나 만료된 토큰입니다."),
+
+    // 4. 이메일 인증 관련 (추가하신다면 필수!)
+    EMAIL_AUTH_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH_012", "인증번호가 만료되었습니다."),
+    EMAIL_AUTH_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_013", "인증번호가 일치하지 않습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH_014", "이메일 인증이 완료되지 않았습니다.");
+    
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/kidmily/algoga_server/user/exception/AuthException.java
+++ b/src/main/java/com/kidmily/algoga_server/user/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.user.exception;
+
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+
+public class AuthException extends BusinessException {
+    public AuthException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/exception/UserErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/user/exception/UserErrorCode.java
@@ -9,12 +9,20 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
-    ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "USER_001", "이미 사용 중인 이메일입니다."),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER_002", "존재하지 않는 계정입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER_003", "아이디 또는 비밀번호가 틀렸습니다."),
-    DELETED_USER(HttpStatus.FORBIDDEN, "USER_004", "탈퇴한 계정입니다."),
-    ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "USER_005", "비밀번호 5회 오류로 인해 5분간 계정이 잠겼습니다.");
+    // 조회 실패 관련
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 계정입니다."),
 
+    // 중복 방지 관련
+    ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "USER_002", "이미 사용 중인 이메일입니다."),
+    ALREADY_EXISTS_USERNAME(HttpStatus.CONFLICT, "USER_003", "이미 사용 중인 아이디입니다."),
+    ALREADY_EXISTS_NICKNAME(HttpStatus.CONFLICT, "USER_004", "이미 사용 중인 닉네임입니다."),
+    ALREADY_EXISTS_PHONE(HttpStatus.CONFLICT, "USER_005", "이미 사용 중인 전화번호입니다."),
+
+    // 인증 및 보안 관련
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER_006", "아이디 또는 비밀번호가 틀렸습니다."),
+    DELETED_USER(HttpStatus.FORBIDDEN, "USER_007", "탈퇴한 계정입니다."),
+    ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "USER_008", "비밀번호 5회 오류로 인해 5분간 계정이 잠겼습니다."),
+    UNAUTHORIZED_PASSWORD_RESET(HttpStatus.FORBIDDEN, "USER_009", "비밀번호 변경(초기화) 대상자가 아닙니다."); // 임시 비번 강제 변경 방어용
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/AuthController.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.user.presentation;
 
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.security.GlobalJwtProvider;
 import com.kidmily.algoga_server.user.application.AuthService;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
 import com.kidmily.algoga_server.user.presentation.request.*;
@@ -17,11 +18,13 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth", description = "회원 인증 API")
 @RestController
+
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
     private final AuthService authService;
+    private final GlobalJwtProvider globalJwtProvider;
 
     // 일반 회원가입
     @Operation(summary = "일반 회원가입", description = "모든 필수 항목 입력 및 유효성 검사를 거쳐 계정을 생성합니다.")
@@ -87,14 +90,37 @@ public class AuthController {
     }
 
     // 로그아웃
-    @Operation(summary = "로그아웃", description = "로그아웃 처리를 합니다. (클라이언트 단 토큰 삭제 필요)")
+    @Operation(summary = "로그아웃", description = "Redis에서 Refresh Token을 삭제합니다.")
     @PostMapping("/logout")
-    public ApiResponse<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        // 토큰을 통해 인증된 유저 정보가 들어옵니다.
-        if (userDetails != null) {
-            authService.logout(userDetails.getUsername()); // CustomUserDetails에서 반환하는 username은 email입니다.
-        }
+    public ApiResponse<Void> logout(@RequestHeader("Authorization") String token) {
+        // 1. 헤더에서 토큰 추출 ("Bearer " 제거)
+        String jwt = token.replace("Bearer ", "");
+
+        // 2. 토큰에서 이메일 추출 (globalJwtProvider를 사용)
+        String email = globalJwtProvider.getSubject(jwt);
+
+        // 3. 서비스의 로그아웃 호출 (Redis 삭제 로직 실행)
+        authService.logout(email);
+
         return ApiResponse.success("AUTH_LOGOUT_SUCCESS", "로그아웃이 완료되었습니다.");
+    }
+
+    // 이메일 인증번호 발송 API
+    @Operation(summary = "회원가입 이메일 인증번호 발송", description = "입력한 이메일로 6자리 인증번호를 발송합니다.")
+    @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"ALREADY_EXISTS_EMAIL"})
+    @PostMapping("/email/send-code")
+    public ApiResponse<Void> sendEmailCode(@RequestBody @Valid SendEmailCodeRequest request) {
+        authService.sendVerificationCode(request);
+        return ApiResponse.success("AUTH_SEND_CODE_SUCCESS", "인증번호가 이메일로 발송되었습니다.");
+    }
+
+    // 이메일 인증번호 확인 API
+    @Operation(summary = "회원가입 이메일 인증번호 확인", description = "발송된 6자리 인증번호가 맞는지 확인합니다.")
+    @ApiErrorCodeExample(domain = UserErrorCode.class, value = {"INVALID_USER_INFO"})
+    @PostMapping("/email/verify-code")
+    public ApiResponse<Void> verifyEmailCode(@RequestBody @Valid VerifyEmailCodeRequest request) {
+        authService.verifyEmailCode(request);
+        return ApiResponse.success("AUTH_VERIFY_CODE_SUCCESS", "이메일 인증이 완료되었습니다.");
     }
 
 

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/auth_test.http
@@ -30,6 +30,40 @@ Accept: application/json
     });
 %}
 
+
+### 1. 일반 회원가입 (POST /api/v1/auth/signup)
+# - 정상적인 데이터를 넣어서 가입이 잘 되는지 확인합니다.
+# "termsServiceAgreed" 랑 "termsPrivacyAgreed" 둘 다 필수 동의 약관이기 때문에
+# 둘 중 하나만 false여도 회원가입 안됨
+POST http://localhost:15000/api/v1/auth/signup
+Content-Type: application/json
+Accept: application/json
+
+{
+  "username": "wndmsld12",
+  "email": "wndmsld12@gmail.com",
+  "password": "password8888",
+  "name": "이주은",
+  "phone": "010-1357-2468",
+  "birthDate": "2004-03-02",
+  "gender": "FEMALE",
+  "nickname": "주은주은",
+  "referralCode": "REF008",
+  "signupPath": "인스타그램",
+  "termsServiceAgreed": true,
+  "termsPrivacyAgreed": true,
+  "termsMarketingAgreed": false
+}
+
+> {%
+    // 응답이 오면 상태 코드와 결과를 콘솔에 출력합니다.
+    client.test("회원가입 성공 여부 확인", function() {
+        client.assert(response.status === 201, "상태 코드가 201이 아닙니다.");
+        client.log("응답 메시지: " + response.body.message);
+    });
+%}
+
+
 ### ------------------------------------------------------------------------
 
 ### 2. 일반 회원가입 - 이메일 중복 에러 테스트

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/email_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/email_test.http
@@ -1,0 +1,78 @@
+### =========================================
+### 🌟 [이메일 인증 테스트]
+### =========================================
+
+### 1. 이메일 인증번호 발송 요청
+# (주의) 하연님이 메일을 확인할 수 있는 '진짜 이메일'을 적어주세요!
+POST http://localhost:15000/api/v1/auth/email/send-code
+Content-Type: application/json
+
+{
+  "email": "lhy2004lhy@gmail.com"
+}
+
+> {%
+    client.test("Request executed successfully", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
+
+### 2. 이메일 인증번호 확인
+# 💡 위 API를 실행하고 실제 메일함으로 날아온 6자리 숫자를 "code"에 적고 실행하세요!
+POST http://localhost:15000/api/v1/auth/email/verify-code
+Content-Type: application/json
+
+{
+  "email": "lhy2004lhy@gmail.com",
+  "code": "205846"
+}
+
+> {%
+    client.test("Request executed successfully", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
+
+### 3. 회원가입 (이메일 인증 완료 후 진행)
+# 💡 반드시 위 1번, 2번을 순서대로 통과한 "같은 이메일"을 넣어야 가입이 성공합니다!
+POST http://localhost:15000/api/v1/auth/signup
+Content-Type: application/json
+
+{
+  "username": "algoga_new_user",
+  "email": "lhy2004lhy@gmail.com",
+  "password": "Password123",
+  "name": "김알고가",
+  "phone": "010-1234-5678",
+  "birthDate": "2000-01-01",
+  "gender": "MALE",
+  "nickname": "알고가조아",
+  "termsServiceAgreed": true,
+  "termsPrivacyAgreed": true,
+  "termsMarketingAgreed": false
+}
+
+
+
+### 3. 일반 로그인 (POST /api/v1/auth/login)
+# - 1번에서 가입한 정보로 로그인을 시도합니다.
+# - 로그인이 성공하면 발급받은 accessToken과 refreshToken을 변수에 자동 저장합니다.
+POST http://localhost:15000/api/v1/auth/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "username": "algoga_new_user",
+  "password": "Password123"
+}
+
+> {%
+    // 로그인 응답으로 온 토큰을 인텔리제이 메모리에 임시로 저장합니다.
+    if(response.status === 200) {
+        client.global.set("accessToken", response.body.data.accessToken);
+        client.global.set("refreshToken", response.body.data.refreshToken);
+        client.log("Access Token: " + client.global.get("accessToken"));
+    }
+%}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/SendEmailCodeRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/SendEmailCodeRequest.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.user.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이메일 인증번호 발송 요청")
+public record SendEmailCodeRequest(
+        @Schema(description = "인증번호를 받을 이메일", example = "test@algoga.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식을 입력해주세요.")
+        String email
+) {}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/request/VerifyEmailCodeRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/request/VerifyEmailCodeRequest.java
@@ -1,0 +1,17 @@
+package com.kidmily.algoga_server.user.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이메일 인증번호 확인 요청")
+public record VerifyEmailCodeRequest(
+        @Schema(description = "인증을 요청했던 이메일", example = "test@algoga.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식을 입력해주세요.")
+        String email,
+
+        @Schema(description = "받은 6자리 인증번호", example = "123456")
+        @NotBlank(message = "인증번호를 입력해주세요.")
+        String code
+) {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,11 @@ spring:
   application:
     name: algoga_server
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/algoga


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->

## 🔗 Issue
Closes #150 

---

## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
### 1. 환경 설정 및 구조 변경
- `build.gradle`: `spring-boot-starter-data-redis` 의존성 추가
- `RedisConfig`: `RedisTemplate<String, String>` 빈 등록 및 직렬화 설정

### 2. 이메일 인증 고도화 (`AuthService`)
- 발송 (`sendVerificationCode`): 6자리 난수 생성 후 Redis에 `AUTH_CODE:{email}` 키로 저장 (3분 TTL 설정).
- 확인 (`verifyEmailCode`): Redis에서 키를 조회하여 검증. 성공 시 기존 키를 삭제하고 `AUTH_SUCCESS:{email}` 키 생성 (30분 TTL 설정).
- 회원가입 (`signup`): 가입 로직 수행 전 Redis를 조회하여 `AUTH_SUCCESS` 상태가 확인된 유저만 가입 허용. 가입 완료 후 Redis 데이터 청소.

### 3. JWT Refresh Token 관리 (`AuthService`, `AuthController`)
- 로그인 (`login`): 정상 로그인 시 생성된 Refresh Token을 Redis에 `RT:{email}` 키로 저장 (7일 TTL 설정).
- 로그아웃 (`logout`): 클라이언트가 요청 헤더에 담아 보낸 토큰에서 `globalJwtProvider.getSubject(jwt)`를 통해 이메일을 추출한 뒤, 해당 이메일로 등록된 Redis 키(`RT:{email}`)를 삭제하여 로그아웃 처리.


※ redis에 저장된 토큰, 로그아웃 후 삭제된 토큰 확인하는 법
<img width="810" height="1189" alt="image" src="https://github.com/user-attachments/assets/29c821b6-02d7-4135-aae1-a4f31ff1fcfe" />

