### PR TITLE
 캘린더 항공권 정보 추가, 디데이 24시간 전 이메일 발송 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
@@ -101,7 +101,7 @@ public class BookingCommandService implements BookingCommandUseCase {
 
         bookingRepository.updateStatus(bookingId, BookingStatus.CANCEL_REQUESTED);
 
-        eventPublisher.publishEvent(new BookingCanceledEvent(booking.getUserId(), booking.getAccommodationId()));
+        eventPublisher.publishEvent(new BookingCanceledEvent(booking.getUserId(), booking.getAccommodationId(),  booking.getId()));
 
         log.info("[BookingCommandService] 예약 취소 완료 - bookingId: {}", bookingId);
     }

--- a/src/main/java/com/kidmily/algoga_server/booking/domain/event/BookingCanceledEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/domain/event/BookingCanceledEvent.java
@@ -2,5 +2,6 @@ package com.kidmily.algoga_server.booking.domain.event;
 
 public record BookingCanceledEvent(
         Long userId,
-        Long accommodationId
+        Long accommodationId,
+        Long bookingId
 ) {}

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.calendar.application.listener;
 
 import com.kidmily.algoga_server.booking.domain.event.BookingCanceledEvent;
+import com.kidmily.algoga_server.calendar.application.policy.CalendarSchedulePolicy;
 import com.kidmily.algoga_server.calendar.domain.model.Calendar;
 import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 import com.kidmily.algoga_server.calendar.domain.repository.CalendarRepository;
@@ -16,12 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.time.LocalDate;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class CalendarEventListener {
 
     private final CalendarRepository calendarRepository;
+    private final CalendarSchedulePolicy calendarSchedulePolicy;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -31,14 +35,29 @@ public class CalendarEventListener {
                 event.userId(), event.accommodationId());
 
         try {
-            Calendar calendar = Calendar.create(
+            // 숙소 캘린더 저장
+            Calendar tripCalendar = Calendar.create(
                     event.userId(),
                     event.accommodationId(),
                     event.checkInDate(),
                     CalendarType.TRIP
             );
-            calendarRepository.save(calendar);
-            log.info("[CalendarEventListener] 패키지 캘린더 일정 저장 완료");
+            calendarRepository.save(tripCalendar);
+            log.info("[CalendarEventListener] 숙소 캘린더 일정 저장 완료");
+
+            // 항공권 캘린더 저장
+            LocalDate departureDate = calendarSchedulePolicy.resolveFlightDepartureDate(event.bookingId());
+            if (departureDate != null) {
+                Calendar flightCalendar = Calendar.create(
+                        event.userId(),
+                        event.bookingId(),
+                        departureDate,
+                        CalendarType.FLIGHT
+                );
+                calendarRepository.save(flightCalendar);
+                log.info("[CalendarEventListener] 항공권 캘린더 일정 저장 완료");
+            }
+
         } catch (Exception e) {
             log.error("[CalendarEventListener] 패키지 결제 반영 중 캘린더 처리 실패! - userId: {}, error: {}",
                     event.userId(), e.getMessage(), e);
@@ -48,14 +67,14 @@ public class CalendarEventListener {
 
     // 단순 예약 취소 완료 시 일정 삭제
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 취소 처리가 DB에 완벽히 커밋되었을 때만!
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleBookingCanceled(BookingCanceledEvent event) {
         log.info("[CalendarEventListener] 예약 취소 완료 커밋 확인 - userId: {}, accommodationId: {}",
                 event.userId(), event.accommodationId());
 
         try {
-            // 비동기 내부 로직을 try-catch 로 보호
+            // 숙소 캘린더 삭제
             calendarRepository.deleteByUserIdAndReferenceIdAndType(
                     event.userId(),
                     event.accommodationId(),
@@ -63,8 +82,15 @@ public class CalendarEventListener {
             );
             log.info("[CalendarEventListener] 여행 캘린더 일정 삭제 완료");
 
+            // 항공권 삭제 추가
+            calendarRepository.deleteByUserIdAndReferenceIdAndType(
+                    event.userId(),
+                    event.bookingId(),
+                    CalendarType.FLIGHT
+            );
+            log.info("[CalendarEventListener] 항공권 캘린더 일정 삭제 완료");
+
         } catch (Exception e) {
-            // 중요: 예외가 밖으로 새어나가서 스레드가 조용히 터지는 걸 막고, 에러 로그를 명확히 남김
             log.error("[CalendarEventListener] 예약 취소 중 캘린더 처리 실패! - userId: {}, error: {}",
                     event.userId(), e.getMessage(), e);
         }
@@ -115,8 +141,18 @@ public class CalendarEventListener {
             );
             log.info("[CalendarEventListener] 환불 반영으로 인한 캘린더 일정 정상 제거 완료");
 
+            // 항공권 삭제 추가 (TRIP인 경우에만)
+            if (calendarType == CalendarType.TRIP && event.bookingId() != null) {
+                calendarRepository.deleteByUserIdAndReferenceIdAndType(
+                        event.userId(),
+                        event.bookingId(),
+                        CalendarType.FLIGHT
+                );
+                log.info("[CalendarEventListener] 환불 반영으로 인한 항공권 캘린더 일정 정상 제거 완료");
+            }
+
         } catch (IllegalArgumentException e) {
-            log.error("[CalendarEventListener] 환불 타입 바인딩 실패 (알 수 없는 Enum Type) - type: {}", event.type());
+            log.error("[CalendarEventListener] 환불 타입 바인딩 실패 - type: {}", event.type());
         } catch (Exception e) {
             log.error("[CalendarEventListener] 환불 반영 중 캘린더 처리 실패! - userId: {}, error: {}",
                     event.userId(), e.getMessage(), e);

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
@@ -1,15 +1,14 @@
 package com.kidmily.algoga_server.calendar.application.listener;
 
 import com.kidmily.algoga_server.booking.domain.event.BookingCanceledEvent;
-import com.kidmily.algoga_server.booking.domain.event.BookingCreatedEvent;
 import com.kidmily.algoga_server.calendar.domain.model.Calendar;
 import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 import com.kidmily.algoga_server.calendar.domain.repository.CalendarRepository;
+import com.kidmily.algoga_server.payment.domain.event.PackagePaymentCompletedEvent;
 import com.kidmily.algoga_server.payment.domain.event.PaymentCompletedEvent;
 import com.kidmily.algoga_server.refund.domain.event.RefundApprovedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -24,12 +23,11 @@ public class CalendarEventListener {
 
     private final CalendarRepository calendarRepository;
 
-    // 단순 예약 생성 완료 시 일정 추가
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 예약 완료 커밋 성공 시에만!
-    @Transactional(propagation = Propagation.REQUIRES_NEW)              // 비동기 스레드 내 독자적 트랜잭션 보장
-    public void handleBookingCreated(BookingCreatedEvent event) {
-        log.info("[CalendarEventListener] 예약 생성 완료 커밋 확인 - userId: {}, packageId: {}",
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handlePackagePaymentCompleted(PackagePaymentCompletedEvent event) {
+        log.info("[CalendarEventListener] 패키지 결제 완료 커밋 확인 - userId: {}, accommodationId: {}",
                 event.userId(), event.accommodationId());
 
         try {
@@ -40,12 +38,13 @@ public class CalendarEventListener {
                     CalendarType.TRIP
             );
             calendarRepository.save(calendar);
-            log.info("[CalendarEventListener] 캘린더 일정 저장 완료");
+            log.info("[CalendarEventListener] 패키지 캘린더 일정 저장 완료");
         } catch (Exception e) {
-            log.error("[CalendarEventListener] 예약 생성 반영 중 캘린더 처리 실패! - userId: {}, error: {}",
+            log.error("[CalendarEventListener] 패키지 결제 반영 중 캘린더 처리 실패! - userId: {}, error: {}",
                     event.userId(), e.getMessage(), e);
         }
     }
+
 
     // 단순 예약 취소 완료 시 일정 삭제
     @Async

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/policy/CalendarSchedulePolicy.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/policy/CalendarSchedulePolicy.java
@@ -1,0 +1,53 @@
+package com.kidmily.algoga_server.calendar.application.policy;
+
+import com.kidmily.algoga_server.calendar.application.port.AccommodationPort;
+import com.kidmily.algoga_server.calendar.application.port.BookingPort;
+import com.kidmily.algoga_server.calendar.application.port.LecturePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarSchedulePolicy {
+
+    private final BookingPort bookingPort;
+    private final LecturePort lecturePort;
+    private final AccommodationPort accommodationPort;
+
+    // 항공권 관련
+    public LocalDate resolveFlightDepartureDate(Long bookingId) {
+        return bookingPort.getDepartureDate(bookingId);
+    }
+
+    public String resolveFlightName(Long bookingId) {
+        return bookingPort.getFlightName(bookingId);
+    }
+
+    // 숙소 관련
+    public String resolveAccommodationName(Long accommodationId) {
+        return accommodationPort.getAccommodationName(accommodationId);
+    }
+
+    // 강의 관련
+    public String resolveLectureName(Long courseId) {
+        return lecturePort.getLectureName(courseId);
+    }
+
+    public LocalDate resolveLectureStartDate(Long courseId, Long userId) {
+        return lecturePort.getLectureStartDate(courseId, userId);
+    }
+
+    public LocalDate resolveLectureEndDate(Long courseId, Long userId) {
+        return lecturePort.getLectureEndDate(courseId, userId);
+    }
+    // 이메일 발송
+    public LocalDateTime resolveDepartureDateTime(Long bookingId) {
+        return bookingPort.getDepartureDateTime(bookingId);
+    }
+    public String resolveFlightInfo(Long bookingId) {
+        return bookingPort.getFlightInfo(bookingId);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/port/BookingPort.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/port/BookingPort.java
@@ -1,0 +1,11 @@
+package com.kidmily.algoga_server.calendar.application.port;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface BookingPort {
+    String getFlightName(Long bookingId);
+    LocalDate getDepartureDate(Long bookingId);
+    LocalDateTime getDepartureDateTime(Long bookingId);
+    String getFlightInfo(Long bookingId);
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/port/UserPort.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/port/UserPort.java
@@ -1,0 +1,6 @@
+package com.kidmily.algoga_server.calendar.application.port;
+
+public interface UserPort {
+    String getUserEmail(Long userId);
+    String getUserName(Long userId);
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/scheduler/FlightReminderScheduler.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/scheduler/FlightReminderScheduler.java
@@ -1,0 +1,71 @@
+package com.kidmily.algoga_server.calendar.application.scheduler;
+
+import com.kidmily.algoga_server.calendar.application.policy.CalendarSchedulePolicy;
+import com.kidmily.algoga_server.calendar.application.service.FlightReminderMailService;
+import com.kidmily.algoga_server.calendar.domain.model.Calendar;
+import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
+import com.kidmily.algoga_server.calendar.domain.repository.CalendarRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FlightReminderScheduler {
+
+    private final CalendarRepository calendarRepository;
+    private final FlightReminderMailService flightReminderMailService;
+    private final CalendarSchedulePolicy calendarSchedulePolicy;
+
+    @Scheduled(cron = "0 0 * * * *") // 매 정시마다 실행
+    public void sendFlightReminders() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime in24Hours = now.plusHours(24);
+
+        log.info("[FlightReminderScheduler] 항공권 리마인더 스케줄러 실행 - 현재: {}", now);
+
+        List<Calendar> flightCalendars = calendarRepository.findByType(CalendarType.FLIGHT);
+
+        for (Calendar calendar : flightCalendars) {
+            try {
+                // 이미 발송된 경우 스킵
+                if (Boolean.TRUE.equals(calendar.getIsDDayAlertSent())) {
+                    continue;
+                }
+
+                LocalDateTime departureDateTime = calendarSchedulePolicy.resolveDepartureDateTime(calendar.getReferenceId());
+
+                if (departureDateTime == null) {
+                    log.warn("[FlightReminderScheduler] 출발 시각 없음 - calendarId: {}", calendar.getCalendarId());
+                    continue;
+                }
+
+                if (departureDateTime.isAfter(now) && departureDateTime.isBefore(in24Hours)) {
+                    log.info("[FlightReminderScheduler] 리마인더 발송 대상 - userId: {}, departureDateTime: {}",
+                            calendar.getUserId(), departureDateTime);
+
+                    flightReminderMailService.sendFlightReminder(
+                            calendar.getUserId(),
+                            calendar.getReferenceId(),
+                            departureDateTime.toLocalDate()
+                    );
+
+                    // 발송 완료 처리
+                    calendar.markDDayAlertSent();
+                    calendarRepository.update(calendar);
+                    log.info("[FlightReminderScheduler] 발송 완료 처리 - calendarId: {}", calendar.getCalendarId());
+                }
+            } catch (Exception e) {
+                log.error("[FlightReminderScheduler] 리마인더 처리 실패 - calendarId: {}, error: {}",
+                        calendar.getCalendarId(), e.getMessage());
+            }
+        }
+        log.info("[FlightReminderScheduler] 항공권 리마인더 발송 완료");
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/service/CalendarQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/service/CalendarQueryService.java
@@ -1,7 +1,6 @@
 package com.kidmily.algoga_server.calendar.application.service;
 
-import com.kidmily.algoga_server.calendar.application.port.LecturePort;
-import com.kidmily.algoga_server.calendar.application.port.AccommodationPort;
+import com.kidmily.algoga_server.calendar.application.policy.CalendarSchedulePolicy;
 import com.kidmily.algoga_server.calendar.application.usecase.CalendarQueryUseCase;
 import com.kidmily.algoga_server.calendar.domain.model.Calendar;
 import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
@@ -24,8 +23,7 @@ import java.util.List;
 public class CalendarQueryService implements CalendarQueryUseCase {
 
     private final CalendarRepository calendarRepository;
-    private final AccommodationPort accommodationPort;
-    private final LecturePort lecturePort;
+    private final CalendarSchedulePolicy calendarSchedulePolicy;
 
     @Override
     public CalendarResponse getCalendar(Long userId, int year, int month) {
@@ -60,9 +58,9 @@ public class CalendarQueryService implements CalendarQueryUseCase {
 
     private List<ScheduleResponse> toScheduleResponses(Calendar calendar, Long userId) {
         if (calendar.getType() == CalendarType.LECTURE) {
-            String title = lecturePort.getLectureName(calendar.getReferenceId());
-            LocalDate startDate = lecturePort.getLectureStartDate(calendar.getReferenceId(), userId);
-            LocalDate endDate = lecturePort.getLectureEndDate(calendar.getReferenceId(), userId);
+            String title = calendarSchedulePolicy.resolveLectureName(calendar.getReferenceId());
+            LocalDate startDate = calendarSchedulePolicy.resolveLectureStartDate(calendar.getReferenceId(), userId);
+            LocalDate endDate = calendarSchedulePolicy.resolveLectureEndDate(calendar.getReferenceId(), userId);
 
             if (startDate == null || endDate == null) {
                 return List.of();
@@ -80,7 +78,10 @@ public class CalendarQueryService implements CalendarQueryUseCase {
 
     private String resolveTitle(Calendar calendar) {
         if (calendar.getType() == CalendarType.TRIP) {
-            return accommodationPort.getAccommodationName(calendar.getReferenceId());
+            return calendarSchedulePolicy.resolveAccommodationName(calendar.getReferenceId());
+        }
+        if (calendar.getType() == CalendarType.FLIGHT) {
+            return calendarSchedulePolicy.resolveFlightName(calendar.getReferenceId());
         }
         return "D-day";
     }

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/service/FlightReminderMailService.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/service/FlightReminderMailService.java
@@ -1,0 +1,109 @@
+package com.kidmily.algoga_server.calendar.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kidmily.algoga_server.calendar.application.policy.CalendarSchedulePolicy;
+import com.kidmily.algoga_server.calendar.application.port.UserPort;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FlightReminderMailService {
+
+    private final JavaMailSender mailSender;
+    private final UserPort userPort;
+    private final CalendarSchedulePolicy calendarSchedulePolicy;
+    private final ObjectMapper objectMapper;
+
+    @Async
+    public void sendFlightReminder(Long userId, Long bookingId, LocalDate departureDate) {
+        String email = userPort.getUserEmail(userId);
+        String name = userPort.getUserName(userId);
+
+        if (email == null) {
+            log.warn("[FlightReminderMailService] 유저 이메일 없음 - userId: {}", userId);
+            return;
+        }
+
+        try {
+            // 항공편 정보 파싱
+            String flightInfoJson = calendarSchedulePolicy.resolveFlightInfo(bookingId);
+            String airline = "알 수 없음";
+            String flightNumber = "알 수 없음";
+            String departure = "알 수 없음";
+            String arrival = "알 수 없음";
+            String departureTime = "알 수 없음";
+            String arrivalTime = "알 수 없음";
+
+            if (flightInfoJson != null) {
+                JsonNode node = objectMapper.readTree(flightInfoJson);
+                airline = node.path("airline").asText("알 수 없음");
+                flightNumber = node.path("flightNumber").asText("알 수 없음");
+                departure = node.path("departure").asText("알 수 없음");
+                arrival = node.path("arrival").asText("알 수 없음");
+                departureTime = node.path("departureTime").asText("알 수 없음");
+                arrivalTime = node.path("arrivalTime").asText("알 수 없음");
+            }
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(email);
+            helper.setSubject("[알고가] 내일 출발입니다! 항공권 안내");
+            helper.setText(buildEmailBody(name, airline, flightNumber, departure, arrival, departureTime, arrivalTime), true);
+
+            mailSender.send(message);
+            log.info("[FlightReminderMailService] 항공권 리마인더 메일 발송 성공 - userId: {}", userId);
+        } catch (Exception e) {
+            log.warn("[FlightReminderMailService] 항공권 리마인더 메일 발송 실패 - userId: {}, error: {}",
+                    userId, e.getMessage());
+        }
+    }
+
+    private String buildEmailBody(String name, String airline, String flightNumber,
+                                  String departure, String arrival,
+                                  String departureTime, String arrivalTime) {
+        return """
+                <html><body style="font-family: sans-serif; color: #333;">
+                <div style="max-width:600px; margin:0 auto; padding:30px;">
+                  <h2 style="color:#2c7be5;">✈ 알고가 출발 안내</h2>
+                  <p>안녕하세요, <strong>%s</strong>님!</p>
+                  <p>내일 출발 일정이 있습니다. 즐거운 여행 되세요! 🎉</p>
+                  <table style="width:100%%; border-collapse:collapse; margin-top:20px;">
+                    <tr style="background:#f5f5f5;">
+                      <td style="padding:10px; border:1px solid #ddd; font-weight:bold;">항공사</td>
+                      <td style="padding:10px; border:1px solid #ddd;">%s</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:10px; border:1px solid #ddd; font-weight:bold;">편명</td>
+                      <td style="padding:10px; border:1px solid #ddd;">%s</td>
+                    </tr>
+                    <tr style="background:#f5f5f5;">
+                      <td style="padding:10px; border:1px solid #ddd; font-weight:bold;">출발</td>
+                      <td style="padding:10px; border:1px solid #ddd;">%s → %s</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:10px; border:1px solid #ddd; font-weight:bold;">출발 시각</td>
+                      <td style="padding:10px; border:1px solid #ddd;">%s</td>
+                    </tr>
+                    <tr style="background:#f5f5f5;">
+                      <td style="padding:10px; border:1px solid #ddd; font-weight:bold;">도착 시각</td>
+                      <td style="padding:10px; border:1px solid #ddd;">%s</td>
+                    </tr>
+                  </table>
+                  <p style="margin-top:30px; color:#888; font-size:12px;">문의: algoga.official@gmail.com</p>
+                </div>
+                </body></html>
+                """.formatted(name, airline, flightNumber, departure, arrival, departureTime, arrivalTime);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/config/CalendarSchedulingConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/config/CalendarSchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.calendar.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class CalendarSchedulingConfig {
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/domain/model/CalendarType.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/domain/model/CalendarType.java
@@ -5,5 +5,6 @@ public enum CalendarType {
     LECTURE_START,  //
     LECTURE_END,    //
     TRIP,      // 여행
+    FLIGHT, // 항공권
     D_DAY      // D-day
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/domain/repository/CalendarRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/domain/repository/CalendarRepository.java
@@ -11,4 +11,6 @@ public interface CalendarRepository {
     List<Calendar> findByUserIdAndDateRange(Long userId, LocalDate startDate, LocalDate endDate);
     // 기존 단일 referenceId 삭제에서 -> 안전한 복합 조건 삭제 포트로 변경
     void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type);
+    List<Calendar> findByType(CalendarType type);
+    Calendar update(Calendar calendar);
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/BookingPortAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/BookingPortAdapter.java
@@ -1,0 +1,71 @@
+package com.kidmily.algoga_server.calendar.infrastructure.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.calendar.application.port.BookingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+// calendar/infrastructure/adapter/BookingPortAdapter.java
+@Component
+@RequiredArgsConstructor
+public class BookingPortAdapter implements BookingPort {
+
+    private final BookingRepository bookingRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String getFlightName(Long bookingId) {
+        return bookingRepository.findById(bookingId)
+                .map(booking -> {
+                    try {
+                        JsonNode node = objectMapper.readTree(booking.getFlightInfo());
+                        return node.path("airline").asText("항공권");
+                    } catch (Exception e) {
+                        return "항공권";
+                    }
+                })
+                .orElse("삭제된 항공권");
+    }
+
+    @Override
+    public LocalDate getDepartureDate(Long bookingId) {
+        return bookingRepository.findById(bookingId)
+                .map(booking -> {
+                    try {
+                        JsonNode node = objectMapper.readTree(booking.getFlightInfo());
+                        String departureTime = node.path("departureTime").asText();
+                        return LocalDateTime.parse(departureTime).toLocalDate();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .orElse(null);
+    }
+
+    @Override
+    public LocalDateTime getDepartureDateTime(Long bookingId) {
+        return bookingRepository.findById(bookingId)
+                .map(booking -> {
+                    try {
+                        JsonNode node = objectMapper.readTree(booking.getFlightInfo());
+                        String departureTime = node.path("departureTime").asText();
+                        return LocalDateTime.parse(departureTime);
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .orElse(null);
+    }
+
+    @Override
+    public String getFlightInfo(Long bookingId) {
+        return bookingRepository.findById(bookingId)
+                .map(booking -> booking.getFlightInfo())
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/UserPortAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/UserPortAdapter.java
@@ -1,0 +1,27 @@
+package com.kidmily.algoga_server.calendar.infrastructure.adapter;
+
+import com.kidmily.algoga_server.calendar.application.port.UserPort;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("calendarUserPortAdapter")
+@RequiredArgsConstructor
+public class UserPortAdapter implements UserPort {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public String getUserEmail(Long userId) {
+        return userRepository.findById(userId)
+                .map(user -> user.getEmail())
+                .orElse(null);
+    }
+
+    @Override
+    public String getUserName(Long userId) {
+        return userRepository.findById(userId)
+                .map(user -> user.getName())
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
@@ -35,12 +35,6 @@ public class CalendarRepositoryAdapter implements CalendarRepository {
                 .toList();
     }
 
-//    @Override
-//    @Transactional
-//    public void deleteByReferenceId(Long referenceId) {
-//        springDataRepository.deleteByReferenceId(referenceId);
-//    }
-
     @Override
     @Transactional
     public void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type) {

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.kidmily.algoga_server.calendar.domain.model.Calendar;
 import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 import com.kidmily.algoga_server.calendar.domain.repository.CalendarRepository;
 import com.kidmily.algoga_server.calendar.infrastructure.mapper.CalendarMapper;
+import com.kidmily.algoga_server.calendar.infrastructure.persistence.entity.CalendarJpaEntity;
 import com.kidmily.algoga_server.calendar.infrastructure.persistence.repository.SpringDataCalendarRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -39,5 +40,20 @@ public class CalendarRepositoryAdapter implements CalendarRepository {
     @Transactional
     public void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type) {
         springDataRepository.deleteByUserIdAndReferenceIdAndType(userId, referenceId, type);
+    }
+
+    @Override
+    public List<Calendar> findByType(CalendarType type) {
+        return springDataRepository.findByType(type)
+                .stream()
+                .map(calendarMapper::toDomain)
+                .toList();
+    }
+    @Override
+    public Calendar update(Calendar calendar) {
+        CalendarJpaEntity entity = springDataRepository.findById(calendar.getCalendarId())
+                .orElseThrow(() -> new RuntimeException("캘린더를 찾을 수 없습니다."));
+        entity.updateDDayAlertSent(calendar.getIsDDayAlertSent());
+        return calendarMapper.toDomain(springDataRepository.save(entity));
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/entity/CalendarJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/entity/CalendarJpaEntity.java
@@ -44,4 +44,8 @@ public class CalendarJpaEntity {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    public void updateDDayAlertSent(Boolean isDDayAlertSent) {
+        this.isDDayAlertSent = isDDayAlertSent;
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/repository/SpringDataCalendarRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/repository/SpringDataCalendarRepository.java
@@ -13,4 +13,5 @@ public interface SpringDataCalendarRepository extends JpaRepository<CalendarJpaE
     );
     void deleteByReferenceId(Long referenceId);
     void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type);
+    List<CalendarJpaEntity> findByType(CalendarType type);
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
@@ -10,6 +10,8 @@ import com.kidmily.algoga_server.notification.domain.model.NotificationType;
 import com.kidmily.algoga_server.notification.domain.repository.NotificationRepository;
 import com.kidmily.algoga_server.notification.domain.repository.NotificationSettingRepository;
 import com.kidmily.algoga_server.payment.domain.event.PaymentCompletedEvent;
+import com.kidmily.algoga_server.refund.domain.event.RefundApprovedEvent;
+import com.kidmily.algoga_server.refund.domain.event.RefundRejectedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -31,7 +33,7 @@ public class NotificationEventListener {
     private final CoursePort coursePort;
 
 
-
+    // 댓글 알림
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -120,4 +122,43 @@ public class NotificationEventListener {
             default -> event.bookingNumber() + " 결제가 완료되었습니다";
         };
     }
+
+    // 환불 승인 알림
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleRefundApproved(RefundApprovedEvent event) {
+        log.info("[NotificationEventListener] 환불 승인 이벤트 수신 - userId: {}", event.userId());
+
+        Notification notification = Notification.create(
+                event.userId(),
+                NotificationType.REFUND_APPROVED,
+                "환불이 승인되었습니다.",
+                null,
+                null
+        );
+
+        notificationRepository.save(notification);
+        log.info("[NotificationEventListener] 환불 승인 알림 저장 완료 - userId: {}", event.userId());
+    }
+
+    // 환불 거절 알림
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleRefundRejected(RefundRejectedEvent event) {
+        log.info("[NotificationEventListener] 환불 거절 이벤트 수신 - userId: {}", event.userId());
+
+        Notification notification = Notification.create(
+                event.userId(),
+                NotificationType.REFUND_REJECTED,
+                "환불이 거절되었습니다.",
+                null,
+                null
+        );
+
+        notificationRepository.save(notification);
+        log.info("[NotificationEventListener] 환불 거절 알림 저장 완료 - userId: {}", event.userId());
+    }
+
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
@@ -116,9 +116,9 @@ public class NotificationEventListener {
             return courseName + " 강의가 결제 완료되었습니다";
         }
         return switch (event.paymentType()) {
-            case DEPOSIT -> event.bookingNumber() + " 숙소 계약금 결제가 완료되었습니다";
-            case BALANCE -> event.bookingNumber() + " 숙소 잔금 결제가 완료되었습니다";
-            case FULL -> event.bookingNumber() + " 숙소 결제가 완료되었습니다";
+            case DEPOSIT -> event.bookingNumber() + " 패키지 계약금 결제가 완료되었습니다";
+            case BALANCE -> event.bookingNumber() + " 패키지 잔금 결제가 완료되었습니다";
+            case FULL -> event.bookingNumber() + " 패키지 결제가 완료되었습니다";
             default -> event.bookingNumber() + " 결제가 완료되었습니다";
         };
     }

--- a/src/main/java/com/kidmily/algoga_server/notification/domain/model/NotificationType.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/domain/model/NotificationType.java
@@ -8,22 +8,22 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
 
     // 학습
-    COURSE_REGISTERED("강의 수강 등록", NotificationCategory.LEARNING),
-    COURSE_COMPLETED("강의 수강 완료", NotificationCategory.LEARNING), // 완료
+    COURSE_REGISTERED("강의 수강 등록", NotificationCategory.LEARNING), // 필요없음
+    COURSE_COMPLETED("강의 수강 완료", NotificationCategory.LEARNING), // ⭐완료
     DDAY_REMINDER("D-day 알림", NotificationCategory.LEARNING),
 
     // Q&A
     QNA_ANSWERED("Q&A 답변 등록", NotificationCategory.QNA),
 
     // 커뮤니티
-    POST_COMMENTED("게시글 댓글", NotificationCategory.COMMUNITY), // 완료
-    COMMENT_REPLIED("댓글 대댓글", NotificationCategory.COMMUNITY), //
+    POST_COMMENTED("게시글 댓글", NotificationCategory.COMMUNITY), // ⭐완료
+    COMMENT_REPLIED("댓글 대댓글", NotificationCategory.COMMUNITY), // ⭐완료
 
     // 결제/예약 (필수 알림 - 설정 무관)
-    PAYMENT_COMPLETED("결제 완료", NotificationCategory.MANDATORY), // 완료
-    RESERVATION_CONFIRMED("예약 확정", NotificationCategory.MANDATORY),
-    REFUND_APPROVED("환불 승인", NotificationCategory.MANDATORY), // 진행종
-    REFUND_REJECTED("환불 거절", NotificationCategory.MANDATORY), // 진행중
+    PAYMENT_COMPLETED("결제 완료", NotificationCategory.MANDATORY), // ⭐완료
+    RESERVATION_CONFIRMED("예약 확정", NotificationCategory.MANDATORY), // 필요없음
+    REFUND_APPROVED("환불 승인", NotificationCategory.MANDATORY), // ⭐완료
+    REFUND_REJECTED("환불 거절", NotificationCategory.MANDATORY), // ⭐완료
 
     // 공지사항
     NOTICE_CREATED("공지사항 등록", NotificationCategory.NOTICE),

--- a/src/main/java/com/kidmily/algoga_server/notification/domain/model/NotificationType.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/domain/model/NotificationType.java
@@ -22,8 +22,8 @@ public enum NotificationType {
     // 결제/예약 (필수 알림 - 설정 무관)
     PAYMENT_COMPLETED("결제 완료", NotificationCategory.MANDATORY), // 완료
     RESERVATION_CONFIRMED("예약 확정", NotificationCategory.MANDATORY),
-    REFUND_APPROVED("환불 승인", NotificationCategory.MANDATORY),
-    REFUND_REJECTED("환불 거절", NotificationCategory.MANDATORY),
+    REFUND_APPROVED("환불 승인", NotificationCategory.MANDATORY), // 진행종
+    REFUND_REJECTED("환불 거절", NotificationCategory.MANDATORY), // 진행중
 
     // 공지사항
     NOTICE_CREATED("공지사항 등록", NotificationCategory.NOTICE),

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
@@ -14,6 +14,7 @@ import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
 import com.kidmily.algoga_server.payment.application.command.CreateLecturePaymentCommand;
 import com.kidmily.algoga_server.payment.application.command.CreatePaymentCommand;
 import com.kidmily.algoga_server.payment.application.usecase.PaymentCommandUseCase;
+import com.kidmily.algoga_server.payment.domain.event.PackagePaymentCompletedEvent;
 import com.kidmily.algoga_server.payment.domain.event.PaymentCompletedEvent;
 import com.kidmily.algoga_server.payment.domain.model.Payment;
 import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
@@ -137,6 +138,17 @@ public class PaymentCommandService implements PaymentCommandUseCase {
                     command.amount(),
                     LocalDateTime.now()
             ));
+            // 캘린더용 패키지 이벤트 발행 승재 추가
+            if (command.paymentType() == PaymentType.DEPOSIT || command.paymentType() == PaymentType.FULL) {
+                eventPublisher.publishEvent(new PackagePaymentCompletedEvent(
+                        user.getId(),
+                        booking.getAccommodationId(),
+                        booking.getCheckInDate()
+                ));
+                log.info("[PaymentCommandService] 패키지 캘린더 이벤트 발행 - userId: {}, accommodationId: {}",
+                        user.getId(), booking.getAccommodationId());
+            }
+
         } else {
             payment.markFailed();
             log.warn("[PaymentCommandService] 결제 실패 - portoneStatus: {}", portoneStatus);

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
@@ -143,6 +143,7 @@ public class PaymentCommandService implements PaymentCommandUseCase {
                 eventPublisher.publishEvent(new PackagePaymentCompletedEvent(
                         user.getId(),
                         booking.getAccommodationId(),
+                        booking.getId(),
                         booking.getCheckInDate()
                 ));
                 log.info("[PaymentCommandService] 패키지 캘린더 이벤트 발행 - userId: {}, accommodationId: {}",

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/event/PackagePaymentCompletedEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/event/PackagePaymentCompletedEvent.java
@@ -5,5 +5,6 @@ import java.time.LocalDate;
 public record PackagePaymentCompletedEvent(
         Long userId,
         Long accommodationId,
+        Long bookingId,
         LocalDate checkInDate
 ) {}

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/event/PackagePaymentCompletedEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/event/PackagePaymentCompletedEvent.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.payment.domain.event;
+
+import java.time.LocalDate;
+
+public record PackagePaymentCompletedEvent(
+        Long userId,
+        Long accommodationId,
+        LocalDate checkInDate
+) {}

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
@@ -1,6 +1,8 @@
 package com.kidmily.algoga_server.payment.infrastructure.portone;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.kidmily.algoga_server.global.exception.BusinessException;
 import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,7 @@ public class PortOneClient {
 
     private final RestClient restClient;
     private final PortOneProperties properties;
+
 
     public PortOneClient(PortOneProperties properties) {
         this.properties = properties;

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
@@ -1,8 +1,6 @@
 package com.kidmily.algoga_server.payment.infrastructure.portone;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.kidmily.algoga_server.global.exception.BusinessException;
 import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
@@ -11,6 +11,7 @@ import com.kidmily.algoga_server.payment.infrastructure.portone.PortOneClient; /
 import com.kidmily.algoga_server.refund.application.command.CreateRefundCommand;
 import com.kidmily.algoga_server.refund.application.usecase.RefundCommandUseCase;
 import com.kidmily.algoga_server.refund.domain.event.RefundApprovedEvent;
+import com.kidmily.algoga_server.refund.domain.event.RefundRejectedEvent;
 import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
 import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
@@ -160,6 +161,22 @@ public class RefundCommandService implements RefundCommandUseCase {
         refundRequest.reject(rejectReason);
         refundRepository.save(refundRequest);
         log.info("[RefundCommandService] 환불 반려 완료 - refundId: {}", refundId);
+
+        // payment 조회해서 강의/패키지 구분 승재 추가
+        Payment payment = paymentRepository.findById(refundRequest.getPaymentId())
+                .orElseThrow(() -> new BusinessException(RefundErrorCode.PAYMENT_NOT_FOUND));
+
+        RefundRejectedEvent event;
+        if (payment.getCourseId() != null) {
+            event = RefundRejectedEvent.ofLecture(refundRequest.getUserId(), payment.getCourseId());
+        } else {
+            Booking booking = bookingRepository.findById(refundRequest.getBookingId())
+                    .orElseThrow(() -> new BusinessException(RefundErrorCode.BOOKING_NOT_FOUND));
+            event = RefundRejectedEvent.ofTrip(refundRequest.getUserId(), booking.getAccommodationId());
+        }
+        eventPublisher.publishEvent(event);
+
+        log.info("[RefundCommandService] RefundRejectedEvent 발행 완료 - userId: {}", refundRequest.getUserId());
     }
 
     @Override
@@ -206,11 +223,12 @@ public class RefundCommandService implements RefundCommandUseCase {
 
 
         // 🌟 [추가 영역 B] 모든 DB 저장이 완벽히 성공한 이 시점에 캘린더 연동 벨을 울립니다
-        RefundApprovedEvent event = new RefundApprovedEvent(
-                booking.getUserId(),         // 유저 ID
-                booking.getAccommodationId(),   // 제거할 숙소/패키지 ID
-                "TRIP"                       // CalendarType.TRIP과 매칭될 문자열 고정
-        );
+        RefundApprovedEvent event;
+        if (payment.getCourseId() != null) {
+            event = RefundApprovedEvent.ofLecture(booking.getUserId(), payment.getCourseId());
+        } else {
+            event = RefundApprovedEvent.ofTrip(booking.getUserId(), booking.getAccommodationId());
+        }
         eventPublisher.publishEvent(event);
 
         log.info("[RefundCommandService] 캘린더 연동을 위한 RefundApprovedEvent 발행 완료");

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
@@ -208,7 +208,7 @@ public class RefundCommandService implements RefundCommandUseCase {
         // 4. Booking 상태 → REFUNDED
         bookingRepository.updateStatus(refundRequest.getBookingId(), BookingStatus.REFUNDED);
 
-        // 🌟 [추가 영역 A] 이벤트를 만들기 위해 Booking 엔티티 정보를 명확히 조회해옵니다.
+        // 이벤트를 만들기 위해 Booking 엔티티 정보를 명확히 조회해옵니다.
         // (bookingRepository 명세에 맞게 findById 등으로 유저 ID와 숙소 ID를 수집합니다.)
         Booking booking = bookingRepository.findById(refundRequest.getBookingId())
                 .orElseThrow(() -> new BusinessException(RefundErrorCode.BOOKING_NOT_FOUND));
@@ -222,12 +222,12 @@ public class RefundCommandService implements RefundCommandUseCase {
 
 
 
-        // 🌟 [추가 영역 B] 모든 DB 저장이 완벽히 성공한 이 시점에 캘린더 연동 벨을 울립니다
+        // 모든 DB 저장이 완벽히 성공한 이 시점에 캘린더 연동 벨을 울립니다
         RefundApprovedEvent event;
         if (payment.getCourseId() != null) {
             event = RefundApprovedEvent.ofLecture(booking.getUserId(), payment.getCourseId());
         } else {
-            event = RefundApprovedEvent.ofTrip(booking.getUserId(), booking.getAccommodationId());
+            event = RefundApprovedEvent.ofTrip(booking.getUserId(), booking.getAccommodationId(), booking.getId() );
         }
         eventPublisher.publishEvent(event);
 

--- a/src/main/java/com/kidmily/algoga_server/refund/domain/event/RefundApprovedEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/domain/event/RefundApprovedEvent.java
@@ -7,19 +7,20 @@ package com.kidmily.algoga_server.refund.domain.event;
 public record RefundApprovedEvent(
         Long userId,
         Long referenceId,       // 캘린더 테이블의 referenceId와 매핑되는 ID (courseId 또는 accommodationId)
+        Long bookingId,
         String type             // "LECTURE" (강의) 또는 "TRIP" (여행/패키지)
 ) {
     /**
      * 강의(Lecture) 환불 승인 시 이벤트를 생성하는 팩토리 메서드
      */
     public static RefundApprovedEvent ofLecture(Long userId, Long courseId) {
-        return new RefundApprovedEvent(userId, courseId, "LECTURE");
+        return new RefundApprovedEvent(userId, courseId,null, "LECTURE");
     }
 
     /**
      * 여행/패키지(Trip) 환불 승인 시 이벤트를 생성하는 팩토리 메서드
      */
-    public static RefundApprovedEvent ofTrip(Long userId, Long accommodationId) {
-        return new RefundApprovedEvent(userId, accommodationId, "TRIP");
+    public static RefundApprovedEvent ofTrip(Long userId, Long accommodationId, Long bookingId) {
+        return new RefundApprovedEvent(userId, accommodationId, bookingId, "TRIP");
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/domain/event/RefundRejectedEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/domain/event/RefundRejectedEvent.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.refund.domain.event;
+
+public record RefundRejectedEvent(
+        Long userId,
+        Long referenceId,
+        String type  // "LECTURE" 또는 "TRIP"
+) {
+    public static RefundRejectedEvent ofLecture(Long userId, Long courseId) {
+        return new RefundRejectedEvent(userId, courseId, "LECTURE");
+    }
+
+    public static RefundRejectedEvent ofTrip(Long userId, Long accommodationId) {
+        return new RefundRejectedEvent(userId, accommodationId, "TRIP");
+    }
+}


### PR DESCRIPTION
## 설명
캘린더에 항공권(FLIGHT) 일정 추가 및 출발 24시간 전 이메일 자동 발송 기능을 구현했습니다.

**캘린더 항공권 정보 추가**
- `CalendarType`에 `FLIGHT` 타입 추가
- 패키지 결제 완료 시 숙소(TRIP)와 함께 항공권(FLIGHT) 캘린더 일정 자동 저장
- 예약 취소/환불 시 항공권 캘린더 일정도 함께 삭제
- `BookingPort` 추가 - `flightInfo` JSON 파싱하여 항공사명, 출발일 조회
- `CalendarSchedulePolicy`에 항공권 관련 메서드 추가

**출발 24시간 전 이메일 자동 발송**
- `FlightReminderScheduler` - 매 정시마다 실행, 24시간 이내 출발 항공권 조회
- `FlightReminderMailService` - 항공편 정보(항공사, 편명, 출발/도착 시각) 포함한 이메일 발송
- `is_d_day_alert_sent` 플래그로 중복 발송 방지
- `UserPort` 추가 - 유저 이메일/이름 조회
- `CalendarSchedulingConfig` - `@EnableScheduling` 설정

## 🔗 Issue
Closes #174

---
## 확인할 사항

- [ ] 패키지 결제 완료 시 캘린더에 숙소(TRIP), 항공권(FLIGHT) 두 개 일정이 저장되는지 확인
- [ ] 예약 취소/환불 시 TRIP, FLIGHT 둘 다 삭제되는지 확인
- [ ] 스케줄러가 매 정시 실행되며 24시간 이내 출발 항공권에 이메일 발송되는지 확인
- [ ] 이메일 발송 후 `is_d_day_alert_sent = true`로 업데이트되어 중복 발송 안 되는지 확인
- [ ] 프론트 FLIGHT 타입 미처리 시 에러 없이 해당 일정만 미표시 확인