### PR TITLE
환불 추가 개발및 수정사항 점검

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingQueryService.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.booking.application.service;
 
 import com.kidmily.algoga_server.booking.application.usecase.BookingQueryUseCase;
 import com.kidmily.algoga_server.booking.domain.model.Booking;
+import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
 import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
 import com.kidmily.algoga_server.booking.exception.BookingErrorCode;
 import com.kidmily.algoga_server.booking.presentation.api.response.BookingResponse;
@@ -40,6 +41,13 @@ public class BookingQueryService implements BookingQueryUseCase {
                 .stream()
                 .map(this::toResponse)
                 .toList();
+    }
+
+    @Override
+    public boolean hasActiveBooking(Long userId) {
+        return bookingRepository.existsByUserIdAndStatusIn(
+                userId,
+                List.of(BookingStatus.PENDING, BookingStatus.DEPOSIT_PAID, BookingStatus.FULL_PAID));
     }
 
     private BookingResponse toResponse(Booking booking) {

--- a/src/main/java/com/kidmily/algoga_server/booking/application/usecase/BookingQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/application/usecase/BookingQueryUseCase.java
@@ -9,4 +9,6 @@ public interface BookingQueryUseCase {
     BookingResponse getBooking(Long bookingId);
 
     List<BookingResponse> getMyBookings(Long userId);
+
+    boolean hasActiveBooking(Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
@@ -15,4 +15,6 @@ public interface BookingRepository {
     List<Booking> findByUserId(Long userId);
 
     Booking updateStatus(Long bookingId, BookingStatus status);
+
+    boolean existsByUserIdAndStatusIn(Long userId, List<BookingStatus> statuses);
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
@@ -45,4 +45,9 @@ public class BookingRepositoryAdapter implements BookingRepository {
         entity.updateStatus(status, LocalDateTime.now());
         return bookingMapper.toDomain(springDataBookingRepository.save(entity));
     }
+
+    @Override
+    public boolean existsByUserIdAndStatusIn(Long userId, List<BookingStatus> statuses) {
+        return springDataBookingRepository.existsByUserIdAndStatusIn(userId, statuses);
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/SpringDataBookingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/SpringDataBookingRepository.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.booking.infrastructure.persistence;
 
+import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface SpringDataBookingRepository extends JpaRepository<BookingJpaEntity, Long> {
 
     List<BookingJpaEntity> findByUserId(Long userId);
+
+    boolean existsByUserIdAndStatusIn(Long userId, List<BookingStatus> statuses);
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentQueryService.java
@@ -1,5 +1,7 @@
 package com.kidmily.algoga_server.payment.application.service;
 
+import com.kidmily.algoga_server.accommodation.domain.model.Accommodation;
+import com.kidmily.algoga_server.accommodation.domain.repository.AccommodationRepository;
 import com.kidmily.algoga_server.benefit.domain.model.MileageHistory;
 import com.kidmily.algoga_server.benefit.domain.model.UserCoupon;
 import com.kidmily.algoga_server.benefit.domain.repository.MileageHistoryRepository;
@@ -16,8 +18,11 @@ import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
 import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
 import com.kidmily.algoga_server.payment.exception.PaymentErrorCode;
 import com.kidmily.algoga_server.payment.infrastructure.pdf.ConfirmationPdfGenerator;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentMonthlyDetailResponse;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentStatsResponse;
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
@@ -31,6 +36,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +54,8 @@ public class PaymentQueryService implements PaymentQueryUseCase {
     private final CourseRepository courseRepository;
     private final UserCouponRepository userCouponRepository;
     private final MileageHistoryRepository mileageHistoryRepository;
+    private final UserRepository userRepository;
+    private final AccommodationRepository accommodationRepository;
 
     @Override
     public PaymentResponse getPayment(Long paymentId) {
@@ -96,7 +104,7 @@ public class PaymentQueryService implements PaymentQueryUseCase {
         LocalDateTime toDt = to.atTime(LocalTime.MAX);
         return paymentRepository.findByCreatedAtBetween(fromDt, toDt)
                 .stream()
-                .map(PaymentResponse::from)
+                .map(this::enrichPayment)
                 .toList();
     }
 
@@ -114,7 +122,7 @@ public class PaymentQueryService implements PaymentQueryUseCase {
             headerStyle.setFont(headerFont);
 
             Row header = sheet.createRow(0);
-            String[] columns = {"결제ID", "유저ID", "예약ID", "강의ID", "결제유형", "금액", "마일리지사용", "상태", "결제일시"};
+            String[] columns = {"결제번호", "사용자명", "상품명", "결제금액", "결제수단", "결제일시"};
             for (int i = 0; i < columns.length; i++) {
                 Cell cell = header.createCell(i);
                 cell.setCellValue(columns[i]);
@@ -125,14 +133,11 @@ public class PaymentQueryService implements PaymentQueryUseCase {
             for (PaymentResponse p : payments) {
                 Row row = sheet.createRow(rowNum++);
                 row.createCell(0).setCellValue(p.paymentId());
-                row.createCell(1).setCellValue(p.userId());
-                row.createCell(2).setCellValue(p.bookingId() != null ? p.bookingId() : 0);
-                row.createCell(3).setCellValue(p.courseId() != null ? p.courseId() : 0);
-                row.createCell(4).setCellValue(p.paymentType().name());
-                row.createCell(5).setCellValue(p.amount());
-                row.createCell(6).setCellValue(p.usedMileage());
-                row.createCell(7).setCellValue(p.status().name());
-                row.createCell(8).setCellValue(p.createdAt().toString());
+                row.createCell(1).setCellValue(p.userName() != null ? p.userName() : "");
+                row.createCell(2).setCellValue(p.productName() != null ? p.productName() : "");
+                row.createCell(3).setCellValue(p.amount());
+                row.createCell(4).setCellValue(p.paymentMethod() != null ? p.paymentMethod() : "");
+                row.createCell(5).setCellValue(p.createdAt().toString());
             }
 
             for (int i = 0; i < columns.length; i++) {
@@ -149,31 +154,130 @@ public class PaymentQueryService implements PaymentQueryUseCase {
         }
     }
 
-    @Cacheable(value = "adminPaymentStats", key = "'all'")
+    @Cacheable(value = "adminPaymentStats", key = "#year != null ? #year : 'all'")
     @Override
-    public List<PaymentStatsResponse> getAdminPaymentStats() {
-        log.info("[PaymentQueryService] 어드민 월별 수익 통계 조회");
+    public List<PaymentStatsResponse> getAdminPaymentStats(Integer year) {
+        log.info("[PaymentQueryService] 어드민 월별 수익 통계 조회 - year: {}", year);
 
-        Map<String, List<Payment>> grouped = paymentRepository
-                .findByCreatedAtBetween(LocalDateTime.of(2000, 1, 1, 0, 0), LocalDateTime.now())
-                .stream()
+        List<Payment> allPayments = paymentRepository
+                .findByCreatedAtBetween(LocalDateTime.of(2000, 1, 1, 0, 0), LocalDateTime.now());
+
+        if (year != null) {
+            allPayments = allPayments.stream()
+                    .filter(p -> p.getCreatedAt().getYear() == year)
+                    .toList();
+        }
+
+        Map<String, List<Payment>> successGrouped = allPayments.stream()
                 .filter(p -> p.getStatus() == PaymentStatus.SUCCESS)
                 .collect(Collectors.groupingBy(p ->
-                        p.getCreatedAt().getYear() + "-" + p.getCreatedAt().getMonthValue()
-                ));
+                        p.getCreatedAt().getYear() + "-" + p.getCreatedAt().getMonthValue()));
 
-        return grouped.entrySet().stream()
+        Map<String, List<Payment>> refundGrouped = allPayments.stream()
+                .filter(p -> p.getStatus() == PaymentStatus.REFUNDED)
+                .collect(Collectors.groupingBy(p ->
+                        p.getCreatedAt().getYear() + "-" + p.getCreatedAt().getMonthValue()));
+
+        List<PaymentStatsResponse> stats = successGrouped.entrySet().stream()
                 .map(entry -> {
                     String[] parts = entry.getKey().split("-");
-                    int year = Integer.parseInt(parts[0]);
-                    int month = Integer.parseInt(parts[1]);
+                    int y = Integer.parseInt(parts[0]);
+                    int m = Integer.parseInt(parts[1]);
                     int totalAmount = entry.getValue().stream().mapToInt(Payment::getAmount).sum();
                     long count = entry.getValue().size();
-                    return new PaymentStatsResponse(year, month, totalAmount, count);
+                    int refundAmount = refundGrouped.getOrDefault(entry.getKey(), List.of())
+                            .stream().mapToInt(Payment::getAmount).sum();
+                    int netAmount = totalAmount - refundAmount;
+                    return new PaymentStatsResponse(y, m, totalAmount, count, refundAmount, netAmount, null);
                 })
                 .sorted(Comparator.comparingInt(PaymentStatsResponse::year)
                         .thenComparingInt(PaymentStatsResponse::month))
                 .toList();
+
+        return applyGrowthRate(stats);
+    }
+
+    @Override
+    public PaymentMonthlyDetailResponse getAdminPaymentStatsByMonth(int year, int month) {
+        log.info("[PaymentQueryService] 어드민 월별 상세 통계 조회 - year: {}, month: {}", year, month);
+
+        YearMonth ym = YearMonth.of(year, month);
+        LocalDateTime from = ym.atDay(1).atStartOfDay();
+        LocalDateTime to = ym.atEndOfMonth().atTime(LocalTime.MAX);
+
+        List<Payment> payments = paymentRepository.findByCreatedAtBetween(from, to);
+
+        int totalAmount = payments.stream().filter(p -> p.getStatus() == PaymentStatus.SUCCESS)
+                .mapToInt(Payment::getAmount).sum();
+        int refundAmount = payments.stream().filter(p -> p.getStatus() == PaymentStatus.REFUNDED)
+                .mapToInt(Payment::getAmount).sum();
+        int netAmount = totalAmount - refundAmount;
+        long count = payments.stream().filter(p -> p.getStatus() == PaymentStatus.SUCCESS).count();
+
+        Map<Integer, List<Payment>> byDay = payments.stream()
+                .collect(Collectors.groupingBy(p -> p.getCreatedAt().getDayOfMonth()));
+
+        List<PaymentMonthlyDetailResponse.DailyStats> dailyStats = byDay.entrySet().stream()
+                .map(entry -> {
+                    int day = entry.getKey();
+                    int daySales = entry.getValue().stream().filter(p -> p.getStatus() == PaymentStatus.SUCCESS)
+                            .mapToInt(Payment::getAmount).sum();
+                    int dayRefund = entry.getValue().stream().filter(p -> p.getStatus() == PaymentStatus.REFUNDED)
+                            .mapToInt(Payment::getAmount).sum();
+                    return new PaymentMonthlyDetailResponse.DailyStats(day, daySales, dayRefund, daySales - dayRefund);
+                })
+                .sorted(Comparator.comparingInt(PaymentMonthlyDetailResponse.DailyStats::day))
+                .toList();
+
+        // 전월 성장률 계산
+        YearMonth prevYm = ym.minusMonths(1);
+        LocalDateTime prevFrom = prevYm.atDay(1).atStartOfDay();
+        LocalDateTime prevTo = prevYm.atEndOfMonth().atTime(LocalTime.MAX);
+        int prevNet = paymentRepository.findByCreatedAtBetween(prevFrom, prevTo).stream()
+                .filter(p -> p.getStatus() == PaymentStatus.SUCCESS)
+                .mapToInt(Payment::getAmount).sum();
+
+        Double growthRate = prevNet > 0 ? Math.round((netAmount - prevNet) * 1000.0 / prevNet) / 10.0 : null;
+
+        return new PaymentMonthlyDetailResponse(year, month, totalAmount, refundAmount, netAmount, count, growthRate, dailyStats);
+    }
+
+    private List<PaymentStatsResponse> applyGrowthRate(List<PaymentStatsResponse> sorted) {
+        java.util.ArrayList<PaymentStatsResponse> result = new java.util.ArrayList<>(sorted);
+        for (int i = 0; i < result.size(); i++) {
+            PaymentStatsResponse cur = result.get(i);
+            Double rate = null;
+            if (i > 0) {
+                int prevNet = result.get(i - 1).netAmount();
+                if (prevNet > 0) {
+                    rate = Math.round((cur.netAmount() - prevNet) * 1000.0 / prevNet) / 10.0;
+                }
+            }
+            result.set(i, new PaymentStatsResponse(
+                    cur.year(), cur.month(), cur.totalAmount(), cur.count(),
+                    cur.refundAmount(), cur.netAmount(), rate));
+        }
+        return result;
+    }
+
+    private PaymentResponse enrichPayment(Payment payment) {
+        String userName = userRepository.findById(payment.getUserId())
+                .map(User::getName)
+                .orElse(null);
+
+        String productName = null;
+        if (payment.getCourseId() != null) {
+            productName = courseRepository.findByIdAndDeletedFalse(payment.getCourseId())
+                    .map(Course::getTitle)
+                    .orElse(null);
+        } else if (payment.getBookingId() != null) {
+            productName = bookingRepository.findById(payment.getBookingId())
+                    .flatMap(b -> accommodationRepository.findById(b.getAccommodationId()))
+                    .map(Accommodation::getName)
+                    .orElse(null);
+        }
+
+        return PaymentResponse.fromWithDetail(payment, userName, productName, payment.getPaymentType().name());
     }
 
     public int calculateLectureAmount(Long courseId, int usedMileage, Long usedCouponId, Long userId) {

--- a/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/usecase/PaymentQueryUseCase.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.payment.application.usecase;
 
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentMonthlyDetailResponse;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentStatsResponse;
 
@@ -12,6 +13,7 @@ public interface PaymentQueryUseCase {
     List<PaymentResponse> getMyPayments(Long userId);
     List<PaymentResponse> getAdminPayments(LocalDate from, LocalDate to);
     byte[] getAdminPaymentsExcel(LocalDate from, LocalDate to);
-    List<PaymentStatsResponse> getAdminPaymentStats();
+    List<PaymentStatsResponse> getAdminPaymentStats(Integer year);
+    PaymentMonthlyDetailResponse getAdminPaymentStatsByMonth(int year, int month);
     int calculateLectureAmount(Long courseId, int usedMileage, Long usedCouponId, Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/AdminPaymentController.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/AdminPaymentController.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.payment.presentation;
 
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.payment.application.usecase.PaymentQueryUseCase;
+import com.kidmily.algoga_server.payment.presentation.api.response.PaymentMonthlyDetailResponse;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentResponse;
 import com.kidmily.algoga_server.payment.presentation.api.response.PaymentStatsResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,9 +53,22 @@ public class AdminPaymentController {
     }
 
     @GetMapping("/stats")
-    @Operation(summary = "[어드민] 월별 수익 통계", description = "월별 결제 합계와 건수 통계를 반환합니다.")
-    public ResponseEntity<ApiResponse<List<PaymentStatsResponse>>> getAdminPaymentStats() {
-        List<PaymentStatsResponse> response = paymentQueryUseCase.getAdminPaymentStats();
+    @Operation(summary = "[어드민] 월별 수익 통계", description = "월별 결제 합계와 건수 통계를 반환합니다. year 파라미터로 연도 필터 가능.")
+    public ResponseEntity<ApiResponse<List<PaymentStatsResponse>>> getAdminPaymentStats(
+            @Parameter(description = "연도 필터 (없으면 전체)", example = "2026")
+            @RequestParam(required = false) Integer year
+    ) {
+        List<PaymentStatsResponse> response = paymentQueryUseCase.getAdminPaymentStats(year);
         return ResponseEntity.ok(ApiResponse.success("PAYMENT_STATS", "월별 수익 통계 조회에 성공했습니다.", response));
+    }
+
+    @GetMapping("/stats/{year}/{month}")
+    @Operation(summary = "[어드민] 월별 수익 상세", description = "특정 월의 일별 매출/환불/순수익 breakdown을 반환합니다.")
+    public ResponseEntity<ApiResponse<PaymentMonthlyDetailResponse>> getAdminPaymentStatsByMonth(
+            @Parameter(description = "연도", example = "2026") @PathVariable int year,
+            @Parameter(description = "월", example = "6") @PathVariable int month
+    ) {
+        PaymentMonthlyDetailResponse response = paymentQueryUseCase.getAdminPaymentStatsByMonth(year, month);
+        return ResponseEntity.ok(ApiResponse.success("PAYMENT_MONTHLY_STATS", "월별 수익 상세 조회에 성공했습니다.", response));
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentMonthlyDetailResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentMonthlyDetailResponse.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.payment.presentation.api.response;
+
+import java.util.List;
+
+public record PaymentMonthlyDetailResponse(
+        int year,
+        int month,
+        int totalAmount,
+        int refundAmount,
+        int netAmount,
+        long count,
+        Double growthRate,
+        List<DailyStats> dailyStats
+) {
+    public record DailyStats(
+            int day,
+            int salesAmount,
+            int refundAmount,
+            int netAmount
+    ) {}
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentResponse.java
@@ -17,7 +17,11 @@ public record PaymentResponse(
         Long usedCouponId,
         PaymentStatus status,
         String portonePaymentId,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        // 어드민 상세 필드 (null 가능)
+        String userName,
+        String productName,
+        String paymentMethod
 ) {
     public static PaymentResponse from(Payment payment) {
         return new PaymentResponse(
@@ -31,7 +35,27 @@ public record PaymentResponse(
                 payment.getUsedCouponId(),
                 payment.getStatus(),
                 payment.getPortonePaymentId(),
-                payment.getCreatedAt()
+                payment.getCreatedAt(),
+                null, null, null
+        );
+    }
+
+    public static PaymentResponse fromWithDetail(Payment payment, String userName, String productName, String paymentMethod) {
+        return new PaymentResponse(
+                payment.getId(),
+                payment.getBookingId(),
+                payment.getCourseId(),
+                payment.getUserId(),
+                payment.getPaymentType(),
+                payment.getAmount(),
+                payment.getUsedMileage(),
+                payment.getUsedCouponId(),
+                payment.getStatus(),
+                payment.getPortonePaymentId(),
+                payment.getCreatedAt(),
+                userName,
+                productName,
+                paymentMethod
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentStatsResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/presentation/api/response/PaymentStatsResponse.java
@@ -4,5 +4,8 @@ public record PaymentStatsResponse(
         int year,
         int month,
         int totalAmount,
-        long count
+        long count,
+        int refundAmount,
+        int netAmount,
+        Double growthRate
 ) {}

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundCommandService.java
@@ -139,12 +139,29 @@ public class RefundCommandService implements RefundCommandUseCase {
 
     @Override
     @Transactional
+    public void markUnderReview(Long refundId) {
+        log.info("[RefundCommandService] 환불 검토 요청 - refundId: {}", refundId);
+
+        RefundRequest refundRequest = findRefundOrThrow(refundId);
+
+        if (refundRequest.getStatus() != RefundStatus.REQUESTED) {
+            log.warn("[RefundCommandService] 검토 요청 불가 상태 - status: {}", refundRequest.getStatus());
+            throw new BusinessException(RefundErrorCode.INVALID_REFUND_STATUS);
+        }
+
+        refundRequest.markUnderReview();
+        refundRepository.save(refundRequest);
+        log.info("[RefundCommandService] 환불 검토 요청 완료 - refundId: {}", refundId);
+    }
+
+    @Override
+    @Transactional
     public void approve(Long refundId) {
         log.info("[RefundCommandService] 환불 승인 - refundId: {}", refundId);
 
         RefundRequest refundRequest = findRefundOrThrow(refundId);
 
-        if (refundRequest.getStatus() != RefundStatus.REQUESTED) {
+        if (refundRequest.getStatus() != RefundStatus.UNDER_REVIEW) {
             log.warn("[RefundCommandService] 승인 불가 상태 - status: {}", refundRequest.getStatus());
             throw new BusinessException(RefundErrorCode.INVALID_REFUND_STATUS);
         }
@@ -162,7 +179,8 @@ public class RefundCommandService implements RefundCommandUseCase {
 
         RefundRequest refundRequest = findRefundOrThrow(refundId);
 
-        if (refundRequest.getStatus() != RefundStatus.REQUESTED) {
+        if (refundRequest.getStatus() != RefundStatus.REQUESTED
+                && refundRequest.getStatus() != RefundStatus.UNDER_REVIEW) {
             log.warn("[RefundCommandService] 반려 불가 상태 - status: {}", refundRequest.getStatus());
             throw new BusinessException(RefundErrorCode.INVALID_REFUND_STATUS);
         }

--- a/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/service/RefundQueryService.java
@@ -1,14 +1,31 @@
 package com.kidmily.algoga_server.refund.application.service;
 
+import com.kidmily.algoga_server.accommodation.domain.model.Accommodation;
+import com.kidmily.algoga_server.accommodation.domain.repository.AccommodationRepository;
+import com.kidmily.algoga_server.booking.domain.model.Booking;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
 import com.kidmily.algoga_server.refund.application.usecase.RefundQueryUseCase;
+import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
 import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
+import com.kidmily.algoga_server.refund.exception.RefundErrorCode;
 import com.kidmily.algoga_server.refund.presentation.api.response.RefundResponse;
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 @Slf4j
@@ -18,6 +35,11 @@ import java.util.List;
 public class RefundQueryService implements RefundQueryUseCase {
 
     private final RefundRepository refundRepository;
+    private final UserRepository userRepository;
+    private final BookingRepository bookingRepository;
+    private final PaymentRepository paymentRepository;
+    private final AccommodationRepository accommodationRepository;
+    private final CourseRepository courseRepository;
 
     @Override
     public List<RefundResponse> getMyRefunds(Long userId) {
@@ -29,17 +51,129 @@ public class RefundQueryService implements RefundQueryUseCase {
     }
 
     @Override
-    public List<RefundResponse> getAllRefunds(RefundStatus status) {
-        log.warn("[RefundQueryService] 전체 환불 목록 조회 - status: {}", status);
-        if (status == null) {
-            return refundRepository.findAll()
-                    .stream()
-                    .map(RefundResponse::from)
-                    .toList();
-        }
-        return refundRepository.findAllByStatus(status)
-                .stream()
-                .map(RefundResponse::from)
+    public List<RefundResponse> getAllRefunds(RefundStatus status, String userName, String bookingNumber, String productName) {
+        log.warn("[RefundQueryService] 전체 환불 목록 조회 - status: {}, userName: {}, bookingNumber: {}, productName: {}",
+                status, userName, bookingNumber, productName);
+
+        List<RefundRequest> refunds = status == null
+                ? refundRepository.findAll()
+                : refundRepository.findAllByStatus(status);
+
+        return refunds.stream()
+                .map(this::enrichRefund)
+                .filter(r -> matchesSearchParams(r, userName, bookingNumber, productName))
                 .toList();
+    }
+
+    @Override
+    public RefundResponse getRefund(Long refundId) {
+        log.info("[RefundQueryService] 환불 단건 조회 - refundId: {}", refundId);
+        RefundRequest refund = refundRepository.findById(refundId)
+                .orElseThrow(() -> {
+                    log.warn("[RefundQueryService] 환불 요청을 찾을 수 없음 - refundId: {}", refundId);
+                    return new BusinessException(RefundErrorCode.REFUND_NOT_FOUND);
+                });
+        return enrichRefund(refund);
+    }
+
+    @Override
+    public boolean hasActiveRefund(Long userId) {
+        return refundRepository.existsByUserIdAndStatusIn(
+                userId, List.of(RefundStatus.REQUESTED, RefundStatus.UNDER_REVIEW));
+    }
+
+    @Override
+    public byte[] getRefundExcel(RefundStatus status) {
+        log.info("[RefundQueryService] 환불 엑셀 다운로드 - status: {}", status);
+        List<RefundResponse> refunds = getAllRefunds(status, null, null, null);
+
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("환불내역");
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerStyle.setFont(headerFont);
+
+            Row header = sheet.createRow(0);
+            String[] columns = {"환불ID", "사용자명", "예약번호", "상품명", "결제금액", "환불금액", "결제수단", "상태", "신청일시"};
+            for (int i = 0; i < columns.length; i++) {
+                Cell cell = header.createCell(i);
+                cell.setCellValue(columns[i]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            int rowNum = 1;
+            for (RefundResponse r : refunds) {
+                Row row = sheet.createRow(rowNum++);
+                row.createCell(0).setCellValue(r.refundId());
+                row.createCell(1).setCellValue(r.userName() != null ? r.userName() : "");
+                row.createCell(2).setCellValue(r.bookingNumber() != null ? r.bookingNumber() : "");
+                row.createCell(3).setCellValue(r.productName() != null ? r.productName() : "");
+                row.createCell(4).setCellValue(r.paidAmount() != null ? r.paidAmount() : 0);
+                row.createCell(5).setCellValue(r.amount());
+                row.createCell(6).setCellValue(r.paymentMethod() != null ? r.paymentMethod() : "");
+                row.createCell(7).setCellValue(r.status().name());
+                row.createCell(8).setCellValue(r.createdAt().toString());
+            }
+
+            for (int i = 0; i < columns.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            workbook.write(out);
+            return out.toByteArray();
+
+        } catch (IOException e) {
+            log.warn("[RefundQueryService] 엑셀 생성 실패: {}", e.getMessage());
+            throw new BusinessException(RefundErrorCode.REFUND_NOT_FOUND);
+        }
+    }
+
+    private RefundResponse enrichRefund(RefundRequest refund) {
+        String userName = userRepository.findById(refund.getUserId())
+                .map(User::getName)
+                .orElse(null);
+
+        Payment payment = paymentRepository.findById(refund.getPaymentId()).orElse(null);
+        int paidAmount = payment != null ? payment.getAmount() : 0;
+        String paymentMethod = payment != null ? payment.getPaymentType().name() : null;
+
+        Booking booking = bookingRepository.findById(refund.getBookingId()).orElse(null);
+        String bookingNumber = booking != null ? booking.getBookingNumber() : null;
+        var checkInDate = booking != null ? booking.getCheckInDate() : null;
+
+        String productName = resolveProductName(payment, booking);
+
+        return RefundResponse.fromWithDetail(
+                refund, userName, productName, bookingNumber, checkInDate, paidAmount, paymentMethod);
+    }
+
+    private String resolveProductName(Payment payment, Booking booking) {
+        if (payment != null && payment.getCourseId() != null) {
+            return courseRepository.findByIdAndDeletedFalse(payment.getCourseId())
+                    .map(Course::getTitle)
+                    .orElse(null);
+        }
+        if (booking != null) {
+            return accommodationRepository.findById(booking.getAccommodationId())
+                    .map(Accommodation::getName)
+                    .orElse(null);
+        }
+        return null;
+    }
+
+    private boolean matchesSearchParams(RefundResponse r, String userName, String bookingNumber, String productName) {
+        if (userName != null && !userName.isBlank()) {
+            if (r.userName() == null || !r.userName().contains(userName)) return false;
+        }
+        if (bookingNumber != null && !bookingNumber.isBlank()) {
+            if (r.bookingNumber() == null || !r.bookingNumber().contains(bookingNumber)) return false;
+        }
+        if (productName != null && !productName.isBlank()) {
+            if (r.productName() == null || !r.productName().contains(productName)) return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundCommandUseCase.java
@@ -7,5 +7,6 @@ public interface RefundCommandUseCase {
     Long convertToRefund(Long bookingId);
     void approve(Long refundId);
     void reject(Long refundId, String rejectReason);
+    void markUnderReview(Long refundId);
     void complete(Long refundId);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/application/usecase/RefundQueryUseCase.java
@@ -7,5 +7,8 @@ import java.util.List;
 
 public interface RefundQueryUseCase {
     List<RefundResponse> getMyRefunds(Long userId);
-    List<RefundResponse> getAllRefunds(RefundStatus status);
+    List<RefundResponse> getAllRefunds(RefundStatus status, String userName, String bookingNumber, String productName);
+    RefundResponse getRefund(Long refundId);
+    boolean hasActiveRefund(Long userId);
+    byte[] getRefundExcel(RefundStatus status);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/domain/model/RefundRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/domain/model/RefundRequest.java
@@ -54,6 +54,11 @@ public class RefundRequest {
         return refundRequest;
     }
 
+    public void markUnderReview() {
+        this.status = RefundStatus.UNDER_REVIEW;
+        this.updatedAt = LocalDateTime.now();
+    }
+
     public void approve() {
         this.status = RefundStatus.APPROVED;
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/com/kidmily/algoga_server/refund/domain/model/RefundStatus.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/domain/model/RefundStatus.java
@@ -1,8 +1,9 @@
 package com.kidmily.algoga_server.refund.domain.model;
 
 public enum RefundStatus {
-    REQUESTED,   // 환불 요청됨
-    APPROVED,    // 승인됨
-    REJECTED,    // 반려됨
-    COMPLETED    // 완료됨
+    REQUESTED,    // 환불 요청됨
+    UNDER_REVIEW, // CS매니저 → 정산매니저 검토 요청 상태
+    APPROVED,     // 승인됨
+    REJECTED,     // 반려됨
+    COMPLETED     // 완료됨
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/domain/repository/RefundRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/domain/repository/RefundRepository.java
@@ -12,5 +12,7 @@ public interface RefundRepository {
     List<RefundRequest> findAllByUserId(Long userId);
     List<RefundRequest> findAll();
     List<RefundRequest> findAllByStatus(RefundStatus status);
+    List<RefundRequest> findAllByStatusIn(List<RefundStatus> statuses);
     boolean existsByBookingId(Long bookingId);
+    boolean existsByUserIdAndStatusIn(Long userId, List<RefundStatus> statuses);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/RefundRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/RefundRepositoryAdapter.java
@@ -54,7 +54,20 @@ public class RefundRepositoryAdapter implements RefundRepository {
     }
 
     @Override
+    public List<RefundRequest> findAllByStatusIn(List<RefundStatus> statuses) {
+        return springDataRefundRepository.findAllByStatusIn(statuses)
+                .stream()
+                .map(refundMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public boolean existsByBookingId(Long bookingId) {
         return springDataRefundRepository.existsByBookingId(bookingId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndStatusIn(Long userId, List<RefundStatus> statuses) {
+        return springDataRefundRepository.existsByUserIdAndStatusIn(userId, statuses);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/SpringDataRefundRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/infrastructure/persistence/SpringDataRefundRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 public interface SpringDataRefundRepository extends JpaRepository<RefundJpaEntity, Long> {
     List<RefundJpaEntity> findAllByUserId(Long userId);
     List<RefundJpaEntity> findAllByStatus(RefundStatus status);
+    List<RefundJpaEntity> findAllByStatusIn(List<RefundStatus> statuses);
     boolean existsByBookingId(Long bookingId);
+    boolean existsByUserIdAndStatusIn(Long userId, List<RefundStatus> statuses);
 }

--- a/src/main/java/com/kidmily/algoga_server/refund/presentation/api/RefundController.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/presentation/api/RefundController.java
@@ -15,7 +15,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -76,17 +78,55 @@ public class RefundController {
     }
 
     @GetMapping("/api/v1/admin/refund-requests")
-    @Operation(summary = "[어드민] 환불 요청 목록", description = "전체 환불 요청 목록을 상태별로 조회합니다.")
+    @Operation(summary = "[어드민] 환불 요청 목록", description = "전체 환불 요청 목록을 상태/사용자명/예약번호/상품명으로 검색합니다.")
     public ResponseEntity<ApiResponse<List<RefundResponse>>> getAllRefunds(
-            @Parameter(description = "환불 상태 필터 (REQUESTED/APPROVED/REJECTED/COMPLETED)")
-            @RequestParam(required = false) RefundStatus status
+            @Parameter(description = "환불 상태 필터 (REQUESTED/UNDER_REVIEW/APPROVED/REJECTED/COMPLETED)")
+            @RequestParam(required = false) RefundStatus status,
+            @RequestParam(required = false) String userName,
+            @RequestParam(required = false) String bookingNumber,
+            @RequestParam(required = false) String productName
     ) {
-        List<RefundResponse> response = refundQueryUseCase.getAllRefunds(status);
+        List<RefundResponse> response = refundQueryUseCase.getAllRefunds(status, userName, bookingNumber, productName);
         return ResponseEntity.ok(ApiResponse.success("REFUND_LIST", "환불 목록 조회에 성공했습니다.", response));
     }
 
+    @GetMapping("/api/v1/admin/refund-requests/{refundId}")
+    @Operation(summary = "[어드민] 환불 단건 조회", description = "환불 요청 상세 정보를 조회합니다.")
+    @ApiErrorCodeExample(domain = RefundErrorCode.class, value = {"REFUND_NOT_FOUND"})
+    public ResponseEntity<ApiResponse<RefundResponse>> getRefund(
+            @Parameter(description = "환불 요청 ID", example = "1")
+            @PathVariable Long refundId
+    ) {
+        RefundResponse response = refundQueryUseCase.getRefund(refundId);
+        return ResponseEntity.ok(ApiResponse.success("REFUND_DETAIL", "환불 상세 조회에 성공했습니다.", response));
+    }
+
+    @GetMapping("/api/v1/admin/refund-requests/excel")
+    @Operation(summary = "[어드민] 환불 내역 엑셀 다운로드", description = "환불 내역을 엑셀로 다운로드합니다.")
+    public ResponseEntity<byte[]> getRefundExcel(
+            @RequestParam(required = false) RefundStatus status
+    ) {
+        byte[] excel = refundQueryUseCase.getRefundExcel(status);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"refunds.xlsx\"")
+                .contentType(MediaType.parseMediaType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(excel);
+    }
+
+    @PutMapping("/api/v1/admin/refund-requests/{refundId}/review")
+    @Operation(summary = "[어드민] 환불 검토 요청", description = "CS매니저가 정산매니저에게 환불 검토를 요청합니다. REQUESTED → UNDER_REVIEW")
+    @ApiErrorCodeExample(domain = RefundErrorCode.class, value = {"REFUND_NOT_FOUND", "INVALID_REFUND_STATUS"})
+    public ResponseEntity<ApiResponse<Void>> markUnderReview(
+            @Parameter(description = "환불 요청 ID", example = "1")
+            @PathVariable Long refundId
+    ) {
+        refundCommandUseCase.markUnderReview(refundId);
+        return ResponseEntity.ok(ApiResponse.success("REFUND_UNDER_REVIEW", "환불 검토 요청이 완료됐습니다."));
+    }
+
     @PutMapping("/api/v1/admin/refund-requests/{refundId}/approve")
-    @Operation(summary = "[어드민] 환불 승인", description = "환불 요청을 승인합니다. REQUESTED → APPROVED")
+    @Operation(summary = "[어드민] 환불 승인", description = "환불 요청을 승인합니다. UNDER_REVIEW → APPROVED")
     @ApiErrorCodeExample(domain = RefundErrorCode.class, value = {"REFUND_NOT_FOUND", "INVALID_REFUND_STATUS"})
     public ResponseEntity<ApiResponse<Void>> approve(
             @Parameter(description = "환불 요청 ID", example = "1")

--- a/src/main/java/com/kidmily/algoga_server/refund/presentation/api/response/RefundResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/refund/presentation/api/response/RefundResponse.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.refund.presentation.api.response;
 import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
 import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record RefundResponse(
@@ -15,7 +16,14 @@ public record RefundResponse(
         String rejectReason,
         int amount,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        // 어드민 상세 필드 (null 가능)
+        String userName,
+        String productName,
+        String bookingNumber,
+        LocalDate checkInDate,
+        Integer paidAmount,
+        String paymentMethod
 ) {
     public static RefundResponse from(RefundRequest refundRequest) {
         return new RefundResponse(
@@ -28,7 +36,37 @@ public record RefundResponse(
                 refundRequest.getRejectReason(),
                 refundRequest.getAmount(),
                 refundRequest.getCreatedAt(),
-                refundRequest.getUpdatedAt()
+                refundRequest.getUpdatedAt(),
+                null, null, null, null, null, null
+        );
+    }
+
+    public static RefundResponse fromWithDetail(
+            RefundRequest refundRequest,
+            String userName,
+            String productName,
+            String bookingNumber,
+            LocalDate checkInDate,
+            Integer paidAmount,
+            String paymentMethod
+    ) {
+        return new RefundResponse(
+                refundRequest.getId(),
+                refundRequest.getBookingId(),
+                refundRequest.getPaymentId(),
+                refundRequest.getUserId(),
+                refundRequest.getStatus(),
+                refundRequest.getReason(),
+                refundRequest.getRejectReason(),
+                refundRequest.getAmount(),
+                refundRequest.getCreatedAt(),
+                refundRequest.getUpdatedAt(),
+                userName,
+                productName,
+                bookingNumber,
+                checkInDate,
+                paidAmount,
+                paymentMethod
         );
     }
 }


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
어드민 페이지 연동을 위한 refund / payment / booking 도메인 기능 확장

**refund**
- `RefundStatus`에 `UNDER_REVIEW` 상태 추가 (REQUESTED → UNDER_REVIEW → APPROVED → COMPLETED / REJECTED)
- CS매니저 검토 요청 API 추가: `PUT /api/v1/admin/refund-requests/{refundId}/review`
- 어드민 상세 조회 / 검색 파라미터(사용자명, 예약번호, 상품명) / Excel 내보내기 API 추가
- `RefundResponse`에 어드민 상세 필드 추가 (사용자명, 상품명, 예약번호, 체크인일, 결제금액, 결제수단)
- 유저 탈퇴 검증용 `hasActiveRefund(userId)` 추가

**payment**
- `PaymentStatsResponse`에 환불금액 / 순수익 / 전월 대비 성장률 필드 추가
- 일별 매출 breakdown API 추가: `GET /api/v1/admin/payments/stats/{year}/{month}`
- `getAdminPaymentStats()`에 연도 필터 추가
- `PaymentResponse`에 사용자명 / 상품명 / 결제수단 필드 추가
- Excel 컬럼 변경 (결제번호, 사용자명, 상품명, 결제금액, 결제수단, 결제일시)

**booking**
- 유저 탈퇴 검증용 `hasActiveBooking(userId)` 추가 (PENDING/DEPOSIT_PAID/FULL_PAID 상태 확인)
## 🔗 Issue
Closes #209 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ]  `approve()`는 `UNDER_REVIEW` 상태에서만 동작하는지 확인
- [ ]`getAdminPaymentStats(year)` 연도 필터 없을 때 전체 조회 동작 확인
- [ ] `UNDER_REVIEW` 상태 전환 흐름: REQUESTED → UNDER_REVIEW → APPROVED → COMPLETED


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 결제 통계 조회를 연도 단위로 필터링 가능하며, 월별 일일 상세 내역(매출/환불/순수익) 확인 가능
  * 환불 목록 조회에 사용자명, 예약번호, 상품명 검색 필터 추가
  * 결제 및 환불 기록을 엑셀로 내보내기 기능 추가
  * 환불 처리 흐름에 "검토 중" 상태 추가

* **Bug Fixes**
  * 환불 승인/반려 상태 조건 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->