### PR TITLE
서킷브레이커 항공 api및 결제 포트원적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     // Redis 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Resilience4j 서킷브레이커
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/kidmily/algoga_server/flight/exception/FlightErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/flight/exception/FlightErrorCode.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.flight.exception;
+
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FlightErrorCode implements BaseErrorCode {
+
+    FLIGHT_API_ERROR(HttpStatus.BAD_GATEWAY, "FLT_001", "항공편 조회 중 오류가 발생했습니다."),
+    FLIGHT_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "FLT_002", "항공편 조회 서비스가 일시적으로 중단되었습니다. 잠시 후 다시 시도해주세요.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kidmily/algoga_server/flight/infrastructure/FlightApiClient.java
+++ b/src/main/java/com/kidmily/algoga_server/flight/infrastructure/FlightApiClient.java
@@ -3,6 +3,10 @@ package com.kidmily.algoga_server.flight.infrastructure;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kidmily.algoga_server.flight.domain.model.FlightInfo;
+import com.kidmily.algoga_server.flight.exception.FlightErrorCode;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -36,6 +40,9 @@ public class FlightApiClient {
         this.objectMapper = new ObjectMapper();
     }
 
+    private static final String FLIGHT_CB = "flight";
+
+    @CircuitBreaker(name = FLIGHT_CB, fallbackMethod = "getDepartureFlightsFallback")
     public List<FlightInfo> getDepartureFlights(String destinationCode, LocalDate departureDate) {
         log.info("[FlightApiClient] 정기운항편 조회 - destination: {}, date: {}", destinationCode, departureDate);
 
@@ -46,12 +53,22 @@ public class FlightApiClient {
                 "&numOfRows=100" +
                 "&pageNo=1";
 
-        String response = restClient.get()
-                .uri(URI.create(url))
-                .retrieve()
-                .body(String.class);
+        try {
+            String response = restClient.get()
+                    .uri(URI.create(url))
+                    .retrieve()
+                    .body(String.class);
+            return parseFlights(response, destinationCode, departureDate);
+        } catch (Exception e) {
+            log.warn("[FlightApiClient] 항공편 API 호출 실패 - destination: {}, error: {}", destinationCode, e.getMessage());
+            throw new BusinessException(FlightErrorCode.FLIGHT_API_ERROR);
+        }
+    }
 
-        return parseFlights(response, destinationCode, departureDate);
+    // 서킷브레이커 OPEN 상태일 때 호출되는 fallback
+    private List<FlightInfo> getDepartureFlightsFallback(String destinationCode, LocalDate departureDate, CallNotPermittedException e) {
+        log.error("[FlightApiClient] 서킷브레이커 OPEN - 항공편 조회 차단됨 destination: {}", destinationCode);
+        throw new BusinessException(FlightErrorCode.FLIGHT_CIRCUIT_OPEN);
     }
 
     private List<FlightInfo> parseFlights(String json, String destinationCode, LocalDate departureDate) {

--- a/src/main/java/com/kidmily/algoga_server/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/exception/PaymentErrorCode.java
@@ -21,7 +21,8 @@ public enum PaymentErrorCode implements BaseErrorCode {
     COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "PAY_010", "이미 사용된 쿠폰입니다."),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "PAY_011", "만료된 쿠폰입니다."),
     COUPON_NOT_OWNED(HttpStatus.FORBIDDEN, "PAY_012", "본인의 쿠폰이 아닙니다."),
-    INSUFFICIENT_MILEAGE(HttpStatus.BAD_REQUEST, "PAY_013", "마일리지 잔액이 부족합니다.");
+    INSUFFICIENT_MILEAGE(HttpStatus.BAD_REQUEST, "PAY_013", "마일리지 잔액이 부족합니다."),
+    PORTONE_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "PAY_014", "결제 서비스가 일시적으로 중단되었습니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/portone/PortOneClient.java
@@ -3,19 +3,22 @@ package com.kidmily.algoga_server.payment.infrastructure.portone;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.kidmily.algoga_server.global.exception.BusinessException;
 import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-import java.util.Map; // 추가
+import java.util.Map;
 
 @Slf4j
 @Component
 public class PortOneClient {
 
+    private static final String PORTONE_CB = "portone";
+
     private final RestClient restClient;
     private final PortOneProperties properties;
-
 
     public PortOneClient(PortOneProperties properties) {
         this.properties = properties;
@@ -26,7 +29,7 @@ public class PortOneClient {
                 .build();
     }
 
-    // 결제 단건 조회 - 검증용
+    @CircuitBreaker(name = PORTONE_CB, fallbackMethod = "getPaymentFallback")
     public JsonNode getPayment(String portonePaymentId) {
         log.info("[PortOneClient] 결제 조회 요청 - portonePaymentId: {}", portonePaymentId);
         try {
@@ -40,7 +43,7 @@ public class PortOneClient {
         }
     }
 
-    // 결제 취소 - 환불 완료 처리 시 호출
+    @CircuitBreaker(name = PORTONE_CB, fallbackMethod = "cancelPaymentFallback")
     public void cancelPayment(String portonePaymentId, int amount, String reason) {
         log.info("[PortOneClient] 결제 취소 요청 - portonePaymentId: {}", portonePaymentId);
         try {
@@ -53,5 +56,16 @@ public class PortOneClient {
             log.warn("[PortOneClient] PortOne 취소 API 호출 실패 - portonePaymentId: {}", portonePaymentId);
             throw new BusinessException(PaymentErrorCode.PORTONE_API_ERROR);
         }
+    }
+
+    // 서킷브레이커 OPEN 상태일 때 호출되는 fallback
+    private JsonNode getPaymentFallback(String portonePaymentId, CallNotPermittedException e) {
+        log.error("[PortOneClient] 서킷브레이커 OPEN - 결제 조회 차단됨 portonePaymentId: {}", portonePaymentId);
+        throw new BusinessException(PaymentErrorCode.PORTONE_CIRCUIT_OPEN);
+    }
+
+    private void cancelPaymentFallback(String portonePaymentId, int amount, String reason, CallNotPermittedException e) {
+        log.error("[PortOneClient] 서킷브레이커 OPEN - 결제 취소 차단됨 portonePaymentId: {}", portonePaymentId);
+        throw new BusinessException(PaymentErrorCode.PORTONE_CIRCUIT_OPEN);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,3 +88,39 @@ user:
   storage:
     bucket: algoga-banner
     directory: profiles
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      portone:
+        # CLOSED → OPEN: 10번 호출 중 50% 이상 실패 시
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        # OPEN 상태 유지 시간 (10초 후 HALF_OPEN 전환)
+        wait-duration-in-open-state: 10s
+        # HALF_OPEN 상태에서 허용할 테스트 호출 수
+        permitted-number-of-calls-in-half-open-state: 3
+        # 예외 기록 대상: BusinessException은 제외 (PortOne이 정상 응답한 것)
+        ignore-exceptions:
+          - com.kidmily.algoga_server.global.exception.BusinessException
+        register-health-indicator: true
+      flight:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s  # 공공 API라 복구 시간 더 여유있게
+        permitted-number-of-calls-in-half-open-state: 3
+        ignore-exceptions:
+          - com.kidmily.algoga_server.global.exception.BusinessException
+        register-health-indicator: true
+  timelimiter:
+    instances:
+      portone:
+        # PortOne API 타임아웃: 5초
+        timeout-duration: 5s
+        cancel-running-future: true
+      flight:
+        # 항공편 API 타임아웃: 10초 (공공데이터 API라 느릴 수 있음)
+        timeout-duration: 10s
+        cancel-running-future: true


### PR DESCRIPTION
## 설명
ortOne 결제/환불 API 및 항공편 API에 대한 안정성 개선 작업입니다.

STEP 1 — PortOne API 트랜잭션 분리

PaymentCommandService, RefundCommandService에서 PortOne API 호출을 @Transactional 밖으로 분리
기존 구조에서는 PortOne이 느리거나 실패할 경우 DB 커넥션을 오래 점유하고 전체 롤백이 발생하는 문제가 있었음
STEP 2 — Resilience4j 서킷브레이커 적용

PortOneClient — 결제 조회/취소 API에 서킷브레이커 적용
FlightApiClient — 항공편 조회 API에 서킷브레이커 적용
서킷 OPEN 시 즉시 503 반환, DB 커넥션 낭비 및 장애 전파 차단

## 🔗 Issue
Closes #186 

---


- [ ]

## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ]PortOne API 호출이 트랜잭션 밖에서 실행되는지 확인 (PaymentCommandService.handle(), RefundCommandService.complete())
- [ ]PortOne 장애 시 10번 중 5번 실패 후 서킷 OPEN 전환 확인
- [ ]서킷 OPEN 상태에서 즉시 503 응답 반환 확인 (PAY_014, FLT_002)
- [ ]항공편 API 장애 시 서킷 OPEN 전환 확인 (OPEN 유지 30초)
- [ ]서킷 OPEN → 10초(PortOne) / 30초(Flight) 후 HALF_OPEN 전환 확인
- [ ]BusinessException은 서킷 실패 카운트에서 제외되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 항공편 조회 서비스에 자동 장애 복구 메커니즘을 추가했습니다.
  * 결제 서비스의 안정성을 강화하는 자동 폴백 처리를 도입했습니다.

* **Bug Fixes**
  * 항공편 조회 중 발생하는 오류 처리를 표준화했습니다.
  * 결제 서비스 일시 중단 시 사용자 친화적 에러 응답을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->