### PR TITLE
알림 기능 구현(댓글 알림, 결제 알림)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/notification/application/service/NotificationQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/service/NotificationQueryService.java
@@ -1,11 +1,19 @@
 package com.kidmily.algoga_server.notification.application.service;
 
 import com.kidmily.algoga_server.notification.application.usecase.NotificationQueryUseCase;
+import com.kidmily.algoga_server.notification.domain.model.Notification;
 import com.kidmily.algoga_server.notification.domain.repository.NotificationRepository;
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationItemResponse;
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationListResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -19,5 +27,36 @@ public class NotificationQueryService implements NotificationQueryUseCase {
     public long getUnreadCount(Long userId) {
         log.info("[NotificationQueryService] 읽지 않은 알림 개수 조회 - userId: {}", userId);
         return notificationRepository.countUnreadByUserId(userId);
+    }
+
+    @Override
+    public NotificationListResponse getNotifications(Long userId, Boolean isRead, int page, int size) {
+        log.info("[NotificationQueryService] 알림 목록 조회 - userId: {}, isRead: {}, page: {}, size: {}",
+                userId, isRead, page, size);
+
+        // page는 1부터 시작이라 0 기반으로 변환
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<Notification> notificationPage = notificationRepository.findByUserId(userId, isRead, pageable);
+
+        long unreadCount = notificationRepository.countUnreadByUserId(userId);
+
+        List<NotificationItemResponse> notifications = notificationPage.getContent().stream()
+                .map(n -> new NotificationItemResponse(
+                        n.getNotificationId(),
+                        n.getType(),
+                        n.getMessage(),
+                        n.getIsRead(),
+                        n.getCreatedAt()
+                ))
+                .toList();
+
+        return new NotificationListResponse(
+                unreadCount,
+                unreadCount > 0,
+                notifications,
+                notificationPage.hasNext(),
+                notificationPage.getTotalElements()
+        );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/application/usecase/NotificationQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/usecase/NotificationQueryUseCase.java
@@ -1,5 +1,8 @@
 package com.kidmily.algoga_server.notification.application.usecase;
 
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationListResponse;
+
 public interface NotificationQueryUseCase {
     long getUnreadCount(Long userId);
+    NotificationListResponse getNotifications(Long userId, Boolean isRead, int page, int size);
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.notification.exception;
+
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+
+    // 401
+    NOTIFICATION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NOTIFICATION_001", "알림 조회 권한이 없습니다."),
+
+    // 404
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_002", "알림을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kidmily/algoga_server/notification/exception/NotificationException.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/exception/NotificationException.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.notification.exception;
+
+public class NotificationException extends RuntimeException {
+    private final NotificationErrorCode errorCode;
+
+    public NotificationException(NotificationErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public NotificationErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/advice/NotificationExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/advice/NotificationExceptionAdvice.java
@@ -1,0 +1,41 @@
+package com.kidmily.algoga_server.notification.presentation.advice;
+
+import com.kidmily.algoga_server.global.common.api.response.ErrorResponse;
+import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
+import com.kidmily.algoga_server.notification.exception.NotificationErrorCode;
+import com.kidmily.algoga_server.notification.exception.NotificationException;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.kidmily.algoga_server.notification.presentation.api")
+public class NotificationExceptionAdvice implements CommonExceptionAdvice {
+
+    @Override
+    public Logger getLogger() {
+        return log;
+    }
+
+    @ExceptionHandler(NotificationException.class)
+    public ResponseEntity<ErrorResponse> handleNotificationException(NotificationException e) {
+        String traceId = getOrCreateTraceId();
+        NotificationErrorCode errorCode = e.getErrorCode();
+
+        log.warn("[NotificationDomainException] traceId: {}, code: {}, message: {}",
+                traceId, errorCode.getCode(), errorCode.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                traceId
+        );
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/NotificationController.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/NotificationController.java
@@ -1,16 +1,22 @@
 package com.kidmily.algoga_server.notification.presentation.api;
 
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.notification.application.usecase.NotificationQueryUseCase;
+import com.kidmily.algoga_server.notification.exception.NotificationErrorCode;
+import com.kidmily.algoga_server.notification.exception.NotificationException;
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationListResponse;
 import com.kidmily.algoga_server.notification.presentation.api.response.UnreadCountResponse;
 import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,18 +27,63 @@ public class NotificationController {
 
     private final NotificationQueryUseCase notificationQueryUseCase;
 
+
+    private Long getCurrentUserId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (!(principal instanceof CustomUserDetails)) {
+            throw new NotificationException(NotificationErrorCode.NOTIFICATION_UNAUTHORIZED);
+        }
+        return ((CustomUserDetails) principal).getUser().getId();
+    }
+
     @GetMapping("/unread-count")
     @Operation(summary = "읽지 않은 알림 개수 조회", description = "종 아이콘 뱃지에 표시할 읽지 않은 알림 개수를 조회합니다.")
     public ResponseEntity<ApiResponse<UnreadCountResponse>> getUnreadCount() {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
+        // 비로그인이면 0 반환
+        if (!(principal instanceof CustomUserDetails)) {
+            return ResponseEntity.ok(ApiResponse.success(
+                    "UNREAD_COUNT_FOUND",
+                    "읽지 않은 알림 개수 조회에 성공했습니다.",
+                    new UnreadCountResponse(0)
+            ));
+        }
+
+        Long currentUserId = ((CustomUserDetails) principal).getUser().getId();
         long count = notificationQueryUseCase.getUnreadCount(currentUserId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 "UNREAD_COUNT_FOUND",
                 "읽지 않은 알림 개수 조회에 성공했습니다.",
                 new UnreadCountResponse(count)
+        ));
+    }
+
+    @GetMapping
+    @Operation(summary = "알림 목록 조회", description = "사용자의 알림 리스트를 최신순으로 조회합니다.")
+    @ApiErrorCodeExample(domain = NotificationErrorCode.class, value = {
+            "NOTIFICATION_UNAUTHORIZED"
+    })
+    public ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+
+            @Parameter(description = "페이지 크기", example = "8")
+            @RequestParam(defaultValue = "8") int size,
+
+            @Parameter(description = "읽음 여부 필터 (전체: 생략, 읽지 않음: false)")
+            @RequestParam(required = false) Boolean isRead
+    ) {
+        Long currentUserId = getCurrentUserId();
+
+        NotificationListResponse responseData = notificationQueryUseCase.getNotifications(
+                currentUserId, isRead, page, size);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                "NOTIFICATIONS_FOUND",
+                "알림 목록 조회에 성공했습니다.",
+                responseData
         ));
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationItemResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationItemResponse.java
@@ -1,0 +1,24 @@
+package com.kidmily.algoga_server.notification.presentation.api.response;
+
+import com.kidmily.algoga_server.notification.domain.model.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "알림 항목")
+public record NotificationItemResponse(
+        @Schema(description = "알림 ID", example = "1")
+        Long notificationId,
+
+        @Schema(description = "알림 타입", example = "POST_COMMENTED")
+        NotificationType type,
+
+        @Schema(description = "알림 메시지", example = "김민준님이 내 게시글에 댓글을 달았습니다")
+        String message,
+
+        @Schema(description = "읽음 여부", example = "false")
+        Boolean isRead,
+
+        @Schema(description = "생성 시각")
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationListResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationListResponse.java
@@ -1,0 +1,23 @@
+package com.kidmily.algoga_server.notification.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "알림 목록 응답")
+public record NotificationListResponse(
+        @Schema(description = "전체 읽지 않은 알림 수", example = "2")
+        long unreadCount,
+
+        @Schema(description = "읽지 않은 알림 존재 여부", example = "true")
+        boolean hasUnread,
+
+        @Schema(description = "알림 목록")
+        List<NotificationItemResponse> notifications,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "전체 알림 수", example = "8")
+        long totalElements
+) {}


### PR DESCRIPTION
## 설명

알림 도메인 구현 (목록 조회, 읽음 처리, 삭제, 결제 알림 연동)
알림 도메인 전체 구조 설계 (Domain, Application, Infrastructure, Presentation 계층)
댓글/대댓글 작성 시 게시글/댓글 작성자에게 비동기 알림 저장
강의/숙소 결제 완료 시 알림 저장 (PaymentCompletedEvent 연동)
알림 목록 조회 API (페이징, 읽음 여부 필터링)
읽지 않은 알림 개수 조회 API (종 아이콘 뱃지용)
개별/전체 읽음 처리 API
개별/전체 삭제 API
알림에 detail(세부내용), referenceId(이동할 페이지 ID) 포함

## 🔗 Issue
Closes #152

API 목록

알림 아이콘 표시(읽지 않은 알림 표시)
알림 목록 조회
알림 개별 삭제
알림 전체 삭제
알림 개별 읽음
알림 전체 읽음

# API 명세

1. 읽지 않은 알림 개수 조회
GET /api/v1/notifications/unread-count
Authorization: Bearer {token}

Response (200)
json{
  "status": 200,
  "code": "UNREAD_COUNT_FOUND",
  "data": {
    "count": 2
  }
}

2. 알림 목록 조회
GET /api/v1/notifications?page=1&size=8&isRead=false
Authorization: Bearer {token}

Response (200)
json{
  "status": 200,
  "code": "NOTIFICATIONS_FOUND",
  "data": {
    "unreadCount": 2,
    "hasUnread": true,
    "notifications": [
      {
        "notificationId": 1,
        "type": "POST_COMMENTED",
        "message": "김민준님이 내 게시글에 댓글을 달았습니다",
        "detail": "정말 유용한 정보네요!",
        "referenceId": 43,
        "isRead": false,
        "createdAt": "2026-05-29T01:02:26"
      }
    ],
    "hasNext": false,
    "totalElements": 2
  }
}

3. 알림 개별 읽음 처리
PATCH /api/v1/notifications/{notificationId}/read
Authorization: Bearer {token}

Response (204) - No Content

4. 알림 전체 읽음 처리
PATCH /api/v1/notifications/read-all
Authorization: Bearer {token}
Response (204) - No Content

5. 알림 개별 삭제
DELETE /api/v1/notifications/{notificationId}
Authorization: Bearer {token}

Response (204) - No Content

6. 알림 전체 삭제
DELETE /api/v1/notifications
Authorization: Bearer {token}
Response (204) - No Content


## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
 - [ ] 다른 유저 게시글에 댓글 작성 후 notifications 테이블에 POST_COMMENTED 타입 알림 저장 확인
- [ ]  대댓글 작성 후 notifications 테이블에 COMMENT_REPLIED 타입 알림 저장 확인
 - [ ] 본인 게시글에 본인이 댓글 달았을 때 알림 생성되지 않는지 확인
 - [ ] 강의 결제 완료 후 PAYMENT_COMPLETED 타입 알림 저장 확인 (강의명 포함)
 - [ ] 숙소 결제 완료 후 PAYMENT_COMPLETED 타입 알림 저장 확인 (예약번호 포함)
 - [ ] GET /api/v1/notifications/unread-count 읽지 않은 알림 개수 정상 반환 확인
 - [ ] GET /api/v1/notifications 알림 목록 페이징 정상 동작 확인
 - [ ] PATCH /api/v1/notifications/{notificationId}/read 개별 읽음 처리 후 is_read = true 확인
 - [ ] PATCH /api/v1/notifications/read-all 전체 읽음 처리 후 모든 알림 is_read = true 확인
 - [ ] DELETE /api/v1/notifications/{notificationId} 개별 삭제 후 DB에서 삭제 확인
 - [ ] DELETE /api/v1/notifications 전체 삭제 후 DB에서 모든 알림 삭제 확인
 - [ ] 알림은 비동기 처리라 댓글 작성 응답 속도에 영향 없는지 확인
