### PR TITLE
예약 전환율 분석 통계 API 개발

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.booking.domain.repository;
 import com.kidmily.algoga_server.booking.domain.model.Booking;
 import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,10 @@ public interface BookingRepository {
     Booking updateStatus(Long bookingId, BookingStatus status);
 
     boolean existsByUserIdAndStatusIn(Long userId, List<BookingStatus> statuses);
+
+    long countByStatusAndCreatedAtBetween(BookingStatus status, LocalDateTime from, LocalDateTime to);
+
+    long countByAccommodationIdAndStatusAndCreatedAtBetween(Long accommodationId, BookingStatus status, LocalDateTime from, LocalDateTime to);
+
+    List<Long> findDistinctAccommodationIdsByStatusAndCreatedAtBetween(BookingStatus status, LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+
 @Repository
 @RequiredArgsConstructor
 public class BookingRepositoryAdapter implements BookingRepository {
@@ -49,5 +50,20 @@ public class BookingRepositoryAdapter implements BookingRepository {
     @Override
     public boolean existsByUserIdAndStatusIn(Long userId, List<BookingStatus> statuses) {
         return springDataBookingRepository.existsByUserIdAndStatusIn(userId, statuses);
+    }
+
+    @Override
+    public long countByStatusAndCreatedAtBetween(BookingStatus status, LocalDateTime from, LocalDateTime to) {
+        return springDataBookingRepository.countByStatusAndCreatedAtBetween(status, from, to);
+    }
+
+    @Override
+    public long countByAccommodationIdAndStatusAndCreatedAtBetween(Long accommodationId, BookingStatus status, LocalDateTime from, LocalDateTime to) {
+        return springDataBookingRepository.countByAccommodationIdAndStatusAndCreatedAtBetween(accommodationId, status, from, to);
+    }
+
+    @Override
+    public List<Long> findDistinctAccommodationIdsByStatusAndCreatedAtBetween(BookingStatus status, LocalDateTime from, LocalDateTime to) {
+        return springDataBookingRepository.findDistinctAccommodationIdsByStatusAndCreatedAtBetween(status, from, to);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/SpringDataBookingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/SpringDataBookingRepository.java
@@ -2,7 +2,10 @@ package com.kidmily.algoga_server.booking.infrastructure.persistence;
 
 import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SpringDataBookingRepository extends JpaRepository<BookingJpaEntity, Long> {
@@ -10,4 +13,11 @@ public interface SpringDataBookingRepository extends JpaRepository<BookingJpaEnt
     List<BookingJpaEntity> findByUserId(Long userId);
 
     boolean existsByUserIdAndStatusIn(Long userId, List<BookingStatus> statuses);
+
+    long countByStatusAndCreatedAtBetween(BookingStatus status, LocalDateTime from, LocalDateTime to);
+
+    long countByAccommodationIdAndStatusAndCreatedAtBetween(Long accommodationId, BookingStatus status, LocalDateTime from, LocalDateTime to);
+
+    @Query("SELECT DISTINCT e.accommodationId FROM BookingJpaEntity e WHERE e.status = :status AND e.createdAt BETWEEN :from AND :to")
+    List<Long> findDistinctAccommodationIdsByStatusAndCreatedAtBetween(@Param("status") BookingStatus status, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }

--- a/src/main/java/com/kidmily/algoga_server/stats/application/service/ConversionStatsService.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/application/service/ConversionStatsService.java
@@ -1,0 +1,92 @@
+package com.kidmily.algoga_server.stats.application.service;
+
+import com.kidmily.algoga_server.accommodation.domain.repository.AccommodationRepository;
+import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.stats.application.usecase.ConversionStatsUseCase;
+import com.kidmily.algoga_server.stats.domain.model.PaymentAttempt;
+import com.kidmily.algoga_server.stats.domain.repository.PaymentAttemptRepository;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionDailyResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionProductResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionProductStatsResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConversionStatsService implements ConversionStatsUseCase {
+
+    private final PaymentAttemptRepository paymentAttemptRepository;
+    private final BookingRepository bookingRepository;
+    private final AccommodationRepository accommodationRepository;
+
+    @Override
+    @Transactional
+    public void recordAttempt(Long userId, Long accommodationId) {
+        paymentAttemptRepository.save(PaymentAttempt.create(userId, accommodationId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ConversionSummaryResponse getSummary(LocalDate from, LocalDate to) {
+        LocalDateTime start = from.atStartOfDay();
+        LocalDateTime end = to.plusDays(1).atStartOfDay();
+
+        long attemptCount = paymentAttemptRepository.countByCreatedAtBetween(start, end);
+        long completedCount = bookingRepository.countByStatusAndCreatedAtBetween(BookingStatus.FULL_PAID, start, end);
+
+        return ConversionSummaryResponse.of(attemptCount, completedCount);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ConversionDailyResponse> getDailyStats(LocalDate from, LocalDate to) {
+        return from.datesUntil(to.plusDays(1))
+                .map(date -> {
+                    LocalDateTime start = date.atStartOfDay();
+                    LocalDateTime end = date.plusDays(1).atStartOfDay();
+                    long attempts = paymentAttemptRepository.countByCreatedAtBetween(start, end);
+                    long completed = bookingRepository.countByStatusAndCreatedAtBetween(BookingStatus.FULL_PAID, start, end);
+                    return ConversionDailyResponse.of(date, attempts, completed);
+                })
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ConversionProductStatsResponse getProductStats(LocalDate from, LocalDate to) {
+        LocalDateTime start = from.atStartOfDay();
+        LocalDateTime end = to.plusDays(1).atStartOfDay();
+
+        List<Long> accommodationIds = paymentAttemptRepository.findDistinctAccommodationIdsByCreatedAtBetween(start, end);
+
+        List<ConversionProductResponse> products = accommodationIds.stream()
+                .map(accommodationId -> {
+                    String name = accommodationRepository.findById(accommodationId)
+                            .map(a -> a.getName())
+                            .orElse("알 수 없음");
+                    long attempts = paymentAttemptRepository.countByAccommodationIdAndCreatedAtBetween(accommodationId, start, end);
+                    long completed = bookingRepository.countByAccommodationIdAndStatusAndCreatedAtBetween(accommodationId, BookingStatus.FULL_PAID, start, end);
+                    return ConversionProductResponse.of(accommodationId, name, attempts, completed);
+                })
+                .sorted(Comparator.comparingDouble(ConversionProductResponse::conversionRate).reversed())
+                .toList();
+
+        List<ConversionProductResponse> top = products.stream().limit(5).toList();
+        List<ConversionProductResponse> bottom = products.stream()
+                .sorted(Comparator.comparingDouble(ConversionProductResponse::conversionRate))
+                .limit(5)
+                .toList();
+
+        return new ConversionProductStatsResponse(products, top, bottom);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/application/usecase/ConversionStatsUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/application/usecase/ConversionStatsUseCase.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.stats.application.usecase;
+
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionDailyResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionProductStatsResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionSummaryResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ConversionStatsUseCase {
+    void recordAttempt(Long userId, Long accommodationId);
+    ConversionSummaryResponse getSummary(LocalDate from, LocalDate to);
+    List<ConversionDailyResponse> getDailyStats(LocalDate from, LocalDate to);
+    ConversionProductStatsResponse getProductStats(LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/domain/model/PaymentAttempt.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/domain/model/PaymentAttempt.java
@@ -1,0 +1,34 @@
+package com.kidmily.algoga_server.stats.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentAttempt {
+
+    private Long id;
+    private Long userId;
+    private Long accommodationId;
+    private LocalDateTime createdAt;
+
+    public static PaymentAttempt create(Long userId, Long accommodationId) {
+        PaymentAttempt attempt = new PaymentAttempt();
+        attempt.userId = userId;
+        attempt.accommodationId = accommodationId;
+        attempt.createdAt = LocalDateTime.now();
+        return attempt;
+    }
+
+    public static PaymentAttempt reconstitute(Long id, Long userId, Long accommodationId, LocalDateTime createdAt) {
+        PaymentAttempt attempt = new PaymentAttempt();
+        attempt.id = id;
+        attempt.userId = userId;
+        attempt.accommodationId = accommodationId;
+        attempt.createdAt = createdAt;
+        return attempt;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/domain/repository/PaymentAttemptRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/domain/repository/PaymentAttemptRepository.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.stats.domain.repository;
+
+import com.kidmily.algoga_server.stats.domain.model.PaymentAttempt;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PaymentAttemptRepository {
+    PaymentAttempt save(PaymentAttempt paymentAttempt);
+    long countByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
+    long countByAccommodationIdAndCreatedAtBetween(Long accommodationId, LocalDateTime from, LocalDateTime to);
+    List<Long> findDistinctAccommodationIdsByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/infrastructure/mapper/PaymentAttemptMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/infrastructure/mapper/PaymentAttemptMapper.java
@@ -1,0 +1,26 @@
+package com.kidmily.algoga_server.stats.infrastructure.mapper;
+
+import com.kidmily.algoga_server.stats.domain.model.PaymentAttempt;
+import com.kidmily.algoga_server.stats.infrastructure.persistence.PaymentAttemptJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentAttemptMapper {
+
+    public PaymentAttemptJpaEntity toJpaEntity(PaymentAttempt domain) {
+        return new PaymentAttemptJpaEntity(
+                domain.getUserId(),
+                domain.getAccommodationId(),
+                domain.getCreatedAt()
+        );
+    }
+
+    public PaymentAttempt toDomain(PaymentAttemptJpaEntity entity) {
+        return PaymentAttempt.reconstitute(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getAccommodationId(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/infrastructure/persistence/PaymentAttemptJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/infrastructure/persistence/PaymentAttemptJpaEntity.java
@@ -1,0 +1,35 @@
+package com.kidmily.algoga_server.stats.infrastructure.persistence;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment_attempts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentAttemptJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "accommodation_id", nullable = false)
+    private Long accommodationId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public PaymentAttemptJpaEntity(Long userId, Long accommodationId, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.accommodationId = accommodationId;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/infrastructure/persistence/PaymentAttemptRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/infrastructure/persistence/PaymentAttemptRepositoryAdapter.java
@@ -1,0 +1,39 @@
+package com.kidmily.algoga_server.stats.infrastructure.persistence;
+
+import com.kidmily.algoga_server.stats.domain.model.PaymentAttempt;
+import com.kidmily.algoga_server.stats.domain.repository.PaymentAttemptRepository;
+import com.kidmily.algoga_server.stats.infrastructure.mapper.PaymentAttemptMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentAttemptRepositoryAdapter implements PaymentAttemptRepository {
+
+    private final SpringDataPaymentAttemptRepository springDataPaymentAttemptRepository;
+    private final PaymentAttemptMapper paymentAttemptMapper;
+
+    @Override
+    public PaymentAttempt save(PaymentAttempt paymentAttempt) {
+        PaymentAttemptJpaEntity entity = paymentAttemptMapper.toJpaEntity(paymentAttempt);
+        return paymentAttemptMapper.toDomain(springDataPaymentAttemptRepository.save(entity));
+    }
+
+    @Override
+    public long countByCreatedAtBetween(LocalDateTime from, LocalDateTime to) {
+        return springDataPaymentAttemptRepository.countByCreatedAtBetween(from, to);
+    }
+
+    @Override
+    public long countByAccommodationIdAndCreatedAtBetween(Long accommodationId, LocalDateTime from, LocalDateTime to) {
+        return springDataPaymentAttemptRepository.countByAccommodationIdAndCreatedAtBetween(accommodationId, from, to);
+    }
+
+    @Override
+    public List<Long> findDistinctAccommodationIdsByCreatedAtBetween(LocalDateTime from, LocalDateTime to) {
+        return springDataPaymentAttemptRepository.findDistinctAccommodationIdsByCreatedAtBetween(from, to);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/infrastructure/persistence/SpringDataPaymentAttemptRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/infrastructure/persistence/SpringDataPaymentAttemptRepository.java
@@ -1,0 +1,18 @@
+package com.kidmily.algoga_server.stats.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SpringDataPaymentAttemptRepository extends JpaRepository<PaymentAttemptJpaEntity, Long> {
+
+    long countByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
+
+    long countByAccommodationIdAndCreatedAtBetween(Long accommodationId, LocalDateTime from, LocalDateTime to);
+
+    @Query("SELECT DISTINCT e.accommodationId FROM PaymentAttemptJpaEntity e WHERE e.createdAt BETWEEN :from AND :to")
+    List<Long> findDistinctAccommodationIdsByCreatedAtBetween(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/ConversionStatsController.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/ConversionStatsController.java
@@ -1,0 +1,68 @@
+package com.kidmily.algoga_server.stats.presentation;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.stats.application.usecase.ConversionStatsUseCase;
+import com.kidmily.algoga_server.stats.presentation.api.request.PaymentAttemptRequest;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionDailyResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionProductStatsResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.ConversionSummaryResponse;
+import com.kidmily.algoga_server.user.settings.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Conversion Stats", description = "예약 전환율 분석 API")
+public class ConversionStatsController {
+
+    private final ConversionStatsUseCase conversionStatsUseCase;
+
+    @PostMapping("/api/v1/payment-attempts")
+    @Operation(summary = "결제 페이지 진입 기록", description = "프론트에서 결제 페이지 진입 시 호출합니다.")
+    public ResponseEntity<ApiResponse<Void>> recordAttempt(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PaymentAttemptRequest request
+    ) {
+        Long userId = userDetails.getUser().getId();
+        conversionStatsUseCase.recordAttempt(userId, request.accommodationId());
+        return ResponseEntity.ok(ApiResponse.success("PAYMENT_ATTEMPT_RECORDED", "결제 페이지 진입이 기록되었습니다.", null));
+    }
+
+    @GetMapping("/api/v1/admin/stats/conversion/summary")
+    @Operation(summary = "[어드민] 전환율 요약 조회", description = "결제 페이지 진입 수, 예약 완료 수, 전환율을 조회합니다.")
+    public ResponseEntity<ApiResponse<ConversionSummaryResponse>> getSummary(
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to
+    ) {
+        return ResponseEntity.ok(ApiResponse.success("CONVERSION_SUMMARY", "전환율 요약 조회에 성공했습니다.",
+                conversionStatsUseCase.getSummary(from, to)));
+    }
+
+    @GetMapping("/api/v1/admin/stats/conversion/daily")
+    @Operation(summary = "[어드민] 기간별 전환율 조회", description = "일별 전환율 꺾은선 차트 데이터를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<ConversionDailyResponse>>> getDailyStats(
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to
+    ) {
+        return ResponseEntity.ok(ApiResponse.success("CONVERSION_DAILY", "기간별 전환율 조회에 성공했습니다.",
+                conversionStatsUseCase.getDailyStats(from, to)));
+    }
+
+    @GetMapping("/api/v1/admin/stats/conversion/products")
+    @Operation(summary = "[어드민] 상품별 전환율 조회", description = "상품별 전환율 및 상위/하위 리스트를 조회합니다.")
+    public ResponseEntity<ApiResponse<ConversionProductStatsResponse>> getProductStats(
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to
+    ) {
+        return ResponseEntity.ok(ApiResponse.success("CONVERSION_PRODUCTS", "상품별 전환율 조회에 성공했습니다.",
+                conversionStatsUseCase.getProductStats(from, to)));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/api/request/PaymentAttemptRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/api/request/PaymentAttemptRequest.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.stats.presentation.api.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentAttemptRequest(
+        @NotNull Long accommodationId
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionDailyResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionDailyResponse.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.stats.presentation.api.response;
+
+import java.time.LocalDate;
+
+public record ConversionDailyResponse(
+        LocalDate date,
+        long attemptCount,
+        long completedCount,
+        double conversionRate
+) {
+    public static ConversionDailyResponse of(LocalDate date, long attemptCount, long completedCount) {
+        double rate = attemptCount == 0 ? 0.0 : Math.round((double) completedCount / attemptCount * 10000.0) / 100.0;
+        return new ConversionDailyResponse(date, attemptCount, completedCount, rate);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionProductResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionProductResponse.java
@@ -1,0 +1,15 @@
+package com.kidmily.algoga_server.stats.presentation.api.response;
+
+public record ConversionProductResponse(
+        Long accommodationId,
+        String productName,
+        long attemptCount,
+        long completedCount,
+        double conversionRate
+) {
+    public static ConversionProductResponse of(Long accommodationId, String productName,
+                                                long attemptCount, long completedCount) {
+        double rate = attemptCount == 0 ? 0.0 : Math.round((double) completedCount / attemptCount * 10000.0) / 100.0;
+        return new ConversionProductResponse(accommodationId, productName, attemptCount, completedCount, rate);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionProductStatsResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionProductStatsResponse.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.stats.presentation.api.response;
+
+import java.util.List;
+
+public record ConversionProductStatsResponse(
+        List<ConversionProductResponse> products,
+        List<ConversionProductResponse> topProducts,
+        List<ConversionProductResponse> bottomProducts
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionSummaryResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/ConversionSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.stats.presentation.api.response;
+
+public record ConversionSummaryResponse(
+        long attemptCount,
+        long completedCount,
+        double conversionRate
+) {
+    public static ConversionSummaryResponse of(long attemptCount, long completedCount) {
+        double rate = attemptCount == 0 ? 0.0 : Math.round((double) completedCount / attemptCount * 10000.0) / 100.0;
+        return new ConversionSummaryResponse(attemptCount, completedCount, rate);
+    }
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
예약 전환율 분석 통계 API 개발 (stats 신규 도메인)
- `payment_attempt` 테이블 신규 생성 (결제 페이지 진입 기록)
- 전환율 공식: 예약 완료(FULL_PAID) / 결제 페이지 진입 수 × 100
**API 4개**
- `POST /api/v1/payment-attempts` — 결제 페이지 진입 기록 (프론트 호출)
- `GET /api/v1/admin/stats/conversion/summary?from=&to=` — 요약 카드 (진입 수 / 완료 수 / 전환율)
- `GET /api/v1/admin/stats/conversion/daily?from=&to=` — 일별 전환율 꺾은선 차트
- `GET /api/v1/admin/stats/conversion/products?from=&to=` — 상품별 전환율 + 상위/하위 Top 5

## 🔗 Issue
Closes #216 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ]`POST /api/v1/payment-attempts` 호출 시 `payment_attempts` 테이블에 row 생성 확인 
- [ ]summary` — 기간 내 진입 수 / FULL_PAID 예약 수 / 전환율 계산 정확성 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 관리자가 결제 전환율 통계를 조회할 수 있는 기능 추가 (요약, 일별, 상품별)
  * 결제 페이지 방문 기록 기능 추가로 전환율 추적 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->