### PR TITLE
[Feature] 강의 공개/비공개 상태 수정 기능 연결

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateCourseCommand.java
@@ -11,6 +11,7 @@ public record CreateCourseCommand(
         String description,
         Integer price,
         String level,
+        String status,
         MultipartFile thumbnailFile,
         List<MultipartFile> attachedFiles
 ) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateCourseCommand.java
@@ -9,6 +9,7 @@ public record UpdateCourseCommand(
         String description,
         Integer price,
         String level,
+        String status,
         MultipartFile thumbnailFile,
         List<MultipartFile> attachedFiles
 ) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/AdminContentService.java
@@ -61,7 +61,8 @@ public class AdminContentService implements AdminContentUseCase {
                 command.price(),
                 thumbnailUrl,
                 courseFiles,
-                command.level()
+                command.level(),
+                normalizeCourseStatus(command.status(), "DRAFT")
         );
 
         Course savedCourse = courseRepository.save(newCourse);
@@ -70,6 +71,18 @@ public class AdminContentService implements AdminContentUseCase {
                 savedCourse.getId(), thumbnailUrl, courseFiles.size(), command.level());
 
         return savedCourse.getId();
+    }
+
+    private String normalizeCourseStatus(String status, String defaultStatus) {
+        if (status == null || status.isBlank()) {
+            return defaultStatus;
+        }
+
+        return switch (status.trim().toUpperCase()) {
+            case "PUBLISHED" -> "PUBLISHED";
+            case "DRAFT" -> "DRAFT";
+            default -> defaultStatus;
+        };
     }
 
     @Override
@@ -147,7 +160,8 @@ public class AdminContentService implements AdminContentUseCase {
                 targetThumbnailUrl,
                 targetFileUrl,
                 targetCourseFiles,
-                command.level()
+                command.level(),
+                normalizeCourseStatus(command.status(), course.getStatus())
         ).orElseThrow(() -> {
             log.warn("[Course Command] 강의 수정 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
             return new LmsException(LmsErrorCode.COURSE_NOT_FOUND);

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/Course.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/Course.java
@@ -57,7 +57,8 @@ public class Course {
             Integer price,
             String thumbnailUrl,
             String fileUrl,
-            String level
+            String level,
+            String status
     ) {
         List<CourseFile> courseFiles = new ArrayList<>();
 
@@ -73,7 +74,8 @@ public class Course {
                 price,
                 thumbnailUrl,
                 courseFiles,
-                level
+                level,
+                status
         );
     }
 
@@ -85,7 +87,8 @@ public class Course {
             Integer price,
             String thumbnailUrl,
             List<CourseFile> courseFiles,
-            String level
+            String level,
+            String status
     ) {
         return new Course(
                 null,
@@ -98,7 +101,7 @@ public class Course {
                 getFirstFileUrl(courseFiles),
                 courseFiles,
                 level,
-                "DRAFT",
+                status,
                 false,
                 new ArrayList<>()
         );

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
@@ -27,7 +27,8 @@ public interface CourseRepository {
             String thumbnailUrl,
             String fileUrl,
             List<CourseFile> courseFiles,
-            String level
+            String level,
+            String status
     );
 
     boolean softDelete(Long courseId);

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
@@ -65,7 +65,8 @@ public class CourseRepositoryAdapter implements CourseRepository {
             String thumbnailUrl,
             String fileUrl,
             List<CourseFile> courseFiles,
-            String level
+            String level,
+            String status
     ) {
         return springDataCourseRepository.findByIdAndDeletedFalse(courseId)
                 .map(entity -> {
@@ -76,7 +77,8 @@ public class CourseRepositoryAdapter implements CourseRepository {
                             thumbnailUrl,
                             fileUrl,
                             courseFiles == null ? null : courseMapper.toCourseFileEntities(courseFiles),
-                            level
+                            level,
+                            status
                     );
                     return courseMapper.toDomain(entity);
                 });

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/CourseJpaEntity.java
@@ -125,9 +125,10 @@ public class CourseJpaEntity {
             Integer price,
             String thumbnailUrl,
             String fileUrl,
-            String level
+            String level,
+            String status
     ) {
-        updateBasicInfo(title, description, price, thumbnailUrl, fileUrl, null, level);
+        updateBasicInfo(title, description, price, thumbnailUrl, fileUrl, null, level, status);
     }
 
     public void updateBasicInfo(
@@ -137,12 +138,14 @@ public class CourseJpaEntity {
             String thumbnailUrl,
             String fileUrl,
             List<CourseFileJpaEntity> newCourseFiles,
-            String level
+            String level,
+            String status
     ) {
         this.title = title;
         this.description = description;
         this.price = price;
         this.level = level;
+        this.status = status;
 
         if (thumbnailUrl != null) {
             this.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
@@ -64,6 +64,7 @@ public class AdminCourseController {
                 request.description(),
                 request.price(),
                 request.level(),
+                request.status(),
                 thumbnailFile,
                 attachedFiles
         );
@@ -147,6 +148,7 @@ public class AdminCourseController {
                 request.description(),
                 request.price(),
                 request.level(),
+                request.status(),
                 thumbnailFile,
                 attachedFiles
         );

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/14-course-published-draft-test.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/14-course-published-draft-test.http
@@ -1,0 +1,43 @@
+### 강의 공개로 수정
+PUT http://localhost:15000/api/v1/admin/courses/11
+Authorization: Bearer {{managerAccessToken}}
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"
+Content-Type: application/json
+
+{
+  "title": "테스트 강의",
+  "description": "공개 상태 테스트",
+  "price": 10000,
+  "level": "BEGINNER",
+  "status": "PUBLISHED"
+}
+
+--boundary--
+
+
+### 강의 비공개로 수정
+PUT http://localhost:15000/api/v1/admin/courses/11
+Authorization: Bearer {{managerAccessToken}}
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"
+Content-Type: application/json
+
+{
+  "title": "테스트 강의",
+  "description": "비공개 상태 테스트",
+  "price": 10000,
+  "level": "BEGINNER",
+  "status": "DRAFT"
+}
+
+--boundary--
+
+
+### 강의 상세 조회
+GET http://localhost:15000/api/v1/admin/courses/11
+Authorization: Bearer {{managerAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateCourseRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateCourseRequest.java
@@ -31,6 +31,13 @@ public record CreateCourseRequest(
                 allowableValues = {"BEGINNER", "INTERMEDIATE", "ADVANCED"}
         )
         @NotBlank(message = "강의 난이도는 필수입니다.")
-        String level
+        String level,
+
+        @Schema(
+                description = "강의 공개 상태. PUBLISHED=공개, DRAFT=비공개",
+                example = "PUBLISHED",
+                allowableValues = {"PUBLISHED", "DRAFT"}
+        )
+        String status
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateCourseRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateCourseRequest.java
@@ -27,6 +27,13 @@ public record UpdateCourseRequest(
                 allowableValues = {"BEGINNER", "INTERMEDIATE", "ADVANCED"}
         )
         @NotBlank(message = "강의 난이도는 필수입니다.")
-        String level
+        String level,
+
+        @Schema(
+                description = "강의 공개 상태. PUBLISHED=공개, DRAFT=비공개",
+                example = "PUBLISHED",
+                allowableValues = {"PUBLISHED", "DRAFT"}
+        )
+        String status
 ) {
 }


### PR DESCRIPTION
## 설명
콘텐츠 매니저가 강의 관리 화면에서 설정한 공개/비공개 상태가 백엔드에 정상 반영되도록 수정했습니다.

기존에는 프론트엔드에서 `PUBLISHED` 또는 `DRAFT` 값을 전달해도 백엔드에서 해당 `status` 값을 요청 DTO, Command, Service, Repository, Entity 수정 흐름까지 전달하지 않아 DB에 의도한 상태가 저장되지 않았습니다.

이번 PR에서는 강의 생성/수정 시 전달된 `status` 값을 `lectures.status` 컬럼에 반영하도록 연결했습니다.

## 🔗 Issue
Closes #164 

---

## 확인할 사항
- [ ] 관리자 강의 수정 API에서 `status: "PUBLISHED"` 전송 시 응답 및 DB 상태가 `PUBLISHED`로 저장되는지 확인
- [ ] 관리자 강의 수정 API에서 `status: "DRAFT"` 전송 시 응답 및 DB 상태가 `DRAFT`로 저장되는지 확인