### PR TITLE
환불 시 이벤트 발행으로 캘린더 삭제

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
@@ -101,7 +101,7 @@ public class BookingCommandService implements BookingCommandUseCase {
 
         bookingRepository.updateStatus(bookingId, BookingStatus.CANCEL_REQUESTED);
 
-        eventPublisher.publishEvent(new BookingCanceledEvent(booking.getAccommodationId()));
+        eventPublisher.publishEvent(new BookingCanceledEvent(booking.getUserId(), booking.getAccommodationId()));
 
         log.info("[BookingCommandService] 예약 취소 완료 - bookingId: {}", bookingId);
     }

--- a/src/main/java/com/kidmily/algoga_server/booking/domain/event/BookingCanceledEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/domain/event/BookingCanceledEvent.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.booking.domain.event;
 
 public record BookingCanceledEvent(
+        Long userId,
         Long accommodationId
 ) {}

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
@@ -6,11 +6,16 @@ import com.kidmily.algoga_server.calendar.domain.model.Calendar;
 import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 import com.kidmily.algoga_server.calendar.domain.repository.CalendarRepository;
 import com.kidmily.algoga_server.payment.domain.event.PaymentCompletedEvent;
+import com.kidmily.algoga_server.refund.domain.event.RefundApprovedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -19,52 +24,103 @@ public class CalendarEventListener {
 
     private final CalendarRepository calendarRepository;
 
-    @EventListener
-    @Transactional
+    // 단순 예약 생성 완료 시 일정 추가
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 예약 완료 커밋 성공 시에만!
+    @Transactional(propagation = Propagation.REQUIRES_NEW)              // 비동기 스레드 내 독자적 트랜잭션 보장
     public void handleBookingCreated(BookingCreatedEvent event) {
-        log.info("[CalendarEventListener] 예약 생성 이벤트 수신 - userId: {}, packageId: {}",
+        log.info("[CalendarEventListener] 예약 생성 완료 커밋 확인 - userId: {}, packageId: {}",
                 event.userId(), event.accommodationId());
 
-        Calendar calendar = Calendar.create(
-                event.userId(),
-                event.accommodationId(),  // packageId → accommodationId
-                event.checkInDate(),      // departureDate → checkInDate
-                CalendarType.TRIP
-        );
-        calendarRepository.save(calendar);
-
-        log.info("[CalendarEventListener] 캘린더 일정 저장 완료");
+        try {
+            Calendar calendar = Calendar.create(
+                    event.userId(),
+                    event.accommodationId(),
+                    event.checkInDate(),
+                    CalendarType.TRIP
+            );
+            calendarRepository.save(calendar);
+            log.info("[CalendarEventListener] 캘린더 일정 저장 완료");
+        } catch (Exception e) {
+            log.error("[CalendarEventListener] 예약 생성 반영 중 캘린더 처리 실패! - userId: {}, error: {}",
+                    event.userId(), e.getMessage(), e);
+        }
     }
 
-    @EventListener
-    @Transactional
+    // 단순 예약 취소 완료 시 일정 삭제
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 취소 처리가 DB에 완벽히 커밋되었을 때만!
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleBookingCanceled(BookingCanceledEvent event) {
-        log.info("[CalendarEventListener] 예약 취소 이벤트 수신 - accommodationId: {}", event.accommodationId());
+        log.info("[CalendarEventListener] 예약 취소 완료 커밋 확인 - userId: {}, accommodationId: {}",
+                event.userId(), event.accommodationId());
 
-        calendarRepository.deleteByReferenceId(event.accommodationId());
+        try {
+            // 비동기 내부 로직을 try-catch 로 보호
+            calendarRepository.deleteByUserIdAndReferenceIdAndType(
+                    event.userId(),
+                    event.accommodationId(),
+                    CalendarType.TRIP
+            );
+            log.info("[CalendarEventListener] 여행 캘린더 일정 삭제 완료");
 
-        log.info("[CalendarEventListener] 캘린더 일정 삭제 완료");
+        } catch (Exception e) {
+            // 중요: 예외가 밖으로 새어나가서 스레드가 조용히 터지는 걸 막고, 에러 로그를 명확히 남김
+            log.error("[CalendarEventListener] 예약 취소 중 캘린더 처리 실패! - userId: {}, error: {}",
+                    event.userId(), e.getMessage(), e);
+        }
     }
 
-    @EventListener
-    @Transactional
+    // 강의 결제 완료 시 일정 추가
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 돈이 진짜 성공적으로 완전히 빠져나갔을 때만!
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleLecturePaymentCompleted(PaymentCompletedEvent event) {
-        // 강의 결제인 경우만 처리
         if (event.courseId() == null) {
             return;
         }
 
-        log.info("[CalendarEventListener] 강의 결제 완료 이벤트 수신 - userId: {}, courseId: {}",
+        log.info("[CalendarEventListener] 강의 결제 완료 커밋 확인 - userId: {}, courseId: {}",
                 event.userId(), event.courseId());
 
-        Calendar calendar = Calendar.create(
-                event.userId(),
-                event.courseId(),
-                event.paidAt().toLocalDate(),
-                CalendarType.LECTURE
-        );
-        calendarRepository.save(calendar);
+        try {
+            Calendar calendar = Calendar.create(
+                    event.userId(),
+                    event.courseId(),
+                    event.paidAt().toLocalDate(),
+                    CalendarType.LECTURE
+            );
+            calendarRepository.save(calendar);
+            log.info("[CalendarEventListener] 강의 캘린더 일정 저장 완료");
+        } catch (Exception e) {
+            log.error("[CalendarEventListener] 강의 결제 반영 중 캘린더 처리 실패! - userId: {}, courseId: {}, error: {}",
+                    event.userId(), event.courseId(), e.getMessage(), e);
+        }
+    }
 
-        log.info("[CalendarEventListener] 강의 캘린더 일정 저장 완료");
+    // 환불 완료
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 성공 커밋 후 실행 장치
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // 독자적인 새 트랜잭션 보장
+    public void handleRefundApproved(RefundApprovedEvent event) {
+        log.info("[CalendarEventListener] 환불 승인 도메인 이벤트 수신 - userId: {}, referenceId: {}, type: {}",
+                event.userId(), event.referenceId(), event.type());
+
+        try {
+            CalendarType calendarType = CalendarType.valueOf(event.type());
+
+            calendarRepository.deleteByUserIdAndReferenceIdAndType(
+                    event.userId(),
+                    event.referenceId(),
+                    calendarType
+            );
+            log.info("[CalendarEventListener] 환불 반영으로 인한 캘린더 일정 정상 제거 완료");
+
+        } catch (IllegalArgumentException e) {
+            log.error("[CalendarEventListener] 환불 타입 바인딩 실패 (알 수 없는 Enum Type) - type: {}", event.type());
+        } catch (Exception e) {
+            log.error("[CalendarEventListener] 환불 반영 중 캘린더 처리 실패! - userId: {}, error: {}",
+                    event.userId(), e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/domain/repository/CalendarRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/domain/repository/CalendarRepository.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.calendar.domain.repository;
 
 import com.kidmily.algoga_server.calendar.domain.model.Calendar;
+import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -8,5 +9,6 @@ import java.util.List;
 public interface CalendarRepository {
     Calendar save(Calendar calendar);
     List<Calendar> findByUserIdAndDateRange(Long userId, LocalDate startDate, LocalDate endDate);
-    void deleteByReferenceId(Long referenceId);
+    // 기존 단일 referenceId 삭제에서 -> 안전한 복합 조건 삭제 포트로 변경
+    void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type);
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
@@ -2,6 +2,7 @@
 package com.kidmily.algoga_server.calendar.infrastructure.persistence;
 
 import com.kidmily.algoga_server.calendar.domain.model.Calendar;
+import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 import com.kidmily.algoga_server.calendar.domain.repository.CalendarRepository;
 import com.kidmily.algoga_server.calendar.infrastructure.mapper.CalendarMapper;
 import com.kidmily.algoga_server.calendar.infrastructure.persistence.repository.SpringDataCalendarRepository;
@@ -34,9 +35,15 @@ public class CalendarRepositoryAdapter implements CalendarRepository {
                 .toList();
     }
 
+//    @Override
+//    @Transactional
+//    public void deleteByReferenceId(Long referenceId) {
+//        springDataRepository.deleteByReferenceId(referenceId);
+//    }
+
     @Override
     @Transactional
-    public void deleteByReferenceId(Long referenceId) {
-        springDataRepository.deleteByReferenceId(referenceId);
+    public void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type) {
+        springDataRepository.deleteByUserIdAndReferenceIdAndType(userId, referenceId, type);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/repository/SpringDataCalendarRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/repository/SpringDataCalendarRepository.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.calendar.infrastructure.persistence.repository;//package com.kidmily.algoga_server.calendar.infrastructure.persistence.repository;
 
+import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 import com.kidmily.algoga_server.calendar.infrastructure.persistence.entity.CalendarJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,5 @@ public interface SpringDataCalendarRepository extends JpaRepository<CalendarJpaE
             Long userId, LocalDate startDate, LocalDate endDate
     );
     void deleteByReferenceId(Long referenceId);
+    void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommentController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommentController.java
@@ -9,12 +9,14 @@ import com.kidmily.algoga_server.community.presentation.api.request.UpdateCommen
 import com.kidmily.algoga_server.community.presentation.api.response.UpdateCommentResponse;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -35,9 +37,11 @@ public class CommentController {
     })
     public ResponseEntity<ApiResponse<UpdateCommentResponse>> updateComment(
             @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
-            @Valid @RequestBody UpdateCommentRequest request
+            @Valid @RequestBody UpdateCommentRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = 1L;
+        Long currentUserId = userDetails.getUser().getId();
+
 
         UpdateCommentCommand command = new UpdateCommentCommand(commentId, currentUserId, request.content());
         Comment updatedComment = commentCommandUseCase.handle(command);
@@ -55,9 +59,11 @@ public class CommentController {
             "COMMENT_DELETE_FORBIDDEN"
     })
     public ResponseEntity<Void> deleteComment(
-            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId
+            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = 1L;
+        Long currentUserId = userDetails.getUser().getId();
+
 
         DeleteCommentCommand command = new DeleteCommentCommand(commentId, currentUserId);
         commentCommandUseCase.handle(command);

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
@@ -5,7 +5,6 @@ import com.kidmily.algoga_server.community.application.port.UserPort;
 import com.kidmily.algoga_server.community.application.usecase.CommentCommandUseCase;
 import com.kidmily.algoga_server.community.application.usecase.PostCommandUseCase;
 import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
-import com.kidmily.algoga_server.community.application.usecase.ReactionCommandUseCase;
 import com.kidmily.algoga_server.community.domain.model.Comment;
 import com.kidmily.algoga_server.community.exception.PostErrorCode;
 import com.kidmily.algoga_server.community.domain.model.PostTagType;
@@ -22,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -37,7 +36,6 @@ public class CommunityController {
     private final PostCommandUseCase postCommandUseCase;
     private final PostQueryUseCase postQueryUseCase;
     private final CommentCommandUseCase commentCommandUseCase;
-    private final ReactionCommandUseCase reactionCommandUseCase;
     private final UserPort userPort;
 
 
@@ -54,10 +52,10 @@ public class CommunityController {
             "POST_UNAUTHORIZED"
     })
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
-            @Valid @ModelAttribute CreatePostRequest request
+            @Valid @ModelAttribute CreatePostRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Long currentUserId = userDetails.getUser().getId();
 
         CreatePostCommand command = new CreatePostCommand(
                 currentUserId,
@@ -113,10 +111,10 @@ public class CommunityController {
     public ResponseEntity<ApiResponse<UpdatePostResponse>> updatePost(
             @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId,
-            @Valid @ModelAttribute UpdatePostRequest request
+            @Valid @ModelAttribute UpdatePostRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Long currentUserId = userDetails.getUser().getId();
 
         UpdatePostCommand command = new UpdatePostCommand(
                 postId,
@@ -146,10 +144,11 @@ public class CommunityController {
     })
     public ResponseEntity<Void> deletePost(
             @Parameter(description = "게시글 ID", example = "1")
-            @PathVariable Long postId
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Long currentUserId = userDetails.getUser().getId();
+
 
         DeletePostCommand command = new DeletePostCommand(postId, currentUserId);
         postCommandUseCase.handle(command);
@@ -180,10 +179,11 @@ public class CommunityController {
     public ResponseEntity<ApiResponse<CreateCommentResponse>> createComment(
             @Parameter(description = "게시글 ID", example = "1")
             @PathVariable Long postId,
-            @RequestBody @Valid CreateCommentRequest request
+            @RequestBody @Valid CreateCommentRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Long currentUserId = userDetails.getUser().getId();
+
 
         CreateCommentCommand command = new CreateCommentCommand(
                 postId,

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/MyPostController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/MyPostController.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,10 +43,11 @@ public class MyPostController {
             @RequestParam(required = false) Long lastPostId,
 
             @Parameter(description = "필터링할 카테고리 (다중 선택 가능, 생략 시 전체)", example = "QUESTION,TRAVEL_REVIEW")
-            @RequestParam(required = false) List<PostTagType> categories
+            @RequestParam(required = false) List<PostTagType> categories,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Long currentUserId = userDetails.getUser().getId();
+
 
         PostListResponse responseData = postQueryUseCase.getMyPosts(currentUserId, lastPostId, categories);
         return ResponseEntity.ok(ApiResponse.success("MY_POSTS_FOUND", "내가 작성한 게시글 목록 조회에 성공했습니다.", responseData));

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReactionController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReactionController.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -33,10 +33,11 @@ public class ReactionController {
             "COMMENT_NOT_FOUND"
     })
     public ResponseEntity<ApiResponse<ToggleReactionResponse>> toggleReaction(
-            @Valid @RequestBody ToggleReactionRequest request
+            @Valid @RequestBody ToggleReactionRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Long currentUserId = userDetails.getUser().getId();
+
 
         ToggleReactionCommand command = new ToggleReactionCommand(
                 currentUserId,

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReportController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/ReportController.java
@@ -14,7 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -35,10 +35,11 @@ public class ReportController {
             "REPORT_DUPLICATED"
     })
     public ResponseEntity<ApiResponse<CreateReportResponse>> createReport(
-            @Valid @RequestBody CreateReportRequest request
+            @Valid @RequestBody CreateReportRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = ((CustomUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal()).getUser().getId();
+        Long currentUserId = userDetails.getUser().getId();
+
 
         CreateReportCommand command = new CreateReportCommand(
                 currentUserId,

--- a/src/main/java/com/kidmily/algoga_server/global/config/AsyncConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/AsyncConfig.java
@@ -22,7 +22,7 @@ public class AsyncConfig {
         executor.setMaxPoolSize(10);  // 최대 스레드 수
         executor.setQueueCapacity(500); // 큐 대기 용량
 
-        // 요청하신 대로 스레드 이름 접두사를 'async-'로 설정
+        // 스레드 이름 접두사를 'async-'로 설정
         executor.setThreadNamePrefix("async-");
 
         executor.initialize();

--- a/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
@@ -85,8 +85,8 @@ public class NotificationEventListener {
 
     // 결제 알림
     @Async
-    @EventListener
-    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handlePaymentCompletedEvent(
             PaymentCompletedEvent event) {
 

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/NotificationController.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/NotificationController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,14 +27,6 @@ public class NotificationController {
     private final NotificationQueryUseCase notificationQueryUseCase;
     private final NotificationCommandUseCase notificationCommandUseCase;
 
-
-    private Long getCurrentUserId() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if (!(principal instanceof CustomUserDetails)) {
-            throw new NotificationException(NotificationErrorCode.NOTIFICATION_UNAUTHORIZED);
-        }
-        return ((CustomUserDetails) principal).getUser().getId();
-    }
 
     @GetMapping("/unread-count")
     @Operation(summary = "읽지 않은 알림 개수 조회", description = "종 아이콘 뱃지에 표시할 읽지 않은 알림 개수를 조회합니다.")
@@ -72,9 +65,10 @@ public class NotificationController {
             @RequestParam(defaultValue = "8") int size,
 
             @Parameter(description = "읽음 여부 필터 (전체: 생략, 읽지 않음: false)")
-            @RequestParam(required = false) Boolean isRead
+            @RequestParam(required = false) Boolean isRead,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = getCurrentUserId();
+        Long currentUserId = userDetails.getUser().getId();
 
         NotificationListResponse responseData = notificationQueryUseCase.getNotifications(
                 currentUserId, isRead, page, size);
@@ -95,9 +89,10 @@ public class NotificationController {
     })
     public ResponseEntity<Void> markAsRead(
             @Parameter(description = "알림 ID", example = "1")
-            @PathVariable Long notificationId
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = getCurrentUserId();
+        Long currentUserId = userDetails.getUser().getId();
         notificationCommandUseCase.markAsRead(currentUserId, notificationId);
         return ResponseEntity.noContent().build();
     }
@@ -108,8 +103,10 @@ public class NotificationController {
     @ApiErrorCodeExample(domain = NotificationErrorCode.class, value = {
             "NOTIFICATION_UNAUTHORIZED"
     })
-    public ResponseEntity<Void> markAllAsRead() {
-        Long currentUserId = getCurrentUserId();
+    public ResponseEntity<Void> markAllAsRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails.getUser().getId();
         notificationCommandUseCase.markAllAsRead(currentUserId);
         return ResponseEntity.noContent().build();
     }
@@ -123,9 +120,10 @@ public class NotificationController {
     })
     public ResponseEntity<Void> deleteNotification(
             @Parameter(description = "알림 ID", example = "1")
-            @PathVariable Long notificationId
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long currentUserId = getCurrentUserId();
+        Long currentUserId = userDetails.getUser().getId();
         notificationCommandUseCase.deleteNotification(currentUserId, notificationId);
         return ResponseEntity.noContent().build();
     }
@@ -136,8 +134,10 @@ public class NotificationController {
     @ApiErrorCodeExample(domain = NotificationErrorCode.class, value = {
             "NOTIFICATION_UNAUTHORIZED"
     })
-    public ResponseEntity<Void> deleteAllNotifications() {
-        Long currentUserId = getCurrentUserId();
+    public ResponseEntity<Void> deleteAllNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails.getUser().getId();
         notificationCommandUseCase.deleteAllNotifications(currentUserId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
@@ -10,12 +10,14 @@ import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
 import com.kidmily.algoga_server.payment.infrastructure.portone.PortOneClient; // 추가
 import com.kidmily.algoga_server.refund.application.command.CreateRefundCommand;
 import com.kidmily.algoga_server.refund.application.usecase.RefundCommandUseCase;
+import com.kidmily.algoga_server.refund.domain.event.RefundApprovedEvent;
 import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
 import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
 import com.kidmily.algoga_server.refund.exception.RefundErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,7 @@ public class RefundCommandService implements RefundCommandUseCase {
     private final BookingRepository bookingRepository;
     private final PaymentRepository paymentRepository;
     private final PortOneClient portOneClient; // 추가
+    private final ApplicationEventPublisher eventPublisher; // 🌟승재 추가
 
     @Override
     public Long handle(CreateRefundCommand command) {
@@ -188,12 +191,29 @@ public class RefundCommandService implements RefundCommandUseCase {
         // 4. Booking 상태 → REFUNDED
         bookingRepository.updateStatus(refundRequest.getBookingId(), BookingStatus.REFUNDED);
 
+        // 🌟 [추가 영역 A] 이벤트를 만들기 위해 Booking 엔티티 정보를 명확히 조회해옵니다.
+        // (bookingRepository 명세에 맞게 findById 등으로 유저 ID와 숙소 ID를 수집합니다.)
+        Booking booking = bookingRepository.findById(refundRequest.getBookingId())
+                .orElseThrow(() -> new BusinessException(RefundErrorCode.BOOKING_NOT_FOUND));
+
         // 5. RefundRequest 상태 → COMPLETED
         refundRequest.complete();
         refundRepository.save(refundRequest);
 
         log.info("[RefundCommandService] 환불 완료 - refundId: {}, portonePaymentId: {}",
                 refundId, payment.getPortonePaymentId());
+
+
+
+        // 🌟 [추가 영역 B] 모든 DB 저장이 완벽히 성공한 이 시점에 캘린더 연동 벨을 울립니다
+        RefundApprovedEvent event = new RefundApprovedEvent(
+                booking.getUserId(),         // 유저 ID
+                booking.getAccommodationId(),   // 제거할 숙소/패키지 ID
+                "TRIP"                       // CalendarType.TRIP과 매칭될 문자열 고정
+        );
+        eventPublisher.publishEvent(event);
+
+        log.info("[RefundCommandService] 캘린더 연동을 위한 RefundApprovedEvent 발행 완료");
     }
 
     private RefundRequest findRefundOrThrow(Long refundId) {

--- a/src/main/java/com/kidmily/algoga_server/refund/domain/event/RefundApprovedEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/domain/event/RefundApprovedEvent.java
@@ -1,0 +1,25 @@
+package com.kidmily.algoga_server.refund.domain.event;
+
+/**
+ * 환불 승인 완료 시 발행되는 도메인 이벤트
+ * 캘린더 및 알림 도메인 등에서 구독하여 동기화 작업에 활용합니다.
+ */
+public record RefundApprovedEvent(
+        Long userId,
+        Long referenceId,       // 캘린더 테이블의 referenceId와 매핑되는 ID (courseId 또는 accommodationId)
+        String type             // "LECTURE" (강의) 또는 "TRIP" (여행/패키지)
+) {
+    /**
+     * 강의(Lecture) 환불 승인 시 이벤트를 생성하는 팩토리 메서드
+     */
+    public static RefundApprovedEvent ofLecture(Long userId, Long courseId) {
+        return new RefundApprovedEvent(userId, courseId, "LECTURE");
+    }
+
+    /**
+     * 여행/패키지(Trip) 환불 승인 시 이벤트를 생성하는 팩토리 메서드
+     */
+    public static RefundApprovedEvent ofTrip(Long userId, Long accommodationId) {
+        return new RefundApprovedEvent(userId, accommodationId, "TRIP");
+    }
+}


### PR DESCRIPTION
## 설명
1. 커뮤니티 컨트롤러 세부 로직 수정
일부 누락되었거나 비효율적이었던 커뮤니티 관련 세부 흐름 및 예외 처리 로직을 수정했습니다.

2. 환불 완료 시 비동기 캘린더 일정 자동 삭제 연동
도메인 간 결합도 완화 (Loose Coupling): RefundCommandService에서 환불 완료(complete) 처리 시, 캘린더 도메인을 직접 의존하여 삭제하지 않고 RefundApprovedEvent 도메인 이벤트를 발행하도록 설계했습니다.

## 🔗 Issue
Closes #162

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 비동기 이벤트 정상 동작 여부: 관리자 환불 완료 API(PUT /api/v1/admin/refund-requests/{refundId}/complete) 호출 시, 메인 트랜잭션이 종료된 후 async 스레드 풀에서 CalendarEventListener가 이벤트를 정상 수신하여 캘린더 데이터를 삭제(DELETE)하는지 확인해 주세요.
