### PR TITLE
[FIX] notice - paging

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/notice/application/service/NoticeQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/application/service/NoticeQueryService.java
@@ -1,5 +1,5 @@
 package com.kidmily.algoga_server.notice.application.service;
-
+import com.kidmily.algoga_server.global.common.api.response.PageResponse; // 🌟 추가
 import com.kidmily.algoga_server.notice.application.usecase.NoticeQueryUseCase;
 import com.kidmily.algoga_server.notice.domain.model.Notice;
 import com.kidmily.algoga_server.notice.domain.repository.NoticeRepository;
@@ -9,6 +9,7 @@ import com.kidmily.algoga_server.notice.presentation.NoticeTagType;
 import com.kidmily.algoga_server.notice.presentation.api.response.NoticeListResponse;
 import com.kidmily.algoga_server.notice.presentation.api.response.NoticeMainResponse;
 import com.kidmily.algoga_server.notice.presentation.api.response.NoticeResponse;
+import org.springframework.data.domain.Page; // 🌟 추가
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class NoticeQueryService implements NoticeQueryUseCase {
+public class    NoticeQueryService implements NoticeQueryUseCase {
 
     private final NoticeRepository noticeRepository;
     private static final int PAGE_SIZE = 10;
@@ -46,30 +47,31 @@ public class NoticeQueryService implements NoticeQueryUseCase {
     }
 
     @Override
-    public List<NoticeListResponse> getNotices(String tag, Integer index) {
-        List<Notice> notices;
+    public PageResponse<NoticeListResponse> getNotices(String tag, Integer index) {
+        Page<Notice> noticePage;
         int pageIndex = Math.max(0, index - 1);
 
         try {
             if ("ALL".equalsIgnoreCase(tag)) {
-                notices = noticeRepository.findAll(pageIndex, PAGE_SIZE);
+                noticePage = noticeRepository.findAll(pageIndex, PAGE_SIZE);
             } else {
                 NoticeTagType tagType = NoticeTagType.valueOf(tag.toUpperCase());
-                notices = noticeRepository.findByType(tagType, pageIndex, PAGE_SIZE);
+                noticePage = noticeRepository.findByType(tagType, pageIndex, PAGE_SIZE);
             }
         } catch (IllegalArgumentException e) {
-            // 태그 파싱 에러 등을 잡아서 NoticeException으로 변환
             throw new NoticeException(NoticeErrorCode.INVALID_TAG_OR_INDEX);
         }
 
-        return notices.stream()
-                .map(notice -> new NoticeListResponse(
-                        notice.getNoticeId(),
-                        notice.getType(),
-                        notice.getTitle(),
-                        DATE_FORMATTER.format(notice.getCreatedAt())
-                ))
-                .collect(Collectors.toList());
+        // 도메인 Page 객체를 응답 DTO Page 객체로 변환
+        Page<NoticeListResponse> responsePage = noticePage.map(notice -> new NoticeListResponse(
+                notice.getNoticeId(),
+                notice.getType(),
+                notice.getTitle(),
+                DATE_FORMATTER.format(notice.getCreatedAt())
+        ));
+
+        // 글로벌 공통 응답으로 Wrapping 하여 반환
+        return PageResponse.from(responsePage);
     }
 
     @Override

--- a/src/main/java/com/kidmily/algoga_server/notice/application/usecase/NoticeQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/application/usecase/NoticeQueryUseCase.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.notice.application.usecase;
 
+import com.kidmily.algoga_server.global.common.api.response.PageResponse; // 🌟 추가
 import com.kidmily.algoga_server.notice.presentation.NoticeTagType;
 import com.kidmily.algoga_server.notice.presentation.api.response.NoticeListResponse;
 import com.kidmily.algoga_server.notice.presentation.api.response.NoticeMainResponse;
@@ -8,9 +9,10 @@ import java.util.List;
 
 public interface NoticeQueryUseCase {
     List<NoticeMainResponse> getNoticeMain();
-    List<NoticeListResponse> getNotices(String tag, Integer index);
+    
+    // 🌟 반환 타입 변경
+    PageResponse<NoticeListResponse> getNotices(String tag, Integer index);
+    
     NoticeResponse getNotice(Long noticeId);
-
-    // 🔥 프론트엔드 UI 구성을 위한 태그 목록 조회 메서드 추가
     List<NoticeTagType> getAllNoticeTags();
 }

--- a/src/main/java/com/kidmily/algoga_server/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/domain/repository/NoticeRepository.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.notice.domain.repository;
 
 import com.kidmily.algoga_server.notice.domain.model.Notice;
 import com.kidmily.algoga_server.notice.presentation.NoticeTagType;
+import org.springframework.data.domain.Page; // 🌟 추가
 
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,8 @@ public interface NoticeRepository {
     void deleteById(Long noticeId);
 
     List<Notice> findTop3Notices();
-    List<Notice> findAll(int page, int size);
-    List<Notice> findByType(NoticeTagType type, int page, int size);
+    
+    // 🌟 List 대신 Page 반환
+    Page<Notice> findAll(int page, int size);
+    Page<Notice> findByType(NoticeTagType type, int page, int size);
 }

--- a/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/NoticeRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/NoticeRepositoryAdapter.java
@@ -7,6 +7,7 @@ import com.kidmily.algoga_server.notice.infrastructure.persistence.entity.Notice
 import com.kidmily.algoga_server.notice.infrastructure.persistence.repository.JpaNoticeRepository;
 import com.kidmily.algoga_server.notice.presentation.NoticeTagType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -24,10 +25,7 @@ public class NoticeRepositoryAdapter implements NoticeRepository {
 
     @Override
     public Notice save(Notice notice) {
-        // MapStruct가 notice.getType() 값을 NoticeEntity의 type 필드로 자동 매핑합니다.
         NoticeEntity entity = noticeMapper.toEntity(notice);
-
-        // noticeId가 이미 존재하므로 JPA가 기존 레코드를 찾아 변경된 필드(type, title, content)를 수정합니다.
         return noticeMapper.toDomain(jpaNoticeRepository.save(entity));
     }
 
@@ -48,19 +46,19 @@ public class NoticeRepositoryAdapter implements NoticeRepository {
                 .collect(Collectors.toList());
     }
 
+    // 🌟 Page 객체 매핑
     @Override
-    public List<Notice> findAll(int page, int size) {
+    public Page<Notice> findAll(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return jpaNoticeRepository.findAllByOrderByCreatedAtDesc(pageable).stream()
-                .map(noticeMapper::toDomain)
-                .collect(Collectors.toList());
+        return jpaNoticeRepository.findAllByOrderByCreatedAtDesc(pageable)
+                .map(noticeMapper::toDomain);
     }
 
+    // 🌟 Page 객체 매핑
     @Override
-    public List<Notice> findByType(NoticeTagType type, int page, int size) {
+    public Page<Notice> findByType(NoticeTagType type, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return jpaNoticeRepository.findByTypeOrderByCreatedAtDesc(type, pageable).stream()
-                .map(noticeMapper::toDomain)
-                .collect(Collectors.toList());
+        return jpaNoticeRepository.findByTypeOrderByCreatedAtDesc(type, pageable)
+                .map(noticeMapper::toDomain);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/repository/JpaNoticeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/repository/JpaNoticeRepository.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.notice.infrastructure.persistence.repository;
 
 import com.kidmily.algoga_server.notice.infrastructure.persistence.entity.NoticeEntity;
 import com.kidmily.algoga_server.notice.presentation.NoticeTagType;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +10,8 @@ import java.util.List;
 
 public interface JpaNoticeRepository extends JpaRepository<NoticeEntity, Long> {
     List<NoticeEntity> findTop3ByOrderByCreatedAtDesc();
-    List<NoticeEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
-    List<NoticeEntity> findByTypeOrderByCreatedAtDesc(NoticeTagType type, Pageable pageable);
+    
+    // 🌟 List 대신 Page 로 반환 타입 변경
+    Page<NoticeEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<NoticeEntity> findByTypeOrderByCreatedAtDesc(NoticeTagType type, Pageable pageable);
 }

--- a/src/main/java/com/kidmily/algoga_server/notice/presentation/api/PublicNoticeController.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/presentation/api/PublicNoticeController.java
@@ -1,5 +1,5 @@
 package com.kidmily.algoga_server.notice.presentation.api;
-
+import com.kidmily.algoga_server.global.common.api.response.PageResponse;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.notice.application.usecase.NoticeQueryUseCase;
@@ -42,11 +42,11 @@ public class PublicNoticeController {
     }
 
     @GetMapping("/{tag}/{index}")
-    @Operation(summary = "공지사항 전체 조회", description = "태그와 페이지 번호를 기반으로 공지사항 목록을 조회합니다.")
+    @Operation(summary = "공지사항 전체 조회", description = "태그와 페이지 번호를 기반으로 공지사항 목록을 한 페이지당 10개씩 조회합니다. 스웨거 응답 예시에서 totalPages(최대 인덱스)와 totalElements 등의 페이징 정보를 확인할 수 있습니다.") // 🌟 설명 추가
     @ApiErrorCodeExample(domain = NoticeErrorCode.class, value = {"INVALID_TAG_OR_INDEX"})
-    public ResponseEntity<ApiResponse<List<NoticeListResponse>>> getNotices(
-            @Parameter(description = "조회할 태그명 (ALL, NOTICE, EVENT, MAINTENANCE 등)", example = "ALL") @PathVariable String tag,
-            @Parameter(description = "조회할 페이지 번호 (1부터 시작)", example = "1") @PathVariable Integer index
+    public ResponseEntity<ApiResponse<PageResponse<NoticeListResponse>>> getNotices( // 🌟 PageResponse 로 타입 변경
+                                                                                     @Parameter(description = "조회할 태그명 (ALL, NOTICE, EVENT, MAINTENANCE 등)", example = "ALL") @PathVariable String tag,
+                                                                                     @Parameter(description = "조회할 페이지 번호 (1부터 시작)", example = "1") @PathVariable Integer index
     ) {
         return ResponseEntity.ok(ApiResponse.success(
                 "NOTICE_LIST_FOUND", "공지사항 전체 조회에 성공했습니다.", noticeQueryUseCase.getNotices(tag, index)


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
공지사항 전체조회 수정

## 🔗 Issue
Closes #247 

---
content: 현재 페이지에 해당하는 실체 데이터 목록입니다. (예: 공지사항 10개 리스트, 문의사항 8개 리스트 등)

page: 현재 페이지의 번호입니다. (Spring Data JPA 내부적으로는 0부터 시작합니다.)

size: 한 페이지에 보여줄 데이터의 최대 개수입니다. (공지사항 전체 조회 시 10으로 고정됩니다.)

totalElements: 조건에 부합하는 데이터베이스 내의 전체 데이터 총개수입니다.

totalPages: 전체 데이터를 size로 나누어 계산된 총 페이지 수(최대 인덱스)입니다. 프론트엔드에서 하단 페이지 네비게이션 블록을 그리거나 최대 인덱스를 제한할 때 사용합니다.

first: 현재 페이지가 첫 번째 페이지인지 여부를 나타내는 불리언(true/false) 값입니다.

last: 현재 페이지가 마지막 페이지인지 여부를 나타내는 불리언(true/false) 값입니다. true라면 다음 페이지 요청 버튼을 비활성화할 수 있습니다.



## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 공지사항 전체 조회 수정. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기능 개선**
  * 공지사항 목록 조회 API 응답 형식이 변경되어 페이지네이션 정보를 포함합니다. 공지사항 목록과 함께 현재 페이지 번호, 총 페이지 수, 전체 항목 수, 페이지당 항목 수 등의 페이지네이션 메타데이터가 함께 제공됩니다. 전체 공지사항 조회와 태그 기반 필터링 조회에 모두 적용되며, 페이지 번호 파라미터로 원하는 페이지의 공지사항을 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->