### PR TITLE
Feature/notification setting

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/calendar/application/policy/CalendarSchedulePolicy.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/policy/CalendarSchedulePolicy.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.calendar.application.policy;
 import com.kidmily.algoga_server.calendar.application.port.AccommodationPort;
 import com.kidmily.algoga_server.calendar.application.port.BookingPort;
 import com.kidmily.algoga_server.calendar.application.port.LecturePort;
+import com.kidmily.algoga_server.calendar.application.port.UserPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ public class CalendarSchedulePolicy {
     private final BookingPort bookingPort;
     private final LecturePort lecturePort;
     private final AccommodationPort accommodationPort;
+    private final UserPort userPort;
 
     // 항공권 관련
     public LocalDate resolveFlightDepartureDate(Long bookingId) {
@@ -49,5 +51,14 @@ public class CalendarSchedulePolicy {
     }
     public String resolveFlightInfo(Long bookingId) {
         return bookingPort.getFlightInfo(bookingId);
+    }
+
+    // 유저 관련 이메일 추가
+    public String resolveUserEmail(Long userId) {
+        return userPort.getUserEmail(userId);
+    }
+
+    public String resolveUserName(Long userId) {
+        return userPort.getUserName(userId);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/service/CalendarQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/service/CalendarQueryService.java
@@ -57,7 +57,7 @@ public class CalendarQueryService implements CalendarQueryUseCase {
     }
 
     private List<ScheduleResponse> toScheduleResponses(Calendar calendar, Long userId) {
-        if (calendar.getType() == CalendarType.LECTURE) {
+        if (calendar.isLecture()) {
             String title = calendarSchedulePolicy.resolveLectureName(calendar.getReferenceId());
             LocalDate startDate = calendarSchedulePolicy.resolveLectureStartDate(calendar.getReferenceId(), userId);
             LocalDate endDate = calendarSchedulePolicy.resolveLectureEndDate(calendar.getReferenceId(), userId);
@@ -77,10 +77,10 @@ public class CalendarQueryService implements CalendarQueryUseCase {
     }
 
     private String resolveTitle(Calendar calendar) {
-        if (calendar.getType() == CalendarType.TRIP) {
+        if (calendar.isTrip()) {
             return calendarSchedulePolicy.resolveAccommodationName(calendar.getReferenceId());
         }
-        if (calendar.getType() == CalendarType.FLIGHT) {
+        if (calendar.isFlight()) {
             return calendarSchedulePolicy.resolveFlightName(calendar.getReferenceId());
         }
         return "D-day";

--- a/src/main/java/com/kidmily/algoga_server/calendar/application/service/FlightReminderMailService.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/service/FlightReminderMailService.java
@@ -21,14 +21,13 @@ import java.time.LocalDate;
 public class FlightReminderMailService {
 
     private final JavaMailSender mailSender;
-    private final UserPort userPort;
     private final CalendarSchedulePolicy calendarSchedulePolicy;
     private final ObjectMapper objectMapper;
 
     @Async
     public void sendFlightReminder(Long userId, Long bookingId, LocalDate departureDate) {
-        String email = userPort.getUserEmail(userId);
-        String name = userPort.getUserName(userId);
+        String email = calendarSchedulePolicy.resolveUserEmail(userId);
+        String name = calendarSchedulePolicy.resolveUserName(userId);
 
         if (email == null) {
             log.warn("[FlightReminderMailService] 유저 이메일 없음 - userId: {}", userId);

--- a/src/main/java/com/kidmily/algoga_server/calendar/domain/model/Calendar.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/domain/model/Calendar.java
@@ -52,4 +52,17 @@ public class Calendar {
     public void markDDayAlertSent() {
         this.isDDayAlertSent = true;
     }
+
+    // Calendar.java 도메인 모델에 추가
+    public boolean isLecture() {
+        return this.type == CalendarType.LECTURE;
+    }
+
+    public boolean isTrip() {
+        return this.type == CalendarType.TRIP;
+    }
+
+    public boolean isFlight() {
+        return this.type == CalendarType.FLIGHT;
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/application/policy/CommunityQueryPolicy.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/policy/CommunityQueryPolicy.java
@@ -1,0 +1,28 @@
+package com.kidmily.algoga_server.community.application.policy;
+
+import com.kidmily.algoga_server.community.application.port.CountryPort;
+import com.kidmily.algoga_server.community.application.port.CoursePort;
+import com.kidmily.algoga_server.community.application.port.UserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommunityQueryPolicy {
+
+    private final UserPort userPort;
+    private final CountryPort countryPort;
+    private final CoursePort coursePort;
+
+    public String resolveNickname(Long userId) {
+        return userPort.getNickname(userId);
+    }
+
+    public String resolveProfileImageUrl(Long userId) {
+        return userPort.getProfileImageUrl(userId);
+    }
+
+    public String resolveCountryName(Long countryId) {
+        return countryPort.getCountryName(countryId);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/CommentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/CommentCommandService.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.community.application.service;
 import com.kidmily.algoga_server.community.application.command.CreateCommentCommand;
 import com.kidmily.algoga_server.community.application.command.DeleteCommentCommand;
 import com.kidmily.algoga_server.community.application.command.UpdateCommentCommand;
+import com.kidmily.algoga_server.community.application.policy.CommunityQueryPolicy;
 import com.kidmily.algoga_server.community.application.policy.DeleteCommentPolicy;
 import com.kidmily.algoga_server.community.application.port.UserPort;
 import com.kidmily.algoga_server.community.application.usecase.CommentCommandUseCase;
@@ -30,7 +31,7 @@ public class CommentCommandService implements CommentCommandUseCase {
     private final PostRepository postRepository;
     private final DeleteCommentPolicy deleteCommentPolicy;
     private final ApplicationEventPublisher eventPublisher;
-    private final UserPort userPort;  // ← 추가 (닉네임 조회용)
+    private final CommunityQueryPolicy communityQueryPolicy;
 
     // 댓글 작성
     @Override
@@ -46,6 +47,9 @@ public class CommentCommandService implements CommentCommandUseCase {
         if (command.parentId() != null) {
             Comment parentComment = commentRepository.findById(command.parentId())
                     .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
+
+            Comment.validateDepth(parentComment.getParentId());
+
             parentCommentAuthorId = parentComment.getUserId();
         }
 
@@ -59,7 +63,7 @@ public class CommentCommandService implements CommentCommandUseCase {
         Comment savedComment = commentRepository.save(comment);
 
         // 🌟 알림 이벤트 발행
-        String commenterNickname = userPort.getNickname(command.userId());
+        String commenterNickname = communityQueryPolicy.resolveNickname(command.userId());
 
         if (command.parentId() == null) {
             // 일반 댓글 → 게시글 작성자에게 알림 (본인이 본인 글에 댓글 단 경우 제외)

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.community.application.service;
 
+import com.kidmily.algoga_server.community.application.policy.CommunityQueryPolicy;
 import com.kidmily.algoga_server.community.application.port.CountryPort;
 import com.kidmily.algoga_server.community.application.port.CoursePort;
 import com.kidmily.algoga_server.community.application.port.UserPort;
@@ -32,9 +33,7 @@ public class PostQueryService implements PostQueryUseCase {
     private final CommentRepository commentRepository;
     private final LikeDislikeRepository likeDislikeRepository;
     private static final int PAGE_SIZE = 10;
-    private final UserPort userPort;
-    private final CountryPort countryPort;  // ← 추가
-    private final CoursePort coursePort;
+    private final CommunityQueryPolicy communityQueryPolicy;
 
     @Override
     @Transactional
@@ -70,8 +69,8 @@ public class PostQueryService implements PostQueryUseCase {
         return new PostResponse(
                 post.getId(),
                 post.getAuthorId(),
-                userPort.getNickname(post.getAuthorId()),           // ← 추가
-                userPort.getProfileImageUrl(post.getAuthorId()),    // ← 추가
+                communityQueryPolicy.resolveNickname(post.getAuthorId()),
+                communityQueryPolicy.resolveProfileImageUrl(post.getAuthorId()),
                 tags,
                 post.getTitle(),
                 post.getContent(),
@@ -140,9 +139,9 @@ public class PostQueryService implements PostQueryUseCase {
         Long dislikeCount = likeDislikeRepository.countDislikes(TargetType.POST, post.getId());
         Long commentCount = (long) commentRepository.findActiveCommentsByPostId(post.getId()).size();
 
-        String nickname = userPort.getNickname(post.getAuthorId());
-        String profileImageUrl = userPort.getProfileImageUrl(post.getAuthorId());
-        String countryName = countryPort.getCountryName(post.getCountryId());  // ← 추가
+        String nickname = communityQueryPolicy.resolveNickname(post.getAuthorId());
+        String profileImageUrl = communityQueryPolicy.resolveProfileImageUrl(post.getAuthorId());
+        String countryName = communityQueryPolicy.resolveCountryName(post.getCountryId());
 
         Stream<TagResponse> countryStream = countryName != null ?
                 Stream.of(TagResponse.fromCountry(countryName)) : Stream.empty();
@@ -182,8 +181,8 @@ public class PostQueryService implements PostQueryUseCase {
                 .map(c -> new CommentResponse(
                         c.getCommentId(),
                         c.getUserId(),
-                        userPort.getNickname(c.getUserId()),
-                        userPort.getProfileImageUrl(c.getUserId()),
+                        communityQueryPolicy.resolveNickname(c.getUserId()),        // 변경
+                        communityQueryPolicy.resolveProfileImageUrl(c.getUserId()),
                         c.getContent(),
                         c.getCreatedAt(),
                         // 해당 댓글의 대댓글 붙이기
@@ -192,8 +191,8 @@ public class PostQueryService implements PostQueryUseCase {
                                 .map(r -> new CommentResponse(
                                         r.getCommentId(),
                                         r.getUserId(),
-                                        userPort.getNickname(r.getUserId()),
-                                        userPort.getProfileImageUrl(c.getUserId()),
+                                        communityQueryPolicy.resolveNickname(r.getUserId()),        // 변경
+                                        communityQueryPolicy.resolveProfileImageUrl(r.getUserId()), // 변경
                                         r.getContent(),
                                         r.getCreatedAt(),
                                         List.of()

--- a/src/main/java/com/kidmily/algoga_server/community/application/service/ReportCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/ReportCommandService.java
@@ -26,40 +26,6 @@ public class ReportCommandService implements ReportCommandUseCase {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
 
-//    @Override
-//    public Long handle(CreateReportCommand command) {
-//        log.info("[ReportCommandService] 신고 요청 수신 - userId: {}, targetType: {}, targetId: {}",
-//                command.userId(), command.targetType(), command.targetId());
-//
-//        // 대상 존재 여부 검증
-//        if (command.targetType() == TargetType.POST) {
-//            postRepository.findById(command.targetId())
-//                    .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-//        } else if (command.targetType() == TargetType.COMMENT) {
-//            commentRepository.findById(command.targetId())
-//                    .orElseThrow(() -> new CommentException(PostErrorCode.COMMENT_NOT_FOUND));
-//        }
-//
-//        // 중복 신고 검증
-//        if (reportRepository.existsByUserAndTarget(command.userId(), command.targetType(), command.targetId())) {
-//            throw new ReportException(PostErrorCode.REPORT_DUPLICATED);
-//        }
-//
-//        Report report = Report.create(
-//                command.userId(),
-//                reportedUserId,
-//                command.targetId(),
-//                command.targetType(),
-//                command.reasonType(),
-//                command.detail()
-//        );
-//
-//        Report savedReport = reportRepository.save(report);
-//
-//        log.info("[ReportCommandService] 신고 완료 - reportId: {}", savedReport.getReportId());
-//
-//        return savedReport.getReportId();
-//    }
 @Override
 public Long handle(CreateReportCommand command) {
     log.info("[ReportCommandService] 신고 요청 수신 - userId: {}, targetType: {}, targetId: {}",

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Comment.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Comment.java
@@ -79,4 +79,11 @@ public class Comment {
     public boolean isDeleted() { return deleted; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public boolean isReply() { return parentId != null; }
+
+    // 대댓글의 대댓글 방지
+    public static void validateDepth(Long parentId) {
+        if (parentId != null) {
+            throw new CommentException(PostErrorCode.COMMENT_DEPTH_EXCEEDED);
+        }
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
@@ -19,6 +19,7 @@ public enum PostErrorCode implements BaseErrorCode {
     POST_TITLE_BLANK(HttpStatus.BAD_REQUEST, "POST_006", "제목은 필수입니다."),
     POST_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "POST_007", "본문은 필수입니다."),
     REPORT_DETAIL_TOO_LONG(HttpStatus.BAD_REQUEST, "POST_020", "신고 상세 내용은 최대 255자입니다."),
+    COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "POST_023", "대댓글에는 댓글을 달 수 없습니다."),
 
     // 401 - 인증
     POST_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "POST_008", "게시글 작성 권한이 없습니다."),

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
@@ -173,7 +173,7 @@ public class CommunityController {
     @Operation(summary = "댓글/대댓글 작성", description = "게시글에 댓글 또는 대댓글을 작성합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 작성에 성공했습니다.")
     @ApiErrorCodeExample(domain = PostErrorCode.class, value = {
-            "POST_NOT_FOUND",       // 400 존재하지 않는 게시글
+            "POST_NOT_FOUND",       // 404 존재하지 않는 게시글
             "COMMENT_UNAUTHORIZED"     // 401 비로그인
     })
     public ResponseEntity<ApiResponse<CreateCommentResponse>> createComment(

--- a/src/main/java/com/kidmily/algoga_server/notification/application/command/UpdateNotificationSettingCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/command/UpdateNotificationSettingCommand.java
@@ -1,0 +1,6 @@
+package com.kidmily.algoga_server.notification.application.command;
+
+public record UpdateNotificationSettingCommand(
+        Long userId,
+        Boolean communityEnabled
+) {}

--- a/src/main/java/com/kidmily/algoga_server/notification/application/service/NotificationSettingService.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/service/NotificationSettingService.java
@@ -1,0 +1,39 @@
+package com.kidmily.algoga_server.notification.application.service;
+
+import com.kidmily.algoga_server.notification.application.command.UpdateNotificationSettingCommand;
+import com.kidmily.algoga_server.notification.application.usecase.NotificationSettingCommandUseCase;
+import com.kidmily.algoga_server.notification.application.usecase.NotificationSettingQueryUseCase;
+import com.kidmily.algoga_server.notification.domain.model.NotificationSetting;
+import com.kidmily.algoga_server.notification.domain.repository.NotificationSettingRepository;
+import com.kidmily.algoga_server.notification.presentation.api.request.UpdateNotificationSettingRequest;
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationSettingResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService implements NotificationSettingQueryUseCase, NotificationSettingCommandUseCase {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public NotificationSetting getSetting(Long userId) {
+        return notificationSettingRepository.findByUserId(userId)
+                .orElseGet(() -> NotificationSetting.createDefault(userId));
+    }
+
+    @Override
+    @Transactional
+    public NotificationSetting updateSetting(UpdateNotificationSettingCommand command) {
+        NotificationSetting setting = notificationSettingRepository.findByUserId(command.userId())
+                .orElseGet(() -> NotificationSetting.createDefault(command.userId()));
+
+        setting.update(null, null, command.communityEnabled(), null, null, null);
+
+        return notificationSettingRepository.save(setting);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/notification/application/usecase/NotificationSettingCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/usecase/NotificationSettingCommandUseCase.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.notification.application.usecase;
+
+import com.kidmily.algoga_server.notification.application.command.UpdateNotificationSettingCommand;
+import com.kidmily.algoga_server.notification.domain.model.NotificationSetting;
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationSettingResponse;
+
+public interface NotificationSettingCommandUseCase {
+    NotificationSetting updateSetting(UpdateNotificationSettingCommand command);
+}

--- a/src/main/java/com/kidmily/algoga_server/notification/application/usecase/NotificationSettingQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/usecase/NotificationSettingQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.notification.application.usecase;
+
+import com.kidmily.algoga_server.notification.domain.model.NotificationSetting;
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationSettingResponse;
+
+public interface NotificationSettingQueryUseCase {
+    NotificationSetting getSetting(Long userId);
+}

--- a/src/main/java/com/kidmily/algoga_server/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/exception/NotificationErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum NotificationErrorCode implements BaseErrorCode {
 
+    // 400
+    NOTIFICATION_SETTING_INVALID(HttpStatus.BAD_REQUEST, "NOTIFICATION_003", "알림 설정 값을 입력해주세요."),
+
     // 401
     NOTIFICATION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NOTIFICATION_001", "알림 조회 권한이 없습니다."),
 

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/NotificationSettingController.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/NotificationSettingController.java
@@ -1,0 +1,69 @@
+package com.kidmily.algoga_server.notification.presentation.api;
+
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.notification.application.command.UpdateNotificationSettingCommand;
+import com.kidmily.algoga_server.notification.application.usecase.NotificationSettingCommandUseCase;
+import com.kidmily.algoga_server.notification.application.usecase.NotificationSettingQueryUseCase;
+import com.kidmily.algoga_server.notification.domain.model.NotificationSetting;
+import com.kidmily.algoga_server.notification.exception.NotificationErrorCode;
+import com.kidmily.algoga_server.notification.presentation.api.request.UpdateNotificationSettingRequest;
+import com.kidmily.algoga_server.notification.presentation.api.response.NotificationSettingResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/me/notifications/settings")
+@Tag(name = "Notification Setting", description = "알림 설정 API")
+public class NotificationSettingController {
+
+    private final NotificationSettingQueryUseCase notificationSettingQueryUseCase;
+    private final NotificationSettingCommandUseCase notificationSettingCommandUseCase;
+
+    @GetMapping
+    @Operation(summary = "알림 수신 설정 조회", description = "현재 사용자의 알림 설정 값을 조회합니다.")
+    public ResponseEntity<ApiResponse<NotificationSettingResponse>> getSetting(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        NotificationSetting setting = notificationSettingQueryUseCase.getSetting(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                "NOTIFICATION_SETTING_FOUND",
+                "알림 설정 조회에 성공했습니다.",
+                NotificationSettingResponse.from(setting)
+        ));
+    }
+
+    @PatchMapping
+    @Operation(summary = "알림 수신 설정 변경", description = "사용자의 알림 설정을 변경합니다.")
+    @ApiErrorCodeExample(domain = NotificationErrorCode.class, value = {
+            "NOTIFICATION_SETTING_INVALID"
+    })
+    public ResponseEntity<ApiResponse<NotificationSettingResponse>> updateSetting(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateNotificationSettingRequest request
+    ) {
+        Long userId = userDetails.getUser().getId();
+
+        UpdateNotificationSettingCommand command = new UpdateNotificationSettingCommand(
+                userId,
+                request.communityEnabled()
+        );
+
+        NotificationSetting setting = notificationSettingCommandUseCase.updateSetting(command);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                "NOTIFICATION_SETTING_UPDATED",
+                "알림 설정 변경에 성공했습니다.",
+                NotificationSettingResponse.from(setting)
+        ));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/request/UpdateNotificationSettingRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/request/UpdateNotificationSettingRequest.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.notification.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "알림 수신 설정 변경 요청")
+public record UpdateNotificationSettingRequest(
+
+
+        @Schema(description = "커뮤니티 알림 수신 여부", example = "true")
+        @NotNull(message = "커뮤니티 알림 설정 값을 입력해주세요.")
+        Boolean communityEnabled
+) {}

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationSettingResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationSettingResponse.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.notification.presentation.api.response;
+
+import com.kidmily.algoga_server.notification.domain.model.NotificationSetting;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 수신 설정 응답")
+public record NotificationSettingResponse(
+
+        @Schema(description = "커뮤니티 알림 수신 여부", example = "true")
+        Boolean communityEnabled
+) {
+    public static NotificationSettingResponse from(NotificationSetting setting) {
+        return new NotificationSettingResponse(setting.getCommunityEnabled());
+    }
+}


### PR DESCRIPTION
## 설명
알림 수신 설정 조회/변경 API 구현 및 대댓글 깊이 제한 추가

## 🔗 Issue
Closes #

---


 GET /api/v1/users/me/notifications/settings - 알림 설정 조회 

json  // 응답
  {
    "communityEnabled": true
  }

 PATCH /api/v1/users/me/notifications/settings - 커뮤니티 알림 ON/OFF 변경

json  // 요청
  {
    "communityEnabled": false
  }
  // 응답
  {
    "communityEnabled": false
  }




## 확인할 사항
 GET /api/v1/users/me/notifications/settings - 알림 설정 조회 정상 동작 확인
 PATCH /api/v1/users/me/notifications/settings - 커뮤니티 알림 ON/OFF 변경 및 DB 반영 확인
 알림 설정이 없는 유저 최초 조회 시 기본값(전체 true) 반환 확인
 communityEnabled 없이 PATCH 요청 시 400 반환 확인
 대댓글에 대댓글 작성 시 400 반환 확인 (COMMENT_DEPTH_EXCEEDED)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 설정을 조회하고 커뮤니티 알림 수신 여부를 변경할 수 있는 새로운 API 추가
  * 대댓글에 댓글을 달 수 없도록 깊이 검증 추가

* **Bug Fixes**
  * 신고 기능 활성화 및 중복 신고 방지 기능 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->