### PR TITLE
spring-actuator-prometheu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     // Resilience4j 서킷브레이커
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 
+    // Spring Actuator + Prometheus 메트릭
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/kidmily/algoga_server/global/config/MetricsConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/MetricsConfig.java
@@ -1,0 +1,106 @@
+package com.kidmily.algoga_server.global.config;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    // ── Booking ──────────────────────────────────────────────────────────────
+
+    /** 예약 생성 요청 횟수 */
+    @Bean
+    public Counter bookingCreatedTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_booking_created_total")
+                .description("총 예약 생성 횟수")
+                .register(registry);
+    }
+
+    /** 예약 취소 요청 횟수 */
+    @Bean
+    public Counter bookingCanceledTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_booking_canceled_total")
+                .description("총 예약 취소 횟수")
+                .register(registry);
+    }
+
+    // ── Payment ──────────────────────────────────────────────────────────────
+
+    /** 결제 처리 소요 시간 */
+    @Bean
+    public Timer paymentDurationSeconds(MeterRegistry registry) {
+        return Timer.builder("algoga_payment_duration_seconds")
+                .description("결제 처리 소요 시간")
+                .publishPercentiles(0.5, 0.9, 0.95, 0.99)
+                .register(registry);
+    }
+
+    /** 결제 성공 횟수 */
+    @Bean
+    public Counter paymentSuccessTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_payment_total")
+                .description("결제 처리 횟수")
+                .tag("result", "success")
+                .register(registry);
+    }
+
+    /** 결제 실패 횟수 */
+    @Bean
+    public Counter paymentFailedTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_payment_total")
+                .description("결제 처리 횟수")
+                .tag("result", "failed")
+                .register(registry);
+    }
+
+    /** PortOne API 호출 소요 시간 */
+    @Bean
+    public Timer portoneApiDurationSeconds(MeterRegistry registry) {
+        return Timer.builder("algoga_portone_api_duration_seconds")
+                .description("PortOne API 호출 소요 시간 (p99 모니터링)")
+                .publishPercentiles(0.5, 0.9, 0.95, 0.99)
+                .register(registry);
+    }
+
+    // ── Refund ───────────────────────────────────────────────────────────────
+
+    /** 환불 요청 횟수 */
+    @Bean
+    public Counter refundRequestedTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_refund_requested_total")
+                .description("총 환불 요청 횟수")
+                .register(registry);
+    }
+
+    /** 환불 승인 횟수 */
+    @Bean
+    public Counter refundApprovedTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_refund_total")
+                .description("환불 처리 횟수")
+                .tag("result", "approved")
+                .register(registry);
+    }
+
+    /** 환불 반려 횟수 */
+    @Bean
+    public Counter refundRejectedTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_refund_total")
+                .description("환불 처리 횟수")
+                .tag("result", "rejected")
+                .register(registry);
+    }
+
+    // ── API 에러 ─────────────────────────────────────────────────────────────
+
+    /** API 에러 횟수 (reason 태그: validation / business / server_error) */
+    @Bean
+    public Counter apiErrorsTotal(MeterRegistry registry) {
+        return Counter.builder("algoga_api_errors_total")
+                .description("API 에러 발생 횟수")
+                .tag("reason", "unknown")
+                .register(registry);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
@@ -25,6 +25,8 @@ import com.kidmily.algoga_server.payment.infrastructure.portone.PortOneClient;
 import com.kidmily.algoga_server.user.domain.User;
 import com.kidmily.algoga_server.user.domain.UserRepository;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -49,19 +51,35 @@ public class PaymentCommandService implements PaymentCommandUseCase {
     private final CourseRepository courseRepository;
     private final UserCouponRepository userCouponRepository;
     private final MileageHistoryRepository mileageHistoryRepository;
+    private final Timer paymentDurationSeconds;
+    private final Counter paymentSuccessTotal;
+    private final Counter paymentFailedTotal;
+    private final Timer portoneApiDurationSeconds;
 
     @Override
     public Long handle(CreatePaymentCommand command) {
         log.info("[PaymentCommandService] 결제 요청 - bookingId: {}, type: {}, amount: {}",
                 command.bookingId(), command.paymentType(), command.amount());
 
-        // PortOne API 호출을 트랜잭션 밖에서 먼저 수행
-        JsonNode portoneResult = portOneClient.getPayment(command.portonePaymentId());
-        String portoneStatus = portoneResult.path("status").asText();
-        int paidAmount = portoneResult.path("amount").path("total").asInt();
-        log.info("[PaymentCommandService] PortOne 검증 결과 - status: {}, amount: {}", portoneStatus, paidAmount);
+        return paymentDurationSeconds.record(() -> {
+            // PortOne API 호출 시간 측정
+            JsonNode portoneResult = portoneApiDurationSeconds.record(
+                    () -> portOneClient.getPayment(command.portonePaymentId())
+            );
+            String portoneStatus = portoneResult.path("status").asText();
+            int paidAmount = portoneResult.path("amount").path("total").asInt();
+            log.info("[PaymentCommandService] PortOne 검증 결과 - status: {}, amount: {}", portoneStatus, paidAmount);
 
-        return savePayment(command, portoneStatus, paidAmount);
+            Long paymentId = savePayment(command, portoneStatus, paidAmount);
+
+            if ("PAID".equals(portoneStatus)) {
+                paymentSuccessTotal.increment();
+            } else {
+                paymentFailedTotal.increment();
+            }
+
+            return paymentId;
+        });
     }
 
     @Caching(evict = {

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
@@ -16,6 +16,7 @@ import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
 import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
 import com.kidmily.algoga_server.refund.exception.RefundErrorCode;
+import io.micrometer.core.instrument.Counter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -34,8 +35,11 @@ public class RefundCommandService implements RefundCommandUseCase {
     private final RefundRepository refundRepository;
     private final BookingRepository bookingRepository;
     private final PaymentRepository paymentRepository;
-    private final PortOneClient portOneClient; // 추가
-    private final ApplicationEventPublisher eventPublisher; // 🌟승재 추가
+    private final PortOneClient portOneClient;
+    private final ApplicationEventPublisher eventPublisher;
+    private final Counter refundRequestedTotal;
+    private final Counter refundApprovedTotal;
+    private final Counter refundRejectedTotal;
 
     @Override
     @Transactional
@@ -79,6 +83,7 @@ public class RefundCommandService implements RefundCommandUseCase {
         log.info("[RefundCommandService] 환불 요청 완료 - refundId: {}, amount: {}",
                 saved.getId(), saved.getAmount());
 
+        refundRequestedTotal.increment();
         return saved.getId();
     }
 
@@ -147,6 +152,7 @@ public class RefundCommandService implements RefundCommandUseCase {
         refundRequest.approve();
         refundRepository.save(refundRequest);
         log.info("[RefundCommandService] 환불 승인 완료 - refundId: {}", refundId);
+        refundApprovedTotal.increment();
     }
 
     @Override
@@ -164,6 +170,7 @@ public class RefundCommandService implements RefundCommandUseCase {
         refundRequest.reject(rejectReason);
         refundRepository.save(refundRequest);
         log.info("[RefundCommandService] 환불 반려 완료 - refundId: {}", refundId);
+        refundRejectedTotal.increment();
 
         // payment 조회해서 강의/패키지 구분 승재 추가
         Payment payment = paymentRepository.findById(refundRequest.getPaymentId())

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -89,6 +89,25 @@ user:
     bucket: algoga-banner
     directory: profiles
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, metrics, circuitbreakers
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: algoga-server
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      percentiles:
+        http.server.requests: 0.5, 0.9, 0.95, 0.99
+
 resilience4j:
   circuitbreaker:
     instances:


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
Spring Actuator + Prometheus 메트릭 노출 설정 및 커스텀 비즈니스 메트릭 추가

spring-boot-actuator, micrometer-registry-prometheus 의존성 추가
/actuator/prometheus 엔드포인트 노출 및 SecurityConfig 허용 처리
커스텀 메트릭 등록: 예약/결제/환불 횟수, PortOne API 응답시간(p99), API 에러 카운터
Resilience4j 서킷브레이커 메트릭 자동 연동 (portone / flight)
Spring Cache 메트릭 자동 연동 (myBookings / myPayments / adminPaymentStats)
## 🔗 Issue
Closes #188 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] GET /actuator/prometheus 응답에 algoga_* 커스텀 메트릭 포함 여부 확인
- [ ]resilience4j_circuitbreaker_state{name="portone"}, {name="flight"} 메트릭 노출 확인
- [ ] cache_gets_total{cache="myBookings"} 등 캐시 메트릭 노출 확인
- [ ] /actuator/** 엔드포인트 인증 없이 접근 가능한지 확인 (내부망 전용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 예약, 결제, 환불 등 주요 비즈니스 프로세스에 대한 상세 모니터링 메트릭 추가
  * 시스템 성능 추적 및 진단을 위한 Actuator 엔드포인트 활성화
  * 실시간 상태 확인 및 메트릭 수집 기능 구축

<!-- end of auto-generated comment: release notes by coderabbit.ai -->