### PR TITLE
[Feature] 관리자 전용 배너 상세 조회 기능 추가. (수정할 때 필요)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/banner/application/repository/BannerRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/application/repository/BannerRepository.java
@@ -1,4 +1,4 @@
-package com.kidmily.algoga_server.banner.domain.repository;
+package com.kidmily.algoga_server.banner.application.repository;
 
 import com.kidmily.algoga_server.banner.domain.model.Banner;
 import java.util.List;

--- a/src/main/java/com/kidmily/algoga_server/banner/application/service/BannerQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/application/service/BannerQueryService.java
@@ -2,6 +2,9 @@ package com.kidmily.algoga_server.banner.application.service;
 
 import com.kidmily.algoga_server.banner.application.usecase.BannerQueryUseCase;
 import com.kidmily.algoga_server.banner.domain.repository.BannerRepository;
+import com.kidmily.algoga_server.banner.exception.BannerErrorCode;
+import com.kidmily.algoga_server.banner.exception.BannerException;
+import com.kidmily.algoga_server.banner.presentation.api.response.AdminBannerResponse;
 import com.kidmily.algoga_server.banner.presentation.api.response.BannerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,10 +25,42 @@ public class BannerQueryService implements BannerQueryUseCase {
                 .map(banner -> new BannerResponse(
                         banner.getBannerId(),
                         banner.getImageUrl(),
-                        banner.getFileType().name(), // 🌟 Enum의 문자열("IMAGE" 또는 "VIDEO") 매핑
+                        banner.getFileType().name(),
                         banner.getLinkUrl(),
                         banner.getText()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    // 🔥 관리자용 전체 배너 조회 기능
+    @Override
+    public List<AdminBannerResponse> getAllBanners() {
+        return bannerRepository.findAllBanners().stream()
+                .map(banner -> new AdminBannerResponse(
+                        banner.getBannerId(),
+                        banner.getImageUrl(),
+                        banner.getFileType().name(),
+                        banner.getLinkUrl(),
+                        banner.getText(),
+                        banner.isVisible(),
+                        banner.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    // 🔥 관리자용 배너 상세 조회 기능 (수정 폼 데이터용)
+    @Override
+    public AdminBannerResponse getBannerDetail(Long bannerId) {
+        return bannerRepository.findById(bannerId)
+                .map(banner -> new AdminBannerResponse(
+                        banner.getBannerId(),
+                        banner.getImageUrl(),
+                        banner.getFileType().name(),
+                        banner.getLinkUrl(),
+                        banner.getText(),
+                        banner.isVisible(),
+                        banner.getCreatedAt()
+                ))
+                .orElseThrow(() -> new BannerException(BannerErrorCode.BANNER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/banner/application/usecase/BannerQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/application/usecase/BannerQueryUseCase.java
@@ -1,8 +1,13 @@
 package com.kidmily.algoga_server.banner.application.usecase;
 
+import com.kidmily.algoga_server.banner.presentation.api.response.AdminBannerResponse;
 import com.kidmily.algoga_server.banner.presentation.api.response.BannerResponse;
 import java.util.List;
 
 public interface BannerQueryUseCase {
     List<BannerResponse> getActiveBanners();
+    
+    // 🔥 관리자용 조회 메서드 추가
+    List<AdminBannerResponse> getAllBanners();
+    AdminBannerResponse getBannerDetail(Long bannerId);
 }

--- a/src/main/java/com/kidmily/algoga_server/banner/infrastructure/persistence/BannerRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/infrastructure/persistence/BannerRepositoryAdapter.java
@@ -21,30 +21,32 @@ public class BannerRepositoryAdapter implements BannerRepository {
 
     @Override
     public Banner save(Banner banner) {
-        // Domain -> Entity 변환 (fileType 포함되어 자동 변환됨)
         BannerEntity entity = bannerMapper.toEntity(banner);
-
-        // DB 저장 후 반환된 Entity -> Domain 재변환
         return bannerMapper.toDomain(jpaBannerRepository.save(entity));
     }
 
     @Override
     public Optional<Banner> findById(Long bannerId) {
-        // 단건 조회 후 존재하면 Domain으로 변환하여 반환
         return jpaBannerRepository.findById(bannerId)
                 .map(bannerMapper::toDomain);
     }
 
     @Override
     public void deleteById(Long bannerId) {
-        // PK(ID)를 기반으로 삭제
         jpaBannerRepository.deleteById(bannerId);
     }
 
     @Override
     public List<Banner> findVisibleBanners() {
-        // 공개 상태인 배너만 최신순으로 가져와서 Domain 리스트로 변환
         return jpaBannerRepository.findByIsVisibleTrueOrderByCreatedAtDesc().stream()
+                .map(bannerMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    // 🔥 관리자용 전체 조회 구현 추가
+    @Override
+    public List<Banner> findAllBanners() {
+        return jpaBannerRepository.findAllByOrderByCreatedAtDesc().stream()
                 .map(bannerMapper::toDomain)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/kidmily/algoga_server/banner/infrastructure/persistence/repository/JpaBannerRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/infrastructure/persistence/repository/JpaBannerRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface JpaBannerRepository extends JpaRepository<BannerEntity, Long> {
-    // 공개 상태인 배너만 최신순으로 가져오기
+    // 공개 상태인 배너만 최신순으로 가져오기 (기존)
     List<BannerEntity> findByIsVisibleTrueOrderByCreatedAtDesc();
+
+    // 모든 배너 최신순으로 가져오기 (관리자용 추가)
+    List<BannerEntity> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/kidmily/algoga_server/banner/presentation/api/BannerController.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/presentation/api/BannerController.java
@@ -8,6 +8,7 @@ import com.kidmily.algoga_server.banner.application.usecase.BannerQueryUseCase;
 import com.kidmily.algoga_server.banner.exception.BannerErrorCode;
 import com.kidmily.algoga_server.banner.presentation.api.request.CreateBannerRequest;
 import com.kidmily.algoga_server.banner.presentation.api.request.UpdateBannerRequest;
+import com.kidmily.algoga_server.banner.presentation.api.response.AdminBannerResponse;
 import com.kidmily.algoga_server.banner.presentation.api.response.BannerResponse;
 import com.kidmily.algoga_server.banner.presentation.api.response.CreateBannerResponse;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
@@ -34,10 +35,34 @@ public class BannerController {
     private final BannerQueryUseCase bannerQueryUseCase;
 
     @GetMapping
-    @Operation(summary = "배너 화면 조회")
+    @Operation(summary = "배너 화면 조회 (사용자용)")
     public ResponseEntity<ApiResponse<List<BannerResponse>>> getBanners() {
         List<BannerResponse> banners = bannerQueryUseCase.getActiveBanners();
         return ResponseEntity.ok(ApiResponse.success("BANNER_LIST_FOUND", "배너 조회에 성공했습니다.", banners));
+    }
+
+    // 🔥 관리자용 전체 배너 조회 추가
+    @PreAuthorize("hasAnyRole('CS_MANAGER', 'SUPER_ADMIN')")
+    @GetMapping("/admin/all")
+    @Operation(summary = "전체 배너 조회 (관리자용)", description = "비활성화된 배너를 포함한 모든 배너를 최신순으로 조회합니다.")
+    public ResponseEntity<ApiResponse<List<AdminBannerResponse>>> getAllAdminBanners(
+            @CurrentManager Long managerId
+    ) {
+        List<AdminBannerResponse> banners = bannerQueryUseCase.getAllBanners();
+        return ResponseEntity.ok(ApiResponse.success("ADMIN_BANNER_LIST_FOUND", "관리자용 전체 배너 조회에 성공했습니다.", banners));
+    }
+
+    // 🔥 관리자용 배너 상세 조회 추가
+    @PreAuthorize("hasAnyRole('CS_MANAGER', 'SUPER_ADMIN')")
+    @GetMapping("/admin/{bannerId}")
+    @Operation(summary = "배너 상세 조회 (관리자용)", description = "수정 페이지 등에서 기존 배너의 데이터를 불러올 때 사용합니다.")
+    @ApiErrorCodeExample(domain = BannerErrorCode.class, value = {"BANNER_NOT_FOUND"})
+    public ResponseEntity<ApiResponse<AdminBannerResponse>> getAdminBannerDetail(
+            @PathVariable Long bannerId,
+            @CurrentManager Long managerId
+    ) {
+        AdminBannerResponse banner = bannerQueryUseCase.getBannerDetail(bannerId);
+        return ResponseEntity.ok(ApiResponse.success("ADMIN_BANNER_DETAIL_FOUND", "관리자용 배너 상세 조회에 성공했습니다.", banner));
     }
 
     @PreAuthorize("hasAnyRole('CS_MANAGER', 'SUPER_ADMIN')")

--- a/src/main/java/com/kidmily/algoga_server/banner/presentation/api/response/AdminBannerResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/presentation/api/response/AdminBannerResponse.java
@@ -1,0 +1,29 @@
+package com.kidmily.algoga_server.banner.presentation.api.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+@Schema(description = "관리자용 배너 상세 및 전체 목록 조회 응답 DTO")
+public record AdminBannerResponse(
+        @Schema(description = "배너 ID", example = "1")
+        Long bannerId,
+
+        @Schema(description = "배너 이미지/영상 URL", example = "https://algoga-bucket.kro.kr/.../abc.mp4")
+        String imageUrl,
+
+        @Schema(description = "파일 타입 (IMAGE, VIDEO 등)", example = "VIDEO")
+        String fileType,
+
+        @Schema(description = "배너 클릭 시 이동할 링크 URL", example = "https://algoga.com/event")
+        String linkUrl,
+
+        @Schema(description = "배너 대체 텍스트 또는 설명", example = "여름 맞이 특가 이벤트 배너")
+        String text,
+
+        @Schema(description = "배너 공개 여부 (true: 공개, false: 비공개)", example = "true")
+        Boolean isVisible,
+
+        @Schema(description = "배너 생성 일시")
+        Instant createdAt
+) {
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
배너 상세 조회 및 전체 조회 기능 추가
/api/v1/banner/admin/{bannerId}
/api/v1/banner/admin/all
## 🔗 Issue
Closes #230 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 배너 전체 조회
- [ ] 배너 상세 조회


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 관리자가 모든 배너를 조회하고 개별 배너의 상세 정보를 확인할 수 있는 새로운 기능 추가
  * 관리자 전용 API 엔드포인트 추가로 배너 공개 여부 및 생성일 등 상세 정보 확인 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->