### PR TITLE
캐시히트 관련 메트릭 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
@@ -13,6 +13,7 @@ import com.kidmily.algoga_server.booking.exception.BookingErrorCode;
 import com.kidmily.algoga_server.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ public class BookingCommandService implements BookingCommandUseCase {
     private final AccommodationRepository accommodationRepository;
     private final ApplicationEventPublisher eventPublisher;
 
+    @CacheEvict(value = "myBookings", key = "#command.userId()")
     @Override
     public Long handle(CreateBookingCommand command) {
         log.info("[BookingCommandService] 예약 생성 요청 - accommodationId: {}, userId: {}",
@@ -77,6 +79,7 @@ public class BookingCommandService implements BookingCommandUseCase {
         return savedBooking.getId();
     }
 
+    @CacheEvict(value = "myBookings", key = "#userId")
     @Override
     public void cancel(Long bookingId, Long userId) {
         log.info("[BookingCommandService] 예약 취소 요청 - bookingId: {}, userId: {}", bookingId, userId);

--- a/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingQueryService.java
@@ -8,6 +8,7 @@ import com.kidmily.algoga_server.booking.presentation.api.response.BookingRespon
 import com.kidmily.algoga_server.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,7 @@ public class BookingQueryService implements BookingQueryUseCase {
         return toResponse(booking);
     }
 
+    @Cacheable(value = "myBookings", key = "#userId")
     @Override
     public List<BookingResponse> getMyBookings(Long userId) {
         log.info("[BookingQueryService] 내 예약 목록 조회 - userId: {}", userId);

--- a/src/main/java/com/kidmily/algoga_server/global/config/RedisConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/RedisConfig.java
@@ -1,11 +1,23 @@
 package com.kidmily.algoga_server.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+import java.util.Map;
+
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
@@ -13,11 +25,37 @@ public class RedisConfig {
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
-
-        // 데이터가 깨져 보이지 않게 String(문자열)으로 직렬화해주는 설정
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
-
         return template;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+                objectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .disableCachingNullValues();
+
+        Map<String, RedisCacheConfiguration> cacheConfigs = Map.of(
+                "myBookings", defaultConfig.entryTtl(Duration.ofMinutes(5)),
+                "myPayments", defaultConfig.entryTtl(Duration.ofMinutes(5)),
+                "adminPaymentStats", defaultConfig.entryTtl(Duration.ofHours(1))
+        );
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig.entryTtl(Duration.ofMinutes(10)))
+                .withInitialCacheConfigurations(cacheConfigs)
+                .build();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
@@ -27,6 +27,8 @@ import com.kidmily.algoga_server.user.domain.UserRepository;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +64,10 @@ public class PaymentCommandService implements PaymentCommandUseCase {
         return savePayment(command, portoneStatus, paidAmount);
     }
 
+    @Caching(evict = {
+            @CacheEvict(value = "myPayments", key = "#command.userId()"),
+            @CacheEvict(value = "adminPaymentStats", key = "'all'")
+    })
     @Transactional
     public Long savePayment(CreatePaymentCommand command, String portoneStatus, int paidAmount) {
         Booking booking = bookingRepository.findById(command.bookingId())

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,6 +79,7 @@ public class PaymentQueryService implements PaymentQueryUseCase {
         return confirmationPdfGenerator.generate(payment, booking);
     }
 
+    @Cacheable(value = "myPayments", key = "#userId")
     @Override
     public List<PaymentResponse> getMyPayments(Long userId) {
         log.info("[PaymentQueryService] 내 결제 내역 조회 - userId: {}", userId);
@@ -147,6 +149,7 @@ public class PaymentQueryService implements PaymentQueryUseCase {
         }
     }
 
+    @Cacheable(value = "adminPaymentStats", key = "'all'")
     @Override
     public List<PaymentStatsResponse> getAdminPaymentStats() {
         log.info("[PaymentQueryService] 어드민 월별 수익 통계 조회");


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
Spring Cache + Redis 캐싱 적용 (STEP 3)

조회성 API의 DB 부하를 줄이기 위해 Spring Cache 추상화와 Redis를 연동했습니다.
도메인별 TTL을 설정하고, 쓰기 발생 시 캐시를 무효화하는 evict 전략을 적용했습니다.

## 🔗 Issue
Closes #187 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
Redis 연결 상태에서 GET /api/v1/bookings/my 두 번 호출 시 두 번째부터 DB 쿼리 없이 응답되는지 확인
예약 생성/취소 후 GET /api/v1/bookings/my 호출 시 캐시 evict되어 최신 데이터 반환되는지 확인
GET /api/v1/admin/payments/stats TTL 1시간 적용 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 예약 및 결제 조회 성능 최적화를 위해 캐싱 기능이 추가되었습니다.
  * 사용자별 예약 목록, 결제 목록, 관리자 통계 조회 속도가 개선되었습니다.
  * 예약 생성/취소 및 결제 처리 시 관련 캐시가 자동으로 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->