### PR TITLE
그라파나 연결및 테스트까지완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 // 이메일
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-    // Redis 의존성 추가
+    // Redis 의존성
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // OAuth2 소셜 로그인 라이브러리

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -50,6 +50,14 @@ services:
       - "3000:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - grafana-storage:/var/lib/grafana
     depends_on:
       - prometheus
       - loki
+
+volumes:
+  grafana-storage:

--- a/monitoring/grafana/dashboards/algoga-overview.json
+++ b/monitoring/grafana/dashboards/algoga-overview.json
@@ -1,0 +1,370 @@
+{
+  "title": "Algoga Server Overview",
+  "uid": "algoga-overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "서킷브레이커 상태 - PortOne",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_state{name=\"portone\", state=\"closed\"}",
+          "legendFormat": "CLOSED"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_state{name=\"portone\", state=\"open\"}",
+          "legendFormat": "OPEN"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_state{name=\"portone\", state=\"half_open\"}",
+          "legendFormat": "HALF_OPEN"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "1": { "text": "ACTIVE", "color": "green" } } },
+            { "type": "value", "options": { "0": { "text": "INACTIVE", "color": "grey" } } }
+          ]
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "서킷브레이커 상태 - Flight",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_state{name=\"flight\", state=\"closed\"}",
+          "legendFormat": "CLOSED"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_state{name=\"flight\", state=\"open\"}",
+          "legendFormat": "OPEN"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_state{name=\"flight\", state=\"half_open\"}",
+          "legendFormat": "HALF_OPEN"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 3,
+      "title": "서킷브레이커 실패율 (%)",
+      "type": "gauge",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_failure_rate{name=\"portone\"}",
+          "legendFormat": "PortOne"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_failure_rate{name=\"flight\"}",
+          "legendFormat": "Flight"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0, "max": 100, "unit": "percent",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "PortOne 서킷브레이커 차단 호출",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_not_permitted_calls_total{name=\"portone\"}",
+          "legendFormat": "PortOne 차단"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "resilience4j_circuitbreaker_not_permitted_calls_total{name=\"flight\"}",
+          "legendFormat": "Flight 차단"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 5,
+      "title": "PortOne API 응답시간 (p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "algoga_portone_api_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "algoga_portone_api_duration_seconds{quantile=\"0.95\"}",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "algoga_portone_api_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "결제 처리 소요시간 (p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "algoga_payment_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "algoga_payment_duration_seconds{quantile=\"0.95\"}",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "algoga_payment_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 7,
+      "title": "결제 성공/실패율",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(algoga_payment_total{result=\"success\"}[1m])",
+          "legendFormat": "성공"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(algoga_payment_total{result=\"failed\"}[1m])",
+          "legendFormat": "실패"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "예약/환불 현황",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 12, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(algoga_booking_total[1m])",
+          "legendFormat": "예약 생성"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(algoga_booking_canceled_total[1m])",
+          "legendFormat": "예약 취소"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(algoga_refund_requested_total[1m])",
+          "legendFormat": "환불 요청"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 9,
+      "title": "API 에러 발생률",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 12, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(algoga_api_errors_total[1m])",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 10,
+      "title": "월별 통계 쿼리 응답시간",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "http_server_requests_seconds{uri=~\".*/payments/stats.*\", quantile=\"0.99\"}",
+          "legendFormat": "p99"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "http_server_requests_seconds{uri=~\".*/payments/stats.*\", quantile=\"0.5\"}",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 11,
+      "title": "캐시 히트율",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 20, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(cache_gets_total{result=\"hit\"}[1m]) / (rate(cache_gets_total{result=\"hit\"}[1m]) + rate(cache_gets_total{result=\"miss\"}[1m]))",
+          "legendFormat": "{{cache}} 히트율"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1 }
+      }
+    },
+    {
+      "id": 12,
+      "title": "JVM Heap 사용량",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 28, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "legendFormat": "{{id}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" }
+      }
+    },
+    {
+      "id": 13,
+      "title": "DB 커넥션 풀 상태",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 28, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "Active"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "hikaricp_connections_idle",
+          "legendFormat": "Idle"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "hikaricp_connections_pending",
+          "legendFormat": "Pending"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "JVM GC Pause 시간",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 28, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(jvm_gc_pause_seconds_sum[1m])",
+          "legendFormat": "{{gc}} - {{action}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 15,
+      "title": "실시간 애플리케이션 로그",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 36, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "datasource": "Loki",
+          "expr": "{job=\"algoga-server\"}",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "sortOrder": "Descending"
+      }
+    },
+    {
+      "id": 16,
+      "title": "에러 로그 필터",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 46, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "datasource": "Loki",
+          "expr": "{job=\"algoga-server\"} |= \"ERROR\"",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "sortOrder": "Descending"
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: algoga-dashboards
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 5s
 
 scrape_configs:
-  - job_name: 'popular-shop'
+  - job_name: 'algoga-server'
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['host.docker.internal:15000'] # Docker에서 호스트 PC의 Spring Boot 접근


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
Grafana 모니터링 스택 Docker Compose 구성 및 대시보드 자동 프로비저닝 추가

monitoring/docker-compose.yml — Prometheus, Grafana, Loki, Promtail 컨테이너 구성
prometheus.yml — job_name algoga-server로 수정, /actuator/prometheus scrape 설정
grafana/provisioning/datasources/datasource.yml — Prometheus, Loki 데이터소스 자동 등록
grafana/provisioning/dashboards/dashboard.yml — 대시보드 파일 경로 프로비저닝 설정
grafana/dashboards/algoga-overview.json — 16개 패널 대시보드 (서킷브레이커, 결제/예약/환불, JVM, 캐시, 로그)

## 🔗 Issue
Closes #189

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] cd monitoring && docker-compose up -d 실행 후 전체 컨테이너 정상 기동 확인
- [ ]http://localhost:3000 접속 (admin/admin) → Dashboards → Algoga Server Overview 자동 등록 확인
- [ ]Spring Boot 서버 실행 후 서킷브레이커 상태(CLOSED), PortOne API 응답시간 그래프 데이터 확인
- [ ]에러 로그 패널에서 Loki 로그 수집 여부 확인

