### PR TITLE
feature/stats-countries  관련 개발

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/domain/repository/BookingRepository.java
@@ -24,4 +24,6 @@ public interface BookingRepository {
     long countByAccommodationIdAndStatusAndCreatedAtBetween(Long accommodationId, BookingStatus status, LocalDateTime from, LocalDateTime to);
 
     List<Long> findDistinctAccommodationIdsByStatusAndCreatedAtBetween(BookingStatus status, LocalDateTime from, LocalDateTime to);
+
+    List<Booking> findByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/BookingRepositoryAdapter.java
@@ -66,4 +66,12 @@ public class BookingRepositoryAdapter implements BookingRepository {
     public List<Long> findDistinctAccommodationIdsByStatusAndCreatedAtBetween(BookingStatus status, LocalDateTime from, LocalDateTime to) {
         return springDataBookingRepository.findDistinctAccommodationIdsByStatusAndCreatedAtBetween(status, from, to);
     }
+
+    @Override
+    public List<Booking> findByCreatedAtBetween(LocalDateTime from, LocalDateTime to) {
+        return springDataBookingRepository.findByCreatedAtBetween(from, to)
+                .stream()
+                .map(bookingMapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/SpringDataBookingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/infrastructure/persistence/SpringDataBookingRepository.java
@@ -20,4 +20,6 @@ public interface SpringDataBookingRepository extends JpaRepository<BookingJpaEnt
 
     @Query("SELECT DISTINCT e.accommodationId FROM BookingJpaEntity e WHERE e.status = :status AND e.createdAt BETWEEN :from AND :to")
     List<Long> findDistinctAccommodationIdsByStatusAndCreatedAtBetween(@Param("status") BookingStatus status, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    List<BookingJpaEntity> findByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CountryRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CountryRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface CountryRepository {
     List<Country> findAllActive();
     Optional<Country> findById(Long id);
+    List<Country> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/CountryRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/CountryRepositoryAdapter.java
@@ -31,4 +31,12 @@ public class CountryRepositoryAdapter implements CountryRepository {
                 .map(countryMapper::toDomain);
     }
 
+    @Override
+    public List<Country> findAllByIdIn(List<Long> ids) {
+        return springDataRepository.findAllByIdIn(ids)
+                .stream()
+                .map(countryMapper::toDomain)
+                .toList();
+    }
+
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCountryRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCountryRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface SpringDataCountryRepository extends JpaRepository<CountryJpaEntity, Long> {
     List<CountryJpaEntity> findByActiveTrue();
+    List<CountryJpaEntity> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/domain/repository/PaymentRepository.java
@@ -29,4 +29,6 @@ public interface PaymentRepository {
             PaymentType paymentType,
             PaymentStatus status
     );
+
+    List<Payment> findByBookingIdInAndStatus(List<Long> bookingIds, PaymentStatus status);
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
@@ -93,4 +93,12 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
                 status
         );
     }
+
+    @Override
+    public List<Payment> findByBookingIdInAndStatus(List<Long> bookingIds, PaymentStatus status) {
+        return springDataPaymentRepository.findByBookingIdInAndStatus(bookingIds, status)
+                .stream()
+                .map(paymentMapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/SpringDataPaymentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/infrastructure/persistence/SpringDataPaymentRepository.java
@@ -26,4 +26,6 @@ public interface SpringDataPaymentRepository extends JpaRepository<PaymentJpaEnt
             PaymentType paymentType,
             PaymentStatus status
     );
+
+    List<PaymentJpaEntity> findByBookingIdInAndStatus(List<Long> bookingIds, PaymentStatus status);
 }

--- a/src/main/java/com/kidmily/algoga_server/stats/application/service/CountryStatsService.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/application/service/CountryStatsService.java
@@ -1,0 +1,160 @@
+package com.kidmily.algoga_server.stats.application.service;
+
+import com.kidmily.algoga_server.accommodation.domain.model.Accommodation;
+import com.kidmily.algoga_server.accommodation.domain.repository.AccommodationRepository;
+import com.kidmily.algoga_server.booking.domain.model.Booking;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.lms.domain.model.Country;
+import com.kidmily.algoga_server.lms.domain.repository.CountryRepository;
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
+import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
+import com.kidmily.algoga_server.stats.application.usecase.CountryStatsUseCase;
+import com.kidmily.algoga_server.stats.presentation.api.response.CountryStatsItemResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.CountryTop10Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CountryStatsService implements CountryStatsUseCase {
+
+    private final BookingRepository bookingRepository;
+    private final PaymentRepository paymentRepository;
+    private final AccommodationRepository accommodationRepository;
+    private final CountryRepository countryRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CountryStatsItemResponse> getCountryStats(LocalDate from, LocalDate to, String search) {
+        List<CountryStatsItemResponse> stats = buildStats(from, to);
+
+        if (search != null && !search.isBlank()) {
+            String keyword = search.toLowerCase();
+            stats = stats.stream()
+                    .filter(s -> s.countryName().toLowerCase().contains(keyword))
+                    .toList();
+        }
+
+        return stats;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CountryTop10Response getTop10(LocalDate from, LocalDate to) {
+        List<CountryStatsItemResponse> stats = buildStats(from, to);
+
+        List<CountryStatsItemResponse> bookingTop10 = stats.stream()
+                .sorted(Comparator.comparingLong(CountryStatsItemResponse::bookingCount).reversed())
+                .limit(10)
+                .toList();
+
+        List<CountryStatsItemResponse> revenueTop10 = stats.stream()
+                .sorted(Comparator.comparingLong(CountryStatsItemResponse::revenue).reversed())
+                .limit(10)
+                .toList();
+
+        return new CountryTop10Response(bookingTop10, revenueTop10);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public byte[] getCsvExport(LocalDate from, LocalDate to) {
+        List<CountryStatsItemResponse> stats = buildStats(from, to);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        // BOM for Excel UTF-8
+        baos.write(new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF}, 0, 3);
+
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8))) {
+            writer.println("국가,회원가입 수,예약 건수,매출,점유율(%)");
+            for (CountryStatsItemResponse item : stats) {
+                writer.printf("%s,%d,%d,%d,%.2f%n",
+                        item.countryName(),
+                        item.signupCount(),
+                        item.bookingCount(),
+                        item.revenue(),
+                        item.shareRate());
+            }
+        }
+
+        return baos.toByteArray();
+    }
+
+    private List<CountryStatsItemResponse> buildStats(LocalDate from, LocalDate to) {
+        LocalDateTime start = from.atStartOfDay();
+        LocalDateTime end = to.plusDays(1).atStartOfDay();
+
+        // 기간 내 예약 목록
+        List<Booking> bookings = bookingRepository.findByCreatedAtBetween(start, end);
+        if (bookings.isEmpty()) {
+            return List.of();
+        }
+
+        // bookingId → accommodationId 맵
+        Map<Long, Long> bookingToAccommodation = bookings.stream()
+                .collect(Collectors.toMap(Booking::getId, Booking::getAccommodationId));
+
+        // accommodationId → countryId 맵 (중복 제거 후 조회)
+        Set<Long> accommodationIds = new HashSet<>(bookingToAccommodation.values());
+        Map<Long, Long> accommodationToCountry = accommodationIds.stream()
+                .map(id -> accommodationRepository.findById(id).orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(Accommodation::getId, Accommodation::getCountryId));
+
+        // 나라별 예약 건수 집계
+        Map<Long, Long> bookingCountByCountry = new HashMap<>();
+        for (Booking booking : bookings) {
+            Long countryId = accommodationToCountry.get(booking.getAccommodationId());
+            if (countryId != null) {
+                bookingCountByCountry.merge(countryId, 1L, Long::sum);
+            }
+        }
+
+        // 성공 결제 목록으로 나라별 매출 집계
+        List<Long> bookingIds = bookings.stream().map(Booking::getId).toList();
+        List<Payment> payments = paymentRepository.findByBookingIdInAndStatus(bookingIds, PaymentStatus.SUCCESS);
+
+        Map<Long, Long> revenueByCountry = new HashMap<>();
+        for (Payment payment : payments) {
+            Long accommodationId = bookingToAccommodation.get(payment.getBookingId());
+            if (accommodationId == null) continue;
+            Long countryId = accommodationToCountry.get(accommodationId);
+            if (countryId == null) continue;
+            revenueByCountry.merge(countryId, (long) payment.getAmount(), Long::sum);
+        }
+
+        long totalRevenue = revenueByCountry.values().stream().mapToLong(Long::longValue).sum();
+
+        // 국가 ID 목록 (예약 또는 매출이 있는 모든 나라) — 한 번에 조회 (N+1 방지)
+        Set<Long> countryIdSet = new HashSet<>();
+        countryIdSet.addAll(bookingCountByCountry.keySet());
+        countryIdSet.addAll(revenueByCountry.keySet());
+
+        List<Long> countryIds = new ArrayList<>(countryIdSet);
+        Map<Long, Country> countryMap = countryRepository.findAllByIdIn(countryIds).stream()
+                .collect(Collectors.toMap(Country::getId, c -> c));
+
+        return countryIds.stream()
+                .map(countryId -> {
+                    Country country = countryMap.get(countryId);
+                    String name = country != null ? country.getName() : "알 수 없음";
+                    String code = country != null ? country.getCountryCode() : "";
+                    long bookingCount = bookingCountByCountry.getOrDefault(countryId, 0L);
+                    long revenue = revenueByCountry.getOrDefault(countryId, 0L);
+                    return CountryStatsItemResponse.of(countryId, name, code, bookingCount, revenue, totalRevenue);
+                })
+                .sorted(Comparator.comparingLong(CountryStatsItemResponse::revenue).reversed())
+                .toList();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/application/usecase/CountryStatsUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/application/usecase/CountryStatsUseCase.java
@@ -1,0 +1,16 @@
+package com.kidmily.algoga_server.stats.application.usecase;
+
+import com.kidmily.algoga_server.stats.presentation.api.response.CountryStatsItemResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.CountryTop10Response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CountryStatsUseCase {
+
+    List<CountryStatsItemResponse> getCountryStats(LocalDate from, LocalDate to, String search);
+
+    CountryTop10Response getTop10(LocalDate from, LocalDate to);
+
+    byte[] getCsvExport(LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/CountryStatsController.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/CountryStatsController.java
@@ -1,0 +1,72 @@
+package com.kidmily.algoga_server.stats.presentation;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.stats.application.usecase.CountryStatsUseCase;
+import com.kidmily.algoga_server.stats.presentation.api.response.CountryStatsItemResponse;
+import com.kidmily.algoga_server.stats.presentation.api.response.CountryTop10Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/stats/countries")
+@Tag(name = "Country Stats", description = "나라별 인기도 분석 API")
+public class CountryStatsController {
+
+    private final CountryStatsUseCase countryStatsUseCase;
+
+    @GetMapping
+    @Operation(summary = "[어드민] 나라별 통계 목록", description = "국가별 예약 건수, 매출, 점유율을 조회합니다. search 파라미터로 국가명 검색 가능합니다.")
+    public ResponseEntity<ApiResponse<List<CountryStatsItemResponse>>> getCountryStats(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) String search
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                "COUNTRY_STATS",
+                "나라별 통계 조회에 성공했습니다.",
+                countryStatsUseCase.getCountryStats(from, to, search)
+        ));
+    }
+
+    @GetMapping("/top10")
+    @Operation(summary = "[어드민] 나라별 Top 10", description = "예약 건수 Top 10, 매출 Top 10 차트 데이터를 조회합니다.")
+    public ResponseEntity<ApiResponse<CountryTop10Response>> getTop10(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                "COUNTRY_TOP10",
+                "나라별 Top 10 조회에 성공했습니다.",
+                countryStatsUseCase.getTop10(from, to)
+        ));
+    }
+
+    @GetMapping("/csv")
+    @Operation(summary = "[어드민] 나라별 통계 CSV 다운로드")
+    public ResponseEntity<byte[]> getCsvExport(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        byte[] csv = countryStatsUseCase.getCsvExport(from, to);
+        String filename = URLEncoder.encode("나라별_인기도_통계.csv", StandardCharsets.UTF_8);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + filename)
+                .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+                .body(csv);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/CountryStatsItemResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/CountryStatsItemResponse.java
@@ -1,0 +1,17 @@
+package com.kidmily.algoga_server.stats.presentation.api.response;
+
+public record CountryStatsItemResponse(
+        Long countryId,
+        String countryName,
+        String countryCode,
+        long signupCount,
+        long bookingCount,
+        long revenue,
+        double shareRate
+) {
+    public static CountryStatsItemResponse of(Long countryId, String countryName, String countryCode,
+                                               long bookingCount, long revenue, long totalRevenue) {
+        double share = totalRevenue == 0 ? 0.0 : Math.round((double) revenue / totalRevenue * 10000.0) / 100.0;
+        return new CountryStatsItemResponse(countryId, countryName, countryCode, 0L, bookingCount, revenue, share);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/CountryTop10Response.java
+++ b/src/main/java/com/kidmily/algoga_server/stats/presentation/api/response/CountryTop10Response.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.stats.presentation.api.response;
+
+import java.util.List;
+
+public record CountryTop10Response(
+        List<CountryStatsItemResponse> bookingTop10,
+        List<CountryStatsItemResponse> revenueTop10
+) {
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
나라별 인기도 분석 통계 API를 구현합니다.
기간 내 예약 데이터를 기반으로 국가별 예약 건수·매출·점유율을 집계하며, Top 10 차트 및 CSV 다운로드를 지원합니다.
- `GET /api/v1/admin/stats/countries?from=&to=&search=` — 전체 목록 조회 (국가명 검색, 매출 내림차순 정렬)
- `GET /api/v1/admin/stats/countries/top10?from=&to=` — 예약 건수 Top 10 + 매출 Top 10
- `GET /api/v1/admin/stats/countries/csv?from=&to=` — CSV 다운로드 (BOM 포함, Excel 호환)
데이터 흐름: `Booking → Accommodation.countryId → lms.Country`
매출 기준: `Payment(status=SUCCESS)` 금액 합산
점유율: 해당 국가 매출 / 전체 매출 × 100
※ 회원가입 수는 User 도메인에 countryId 미존재로 0 반환 (추후 User 담당자 연동 예정)
## 🔗 Issue
Closes #217 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] GET /api/v1/admin/stats/countries?from=2025-01-01&to=2025-12-31` 응답에 국가별 예약 건수·매출·점유율 정상 반환 확인
- [ ]/top10` 응답에 `bookingTop10`, `revenueTop10` 각각 최대 10개 반환 확인
- [ ]/csv` 다운로드 시 Excel에서 한글 깨짐 없이 열리는지 확인
- [ ]해당 기간 예약 없을 때 빈 배열 반환 확인 (NPE 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 국가별 통계 조회 기능 추가 - 특정 기간의 예약 건수 및 매출 데이터를 국가별로 집계하여 조회 가능
  * 상위 10개 국가 순위 기능 추가 - 예약 건수와 매출 기준 상위 10개 국가 통계 제공
  * CSV 내보내기 기능 추가 - 국가별 통계를 CSV 파일로 다운로드 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->