### PR TITLE
[Feature] 수강생 강의실 구현 및 LMS/Benefit 정책 반영

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/benefit/application/command/CreateCouponPolicyCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/command/CreateCouponPolicyCommand.java
@@ -5,7 +5,6 @@ public record CreateCouponPolicyCommand(
         Long managerId,
         String couponName,
         String discountType,
-        int discountValue,
-        int validDays
+        int discountValue
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/command/UpdateCouponPolicyCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/command/UpdateCouponPolicyCommand.java
@@ -5,7 +5,6 @@ public record UpdateCouponPolicyCommand(
         Long couponPolicyId,
         String couponName,
         String discountType,
-        int discountValue,
-        int validDays
+        int discountValue
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/service/CouponPolicyService.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/service/CouponPolicyService.java
@@ -34,8 +34,7 @@ public class CouponPolicyService implements CouponPolicyUseCase {
         validateCourse(command.courseId());
         validateCouponPolicy(
                 command.discountType(),
-                command.discountValue(),
-                command.validDays()
+                command.discountValue()
         );
         validateCouponNameNotDuplicated(command.courseId(), command.couponName());
 
@@ -44,8 +43,7 @@ public class CouponPolicyService implements CouponPolicyUseCase {
                 command.managerId(),
                 command.couponName(),
                 command.discountType().toUpperCase(),
-                command.discountValue(),
-                command.validDays()
+                command.discountValue()
         );
 
         CouponPolicy savedCouponPolicy = couponPolicyRepository.save(couponPolicy);
@@ -83,8 +81,7 @@ public class CouponPolicyService implements CouponPolicyUseCase {
         validateCourse(command.courseId());
         validateCouponPolicy(
                 command.discountType(),
-                command.discountValue(),
-                command.validDays()
+                command.discountValue()
         );
         validateCouponNameNotDuplicated(
                 command.courseId(),
@@ -98,7 +95,7 @@ public class CouponPolicyService implements CouponPolicyUseCase {
                 command.couponName(),
                 command.discountType().toUpperCase(),
                 command.discountValue(),
-                command.validDays()
+                CouponPolicy.DEFAULT_VALID_DAYS
         ).orElseThrow(() -> {
             log.warn("[Coupon Policy Command] 쿠폰 정책 수정 실패. 존재하지 않거나 비활성화된 쿠폰 정책입니다. courseId={}, couponPolicyId={}",
                     command.courseId(), command.couponPolicyId());
@@ -162,8 +159,7 @@ public class CouponPolicyService implements CouponPolicyUseCase {
 
     private void validateCouponPolicy(
             String discountType,
-            int discountValue,
-            int validDays
+            int discountValue
     ) {
         if (discountType == null || discountType.isBlank()) {
             throw new BenefitException(BenefitErrorCode.INVALID_COUPON_POLICY);
@@ -189,10 +185,5 @@ public class CouponPolicyService implements CouponPolicyUseCase {
             throw new BenefitException(BenefitErrorCode.INVALID_COUPON_POLICY);
         }
 
-        if (validDays <= 0) {
-            log.warn("[Coupon Policy] 쿠폰 정책 검증 실패. 유효기간은 1일 이상이어야 합니다. validDays={}",
-                    validDays);
-            throw new BenefitException(BenefitErrorCode.INVALID_COUPON_POLICY);
-        }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/domain/model/CouponPolicy.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/domain/model/CouponPolicy.java
@@ -15,7 +15,7 @@ public class CouponPolicy {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    private static final int DEFAULT_VALID_DAYS = 30;
+    public static final int DEFAULT_VALID_DAYS = 30;
 
     private CouponPolicy(
             Long id,
@@ -46,8 +46,7 @@ public class CouponPolicy {
             Long managerId,
             String couponName,
             String discountType,
-            int discountValue,
-            int validDays
+            int discountValue
     ) {
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/kidmily/algoga_server/benefit/exception/BenefitExceptionAdvice.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/exception/BenefitExceptionAdvice.java
@@ -1,9 +1,16 @@
 package com.kidmily.algoga_server.benefit.exception;
 
 import com.kidmily.algoga_server.global.exception.CommonExceptionAdvice;
+import com.kidmily.algoga_server.global.common.api.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
 
 @Slf4j
 @RestControllerAdvice(basePackages = "com.kidmily.algoga_server.benefit.presentation.api")
@@ -12,5 +19,22 @@ public class BenefitExceptionAdvice implements CommonExceptionAdvice {
     @Override
     public Logger getLogger() {
         return log;
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        String traceId = getOrCreateTraceId();
+
+        log.warn("[AccessDenied] traceId: {}, message: {}", traceId, e.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.FORBIDDEN.value(),
+                "GLOBAL_005",
+                "접근 권한이 없습니다.",
+                traceId
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/persistence/entity/UserCouponJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/persistence/entity/UserCouponJpaEntity.java
@@ -29,10 +29,10 @@ public class UserCouponJpaEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "lecture_id")
+    @Column(name = "lecture_id", nullable = false)
     private Long courseId;
 
-    @Column(name = "coupon_policy_id")
+    @Column(name = "coupon_policy_id", nullable = false)
     private Long couponPolicyId;
 
     @Column(name = "coupon_name", nullable = false, length = 100)

--- a/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/persistence/entity/UserCouponJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/persistence/entity/UserCouponJpaEntity.java
@@ -29,10 +29,10 @@ public class UserCouponJpaEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "lecture_id", nullable = false)
+    @Column(name = "lecture_id")
     private Long courseId;
 
-    @Column(name = "coupon_policy_id", nullable = false)
+    @Column(name = "coupon_policy_id")
     private Long couponPolicyId;
 
     @Column(name = "coupon_name", nullable = false, length = 100)

--- a/src/main/java/com/kidmily/algoga_server/benefit/presentation/api/admin/AdminCouponController.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/presentation/api/admin/AdminCouponController.java
@@ -63,8 +63,7 @@ public class AdminCouponController {
                 managerId,
                 request.couponName(),
                 request.discountType(),
-                request.discountValue(),
-                request.validDays()
+                request.discountValue()
         );
 
         var couponPolicy = couponPolicyUseCase.createCouponPolicy(command);
@@ -129,8 +128,7 @@ public class AdminCouponController {
                 couponPolicyId,
                 request.couponName(),
                 request.discountType(),
-                request.discountValue(),
-                request.validDays()
+                request.discountValue()
         );
 
         var couponPolicy = couponPolicyUseCase.updateCouponPolicy(command);

--- a/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/07-coupon-reward.http
+++ b/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/07-coupon-reward.http
@@ -9,8 +9,8 @@
 ### ==========================================================
 
 @host = http://localhost:15000
-@courseId = 76
-@couponPolicyId = 14
+@courseId = 54
+@couponPolicyId = 16
 
 
 ### Content manager login
@@ -27,6 +27,9 @@ Accept: application/json
     if (response.status === 200) {
         client.global.set("managerAccessToken", response.body.data.accessToken);
         client.log("managerAccessToken saved");
+    } else {
+        client.global.clear("managerAccessToken");
+        client.log("manager login failed; stale token cleared");
     }
 %}
 
@@ -57,10 +60,9 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "couponName": "Course completion discount coupon22",
+  "couponName": "Course completion  discount coupon22",
   "discountType": "RATE",
-  "discountValue": 10,
-  "validDays": 30
+  "discountValue": 10
 }
 
 
@@ -79,8 +81,7 @@ Accept: application/json
 {
   "couponName": "Updated course completion discount coupon",
   "discountType": "RATE",
-  "discountValue": 15,
-  "validDays": 30
+  "discountValue": 15
 }
 
 
@@ -93,8 +94,7 @@ Accept: application/json
 {
   "couponName": "Course completion discount coupon",
   "discountType": "RATE",
-  "discountValue": 15,
-  "validDays": 30
+  "discountValue": 15
 }
 
 

--- a/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/11-couppon-statistics.http
+++ b/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/11-couppon-statistics.http
@@ -1,22 +1,7 @@
 ### ==========================================================
 ### 11. 쿠폰 통계
-### 관리자 API라서 매니저 토큰 필요
-### 자동 변수 안 될 때 쓰는 수동 토큰 버전
+### 먼저 LMS의 01-auth-map.http에서 콘텐츠 매니저 로그인 실행 후 사용
 ### ==========================================================
-
-@managerAccessToken = 여기에_매니저_accessToken_붙여넣기
-
-
-### 콘텐츠 매니저 로그인
-### 실행 후 응답의 data.accessToken을 복사해서 위 managerAccessToken에 붙여넣기
-POST http://localhost:15000/api/v1/admin/auth/login
-Content-Type: application/json
-Accept: application/json
-
-{
-  "loginId": "content_manager_01",
-  "password": "password123!"
-}
 
 
 ### 쿠폰 통계 - 전체 조회

--- a/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/CreateCouponPolicyRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/CreateCouponPolicyRequest.java
@@ -12,18 +12,14 @@ public record CreateCouponPolicyRequest(
         @NotBlank(message = "쿠폰명은 필수입니다.")
         String couponName,
 
-        @Schema(description = "할인 타입. RATE는 정률, AMOUNT는 정액", example = "RATE")
+        @Schema(description = "할인 타입. RATE는 정률, AMOUNT는 정액", example = "RATE",
+                allowableValues = {"RATE", "AMOUNT"})
         @NotBlank(message = "할인 타입은 필수입니다.")
         String discountType,
 
         @Schema(description = "할인 값. RATE면 퍼센트, AMOUNT면 금액", example = "10")
         @NotNull(message = "할인 값은 필수입니다.")
         @Positive(message = "할인 값은 0보다 커야 합니다.")
-        Integer discountValue,
-
-        @Schema(description = "쿠폰 유효기간 일수", example = "30")
-        @NotNull(message = "쿠폰 유효기간은 필수입니다.")
-        @Positive(message = "쿠폰 유효기간은 0보다 커야 합니다.")
-        Integer validDays
+        Integer discountValue
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/UpdateCouponPolicyRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/presentation/request/UpdateCouponPolicyRequest.java
@@ -12,18 +12,14 @@ public record UpdateCouponPolicyRequest(
         @NotBlank(message = "쿠폰명은 필수입니다.")
         String couponName,
 
-        @Schema(description = "할인 타입. RATE는 정률, AMOUNT는 정액", example = "RATE")
+        @Schema(description = "할인 타입. RATE는 정률, AMOUNT는 정액", example = "RATE",
+                allowableValues = {"RATE", "AMOUNT"})
         @NotBlank(message = "할인 타입은 필수입니다.")
         String discountType,
 
         @Schema(description = "할인 값. RATE면 퍼센트, AMOUNT면 금액", example = "10")
         @NotNull(message = "할인 값은 필수입니다.")
         @Positive(message = "할인 값은 0보다 커야 합니다.")
-        Integer discountValue,
-
-        @Schema(description = "쿠폰 유효기간 일수", example = "30")
-        @NotNull(message = "쿠폰 유효기간은 필수입니다.")
-        @Positive(message = "쿠폰 유효기간은 0보다 커야 합니다.")
-        Integer validDays
+        Integer discountValue
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseClassroomChapterResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseClassroomChapterResult.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+public record CourseClassroomChapterResult(
+        Long chapterId,
+        String title,
+        String videoUrl,
+        int durationSeconds,
+        int chapterOrder,
+        int watchedSeconds,
+        int progressRate,
+        boolean completed,
+        boolean locked
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseClassroomResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseClassroomResult.java
@@ -1,0 +1,13 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CourseClassroomResult(
+        Long courseId,
+        String title,
+        LocalDateTime accessExpiresAt,
+        boolean quizAvailable,
+        List<CourseClassroomChapterResult> chapters
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
@@ -159,13 +159,7 @@ public class CourseService implements CourseUseCase {
 
     @Override
     public void deleteCourse(Long courseId) {
-        Course course = findCourse(courseId);
-
-        if (course.getThumbnailUrl() != null && !course.getThumbnailUrl().isBlank()) {
-            fileStoragePort.deleteFile(storageSettings.getBucketName(), course.getThumbnailUrl());
-        }
-
-        deleteCourseFiles(course.getFileUrls());
+        findCourse(courseId);
 
         if (!courseRepository.softDelete(courseId)) {
             throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
@@ -174,7 +168,8 @@ public class CourseService implements CourseUseCase {
 
     @Override
     public CourseCompletionResult completeCourse(CompleteCourseCommand command) {
-        findCourse(command.courseId());
+        validateAccessibleEnrollment(command.userId(), command.courseId());
+        findCourseIncludingDeleted(command.courseId());
         validateNotCompleted(command.userId(), command.courseId());
         validateAllChaptersCompleted(command.userId(), command.courseId());
         validateQuizSubmitted(command.userId(), command.courseId());
@@ -223,11 +218,11 @@ public class CourseService implements CourseUseCase {
     @Override
     @Transactional(readOnly = true)
     public CourseClassroomResult getCourseClassroom(Long userId, Long courseId) {
-        Course course = findCourse(courseId);
-
         var enrollment = enrollmentRepository.findByUserIdAndCourseId(userId, courseId)
                 .filter(value -> value.isAccessibleAt(LocalDateTime.now()))
                 .orElseThrow(() -> new LmsException(LmsErrorCode.NOT_ENROLLED));
+
+        Course course = findCourseIncludingDeleted(courseId);
 
         List<Chapter> chapters = chapterRepository.findByCourseId(courseId);
         List<LearningProgress> progresses = learningProgressRepository.findByUserIdAndCourseId(userId, courseId);
@@ -427,6 +422,21 @@ public class CourseService implements CourseUseCase {
         return courseRepository.findByIdAndDeletedFalse(courseId)
                 .orElseThrow(() -> new LmsException(LmsErrorCode.COURSE_NOT_FOUND));
     }
+
+    private Course findCourseIncludingDeleted(Long courseId) {
+        return courseRepository.findById(courseId)
+                .orElseThrow(() -> new LmsException(LmsErrorCode.COURSE_NOT_FOUND));
+    }
+
+    private void validateAccessibleEnrollment(Long userId, Long courseId) {
+        boolean accessible = enrollmentRepository.findByUserIdAndCourseId(userId, courseId)
+                .map(enrollment -> enrollment.isAccessibleAt(LocalDateTime.now()))
+                .orElse(false);
+
+        if (!accessible) {
+            throw new LmsException(LmsErrorCode.NOT_ENROLLED);
+        }
+    }
     private void validateCountry(Long countryId) {
         mapRepository.findActiveCountryById(countryId)
                 .orElseThrow(() -> new LmsException(LmsErrorCode.COUNTRY_NOT_FOUND));
@@ -529,7 +539,7 @@ public class CourseService implements CourseUseCase {
     }
 
     private Optional<MyCourseResult> createMyCourseResult(Long userId, Long courseId) {
-        Optional<Course> optionalCourse = courseRepository.findByIdAndDeletedFalse(courseId);
+        Optional<Course> optionalCourse = courseRepository.findById(courseId);
 
         if (optionalCourse.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
@@ -221,6 +221,60 @@ public class CourseService implements CourseUseCase {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public CourseClassroomResult getCourseClassroom(Long userId, Long courseId) {
+        Course course = findCourse(courseId);
+
+        var enrollment = enrollmentRepository.findByUserIdAndCourseId(userId, courseId)
+                .filter(value -> value.isAccessibleAt(LocalDateTime.now()))
+                .orElseThrow(() -> new LmsException(LmsErrorCode.NOT_ENROLLED));
+
+        List<Chapter> chapters = chapterRepository.findByCourseId(courseId);
+        List<LearningProgress> progresses = learningProgressRepository.findByUserIdAndCourseId(userId, courseId);
+
+        Map<Long, LearningProgress> progressByChapterId = progresses.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        LearningProgress::getChapterId,
+                        progress -> progress,
+                        (first, second) -> first
+                ));
+
+        List<CourseClassroomChapterResult> chapterResults = new java.util.ArrayList<>();
+        boolean previousChaptersCompleted = true;
+
+        for (Chapter chapter : chapters) {
+            LearningProgress progress = progressByChapterId.get(chapter.getId());
+            boolean completed = progress != null && progress.isCompleted();
+            boolean locked = !previousChaptersCompleted;
+
+            chapterResults.add(new CourseClassroomChapterResult(
+                    chapter.getId(),
+                    chapter.getTitle(),
+                    locked ? null : chapter.getVideoUrl(),
+                    chapter.getDurationSeconds(),
+                    chapter.getChapterOrder(),
+                    progress == null ? 0 : progress.getWatchedSeconds(),
+                    progress == null ? 0 : progress.getProgressRate(),
+                    completed,
+                    locked
+            ));
+
+            previousChaptersCompleted = previousChaptersCompleted && completed;
+        }
+
+        boolean quizAvailable = !chapters.isEmpty()
+                && chapterResults.stream().allMatch(CourseClassroomChapterResult::completed);
+
+        return new CourseClassroomResult(
+                course.getId(),
+                course.getTitle(),
+                enrollment.getAccessExpiresAt(),
+                quizAvailable,
+                chapterResults
+        );
+    }
+
+    @Override
     public CourseQnaResult createQna(CreateCourseQnaCommand command) {
         findCourse(command.courseId());
 

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/DiagnosisService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/DiagnosisService.java
@@ -118,6 +118,16 @@ public class DiagnosisService implements DiagnosisUseCase {
         return toResultView(result, List.of());
     }
 
+    @Override
+    public void deleteQuestion(Long questionId) {
+        if (!diagnosisQuestionRepository.existsById(questionId)) {
+            throw new LmsException(LmsErrorCode.DIAGNOSIS_QUESTION_NOT_FOUND);
+        }
+
+        diagnosisAnswerRepository.deleteByQuestionId(questionId);
+        diagnosisQuestionRepository.deleteById(questionId);
+    }
+
     private DiagnosisAnswerResult saveAndCreateAnswerResult(
             Long resultId,
             SubmitDiagnosisAnswerCommand answer,

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/LearningProgressService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/LearningProgressService.java
@@ -90,7 +90,7 @@ public class LearningProgressService implements LearningProgressUseCase {
     }
 
     private void validateCourse(Long courseId) {
-        if (courseRepository.findByIdAndDeletedFalse(courseId).isEmpty()) {
+        if (courseRepository.findById(courseId).isEmpty()) {
             log.warn("[Learning Progress Command] 진도율 업데이트 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}",
                     courseId);
             throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
@@ -47,7 +47,7 @@ public class QuizService implements QuizUseCase {
     @Override
     @Transactional(readOnly = true)
     public List<QuizResult> getQuizzes(Long courseId) {
-        validateCourse(courseId);
+        validateActiveCourse(courseId);
         return quizRepository.findByCourseId(courseId).stream()
                 .map(QuizResult::from)
                 .toList();
@@ -56,8 +56,8 @@ public class QuizService implements QuizUseCase {
     @Override
     @Transactional(readOnly = true)
     public List<QuizResult> getQuizzes(Long userId, Long courseId) {
-        validateCourse(courseId);
         validateEnrollment(userId, courseId);
+        validateCourseExists(courseId);
         validateAllChaptersCompleted(userId, courseId);
 
         List<Quiz> quizzes = quizRepository.findByCourseId(courseId);
@@ -72,7 +72,7 @@ public class QuizService implements QuizUseCase {
 
     @Override
     public QuizResult createQuiz(CreateQuizCommand command) {
-        validateCourse(command.courseId());
+        validateActiveCourse(command.courseId());
         validateOptions(command.option1(), command.option2(), command.option3(), command.option4());
         validateCorrectOption(command.correctOption());
 
@@ -92,7 +92,7 @@ public class QuizService implements QuizUseCase {
 
     @Override
     public QuizResult updateQuiz(Long courseId, Long quizId, UpdateQuizCommand command) {
-        validateCourse(courseId);
+        validateActiveCourse(courseId);
         validateOptions(command.option1(), command.option2(), command.option3(), command.option4());
         validateCorrectOption(command.correctOption());
 
@@ -113,7 +113,7 @@ public class QuizService implements QuizUseCase {
 
     @Override
     public void deleteQuiz(Long courseId, Long quizId) {
-        validateCourse(courseId);
+        validateActiveCourse(courseId);
 
         if (!quizRepository.delete(quizId, courseId)) {
             throw new LmsException(LmsErrorCode.QUIZ_NOT_FOUND);
@@ -122,8 +122,8 @@ public class QuizService implements QuizUseCase {
 
     @Override
     public QuizSubmitResult submitQuiz(SubmitQuizCommand command) {
-        validateCourse(command.courseId());
         validateEnrollment(command.userId(), command.courseId());
+        validateCourseExists(command.courseId());
         validateAllChaptersCompleted(command.userId(), command.courseId());
 
         List<Quiz> quizzes = quizRepository.findByCourseId(command.courseId());
@@ -176,8 +176,14 @@ public class QuizService implements QuizUseCase {
         );
     }
 
-    private void validateCourse(Long courseId) {
+    private void validateActiveCourse(Long courseId) {
         if (courseRepository.findByIdAndDeletedFalse(courseId).isEmpty()) {
+            throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+        }
+    }
+
+    private void validateCourseExists(Long courseId) {
+        if (courseRepository.findById(courseId).isEmpty()) {
             throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
         }
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
@@ -13,6 +13,7 @@ import com.kidmily.algoga_server.lms.domain.model.Quiz;
 import com.kidmily.algoga_server.lms.domain.model.QuizSubmission;
 import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
 import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.EnrollmentRepository;
 import com.kidmily.algoga_server.lms.domain.repository.LearningProgressRepository;
 import com.kidmily.algoga_server.lms.domain.repository.QuizRepository;
 import com.kidmily.algoga_server.lms.domain.repository.QuizSubmissionRepository;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -38,6 +40,7 @@ public class QuizService implements QuizUseCase {
     private final CourseRepository courseRepository;
     private final ChapterRepository chapterRepository;
     private final LearningProgressRepository learningProgressRepository;
+    private final EnrollmentRepository enrollmentRepository;
     private final QuizRepository quizRepository;
     private final QuizSubmissionRepository quizSubmissionRepository;
 
@@ -54,6 +57,7 @@ public class QuizService implements QuizUseCase {
     @Transactional(readOnly = true)
     public List<QuizResult> getQuizzes(Long userId, Long courseId) {
         validateCourse(courseId);
+        validateEnrollment(userId, courseId);
         validateAllChaptersCompleted(userId, courseId);
 
         List<Quiz> quizzes = quizRepository.findByCourseId(courseId);
@@ -119,6 +123,7 @@ public class QuizService implements QuizUseCase {
     @Override
     public QuizSubmitResult submitQuiz(SubmitQuizCommand command) {
         validateCourse(command.courseId());
+        validateEnrollment(command.userId(), command.courseId());
         validateAllChaptersCompleted(command.userId(), command.courseId());
 
         List<Quiz> quizzes = quizRepository.findByCourseId(command.courseId());
@@ -174,6 +179,16 @@ public class QuizService implements QuizUseCase {
     private void validateCourse(Long courseId) {
         if (courseRepository.findByIdAndDeletedFalse(courseId).isEmpty()) {
             throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+        }
+    }
+
+    private void validateEnrollment(Long userId, Long courseId) {
+        boolean accessible = enrollmentRepository.findByUserIdAndCourseId(userId, courseId)
+                .map(enrollment -> enrollment.isAccessibleAt(LocalDateTime.now()))
+                .orElse(false);
+
+        if (!accessible) {
+            throw new LmsException(LmsErrorCode.NOT_ENROLLED);
         }
     }
 

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseUseCase.java
@@ -31,6 +31,8 @@ public interface CourseUseCase {
 
     List<MyCourseResult> getMyCourses(Long userId);
 
+    CourseClassroomResult getCourseClassroom(Long userId, Long courseId);
+
     CourseQnaResult createQna(CreateCourseQnaCommand command);
 
     List<CourseQnaResult> getQnas(Long courseId);

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/DiagnosisUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/DiagnosisUseCase.java
@@ -13,4 +13,6 @@ public interface DiagnosisUseCase {
     DiagnosisResultView submitResult(SubmitDiagnosisCommand command);
 
     DiagnosisResultView getLatestResult(Long userId);
+
+    void deleteQuestion(Long questionId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/DiagnosisAnswerRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/DiagnosisAnswerRepository.java
@@ -5,4 +5,6 @@ import com.kidmily.algoga_server.lms.domain.model.DiagnosisAnswer;
 public interface DiagnosisAnswerRepository {
 
     DiagnosisAnswer save(DiagnosisAnswer diagnosisAnswer);
+
+    void deleteByQuestionId(Long questionId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/DiagnosisQuestionRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/DiagnosisQuestionRepository.java
@@ -9,4 +9,8 @@ public interface DiagnosisQuestionRepository {
     List<DiagnosisQuestion> findActiveByCountryId(Long countryId);
 
     List<DiagnosisQuestion> findByIds(List<Long> ids);
+
+    boolean existsById(Long id);
+
+    void deleteById(Long id);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
@@ -42,7 +42,8 @@ public enum LmsErrorCode implements BaseErrorCode {
     NOT_ENROLLED(HttpStatus.FORBIDDEN, "LMS_035", "수강 등록된 강의가 아닙니다."),
     DIAGNOSIS_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_036", "진단평가 문제를 찾을 수 없습니다."),
     INVALID_DIAGNOSIS_ANSWER(HttpStatus.BAD_REQUEST, "LMS_037", "진단평가 답안이 올바르지 않습니다."),
-    DIAGNOSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_038", "진단평가 결과를 찾을 수 없습니다.");
+    DIAGNOSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_038", "진단평가 결과를 찾을 수 없습니다."),
+    DIAGNOSIS_LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "LMS_039", "진단평가 결과를 저장하려면 로그인이 필요합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/DiagnosisAnswerRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/DiagnosisAnswerRepositoryAdapter.java
@@ -31,4 +31,9 @@ public class DiagnosisAnswerRepositoryAdapter implements DiagnosisAnswerReposito
                 savedEntity.isCorrect()
         );
     }
+
+    @Override
+    public void deleteByQuestionId(Long questionId) {
+        springDataDiagnosisAnswerRepository.deleteByQuestionId(questionId);
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/DiagnosisQuestionRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/DiagnosisQuestionRepositoryAdapter.java
@@ -31,6 +31,16 @@ public class DiagnosisQuestionRepositoryAdapter implements DiagnosisQuestionRepo
                 .toList();
     }
 
+    @Override
+    public boolean existsById(Long id) {
+        return springDataDiagnosisQuestionRepository.existsById(id);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        springDataDiagnosisQuestionRepository.deleteById(id);
+    }
+
     private DiagnosisQuestion toDomain(DiagnosisQuestionJpaEntity entity) {
         return new DiagnosisQuestion(
                 entity.getId(),

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataDiagnosisAnswerRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataDiagnosisAnswerRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface SpringDataDiagnosisAnswerRepository extends JpaRepository<DiagnosisAnswerJpaEntity, Long> {
 
     List<DiagnosisAnswerJpaEntity> findByResultIdOrderByIdAsc(Long resultId);
+
+    void deleteByQuestionId(Long questionId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/DiagnosisController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/DiagnosisController.java
@@ -34,6 +34,7 @@ public class DiagnosisController {
 
     @Operation(summary = "진단평가 문제 목록 조회")
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "DIAGNOSIS_LOGIN_REQUIRED",
             "COUNTRY_NOT_FOUND",
             "DIAGNOSIS_QUESTION_NOT_FOUND"
     })
@@ -90,7 +91,7 @@ public class DiagnosisController {
             @AuthenticationPrincipal Object userDetails,
             @Valid @RequestBody DiagnosisSubmitRequest request
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveRequired(userDetails);
 
         SubmitDiagnosisCommand command = new SubmitDiagnosisCommand(
                 currentUserId,
@@ -114,13 +115,14 @@ public class DiagnosisController {
 
     @Operation(summary = "내 최신 진단평가 결과 조회")
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "DIAGNOSIS_LOGIN_REQUIRED",
             "DIAGNOSIS_RESULT_NOT_FOUND"
     })
     @GetMapping("/me/latest")
     public ResponseEntity<ApiResponse<DiagnosisResultResponse>> getMyLatestDiagnosisResult(
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveRequired(userDetails);
 
         return ResponseEntity.ok(
                 ApiResponse.success(

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
@@ -2,6 +2,9 @@ package com.kidmily.algoga_server.lms.presentation.api;
 
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.lms.application.usecase.CourseUseCase;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.lms.presentation.response.CourseClassroomResponse;
 import com.kidmily.algoga_server.lms.presentation.response.MyCourseResponse;
 import com.kidmily.algoga_server.lms.presentation.support.CurrentUserIdResolver;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +47,28 @@ public class MyCourseController {
                         "MY_COURSES_FOUND",
                         "내 수강 강의 목록 조회에 성공했습니다.",
                         response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "수강생 강의실 상세 조회",
+            description = "수강 중인 강의의 챕터 영상과 진도, 잠금 상태 및 퀴즈 응시 가능 여부를 조회합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "NOT_ENROLLED"})
+    @GetMapping("/{courseId}")
+    public ResponseEntity<ApiResponse<CourseClassroomResponse>> getCourseClassroom(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal Object userDetails
+    ) {
+        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        var result = courseUseCase.getCourseClassroom(currentUserId, courseId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "COURSE_CLASSROOM_FOUND",
+                        "수강생 강의실 조회에 성공했습니다.",
+                        CourseClassroomResponse.from(result)
                 )
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminDiagnosisController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminDiagnosisController.java
@@ -1,0 +1,43 @@
+package com.kidmily.algoga_server.lms.presentation.api.admin;
+
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.lms.application.usecase.DiagnosisUseCase;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin Diagnosis", description = "관리자 진단평가 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/diagnosis/questions")
+@RequiredArgsConstructor
+public class AdminDiagnosisController {
+
+    private final DiagnosisUseCase diagnosisUseCase;
+
+    @Operation(summary = "진단평가 문제 즉시 삭제", description = "진단평가 문제와 연결된 답안을 즉시 물리 삭제합니다.")
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"DIAGNOSIS_QUESTION_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteQuestion(
+            @Parameter(description = "진단평가 문제 ID", example = "1")
+            @PathVariable Long questionId
+    ) {
+        diagnosisUseCase.deleteQuestion(questionId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "DIAGNOSIS_QUESTION_DELETED",
+                        "진단평가 문제 삭제에 성공했습니다."
+                )
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/04-admin-quiz.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/04-admin-quiz.http
@@ -1,25 +1,11 @@
+
 ### ==========================================================
 ### 04. 어드민 퀴즈 관리
-### 관리자 API라서 매니저 토큰 필요
-### 자동 변수 안 될 때 쓰는 수동 토큰 버전
+### 먼저 01-auth-map.http에서 콘텐츠 매니저 로그인 실행 후 사용
 ### ==========================================================
 
-@managerAccessToken = eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJjb250ZW50X21hbmFnZXJfMDEiLCJ0eXBlIjoiQURNSU4iLCJpZCI6Mywicm9sZSI6IlJPTEVfQ09OVEVOVF9NQU5BR0VSIiwiaWF0IjoxNzgxMTg3MTQyLCJleHAiOjE3ODExODg5NDJ9.zSH74QQLKKojFp0baZRu3P96AQwJ9r38IJDsn2oLaU21aywMKCd6_ylXaAt-SsVV
-@courseId = 76
-@quizId = 23
-
-
-### 콘텐츠 매니저 로그인
-### 실행 후 응답의 data.accessToken을 복사해서 위 managerAccessToken에 붙여넣기
-POST http://localhost:15000/api/v1/admin/auth/login
-Content-Type: application/json
-Accept: application/json
-
-{
-  "loginId": "content_manager_01",
-  "password": "password123"
-}
-
+@courseId = 54
+@quizId = 9
 
 ### 퀴즈 관리 - 퀴즈 목록 조회
 GET http://localhost:15000/api/v1/admin/courses/{{courseId}}/quizzes

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/06-user-quiz-completion.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/06-user-quiz-completion.http
@@ -11,14 +11,15 @@
 ### ==========================================================
 
 
-### 1. 챕터 목록 조회
-GET http://localhost:15000/api/v1/courses/3/chapters
-Authorization: Bearer {{accessToken}}
+### 1. 수강생 강의실 상세 조회
+### chapters[].locked=false인 챕터만 videoUrl이 내려옴
+GET http://localhost:15000/api/v1/my/courses/3
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 2-1. 챕터 5 완료 처리
 POST http://localhost:15000/api/v1/courses/3/chapters/5/progress
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -28,7 +29,7 @@ Content-Type: application/json
 
 ### 2-2. 챕터 6 완료 처리
 POST http://localhost:15000/api/v1/courses/3/chapters/6/progress
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -38,7 +39,7 @@ Content-Type: application/json
 
 ### 2-3. 챕터 7 완료 처리
 POST http://localhost:15000/api/v1/courses/3/chapters/7/progress
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -48,7 +49,7 @@ Content-Type: application/json
 
 ### 2-4. 챕터 8 완료 처리
 POST http://localhost:15000/api/v1/courses/3/chapters/8/progress
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -59,13 +60,13 @@ Content-Type: application/json
 ### 3. 사용자 퀴즈 조회
 ### 모든 챕터 완료 후 실행해야 함
 GET http://localhost:15000/api/v1/courses/3/quiz
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 4. 사용자 퀴즈 제출 및 채점
 ### quizId는 위 퀴즈 조회 응답의 data[].quizId 값으로 변경
 POST http://localhost:15000/api/v1/courses/3/quiz/submit
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -92,12 +93,18 @@ GET http://localhost:15000/api/v1/my/courses
 Authorization: Bearer {{userAccessToken}}
 
 
+### 6-1. 마이페이지 - 수강생 강의실 상세 재조회
+### 모든 챕터 완료 후 quizAvailable=true 확인
+GET http://localhost:15000/api/v1/my/courses/3
+Authorization: Bearer {{userAccessToken}}
+
+
 ### ----------------------------------------------------------
 ### 7. 마이페이지 - 내 쿠폰함 조회
-GET http://localhost:15000/api/v1/my/coupons
+GET http://localhost:15000/api/v1/my/benefits/coupons
 Authorization: Bearer {{userAccessToken}}
 
 
 ### 8. 마이페이지 - 내 마일리지 내역 조회
-GET http://localhost:15000/api/v1/my/mileages
-Authorization: Bearer {{accessToken}}
+GET http://localhost:15000/api/v1/my/benefits/mileages
+Authorization: Bearer {{userAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/06-user-quiz-completion.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/06-user-quiz-completion.http
@@ -9,16 +9,33 @@
 ### 4) quizId를 확인해서 퀴즈 제출
 ### 5) 강의 이수 완료
 ### ==========================================================
+### 일반 사용자 로그인
+POST http://localhost:15000/api/v1/auth/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "username": "test1",
+  "password": "test1234"
+}
+
+> {%
+    if (response.status === 200) {
+        client.global.set("userAccessToken", response.body.data.accessToken);
+        client.global.set("userRefreshToken", response.body.data.refreshToken);
+        client.log("User Access Token 저장 완료: " + client.global.get("userAccessToken"));
+    }
+%}
 
 
 ### 1. 수강생 강의실 상세 조회
 ### chapters[].locked=false인 챕터만 videoUrl이 내려옴
-GET http://localhost:15000/api/v1/my/courses/3
+GET http://localhost:15000/api/v1/my/courses/54
 Authorization: Bearer {{userAccessToken}}
 
 
 ### 2-1. 챕터 5 완료 처리
-POST http://localhost:15000/api/v1/courses/3/chapters/5/progress
+POST http://localhost:15000/api/v1/courses/54/chapters/42/progress
 Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
@@ -28,7 +45,7 @@ Content-Type: application/json
 
 
 ### 2-2. 챕터 6 완료 처리
-POST http://localhost:15000/api/v1/courses/3/chapters/6/progress
+POST http://localhost:15000/api/v1/courses/54/chapters/42/progress
 Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
@@ -59,20 +76,20 @@ Content-Type: application/json
 
 ### 3. 사용자 퀴즈 조회
 ### 모든 챕터 완료 후 실행해야 함
-GET http://localhost:15000/api/v1/courses/3/quiz
+GET http://localhost:15000/api/v1/courses/54/quiz
 Authorization: Bearer {{userAccessToken}}
 
 
 ### 4. 사용자 퀴즈 제출 및 채점
 ### quizId는 위 퀴즈 조회 응답의 data[].quizId 값으로 변경
-POST http://localhost:15000/api/v1/courses/3/quiz/submit
+POST http://localhost:15000/api/v1/courses/54/quiz/submit
 Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
   "answers": [
     {
-      "quizId": 3,
+      "quizId": 9,
       "selectedOption": 1
     }
   ]
@@ -83,7 +100,7 @@ Content-Type: application/json
 ### 조건:
 ### - 해당 강의의 모든 챕터 completed=true
 ### - 해당 강의 퀴즈 제출 내역이 quiz_submissions에 존재
-POST http://localhost:15000/api/v1/courses/3/complete
+POST http://localhost:15000/api/v1/courses/54/complete
 Authorization: Bearer {{userAccessToken}}
 
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/08-certificate.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/08-certificate.http
@@ -9,4 +9,4 @@
 
 ### 수료증 - PDF 발급
 GET http://localhost:15000/api/v1/courses/3/certificate
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/09-qna.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/09-qna.http
@@ -9,7 +9,7 @@
 
 ### 강의 Q&A - 질문 등록
 POST http://localhost:15000/api/v1/courses/3/qnas
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -20,13 +20,13 @@ Content-Type: application/json
 
 ### 강의 Q&A - 목록 조회
 GET http://localhost:15000/api/v1/courses/3/qnas
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 강의 Q&A - 답변 등록 - 관리자 API
 ### qnaId는 질문 등록 응답의 data.qnaId 값으로 변경
 POST http://localhost:15000/api/v1/admin/courses/3/qnas/1/answer
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -36,7 +36,7 @@ Content-Type: application/json
 
 ### 강의 Q&A - 답변 후 목록 조회
 GET http://localhost:15000/api/v1/courses/3/qnas
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 
@@ -45,13 +45,13 @@ Authorization: Bearer {{accessToken}}
 ### 강의 Q&A - 상세 조회
 ### qnaId는 실제 Q&A ID로 변경
 GET http://localhost:15000/api/v1/courses/3/qnas/1
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 강의 Q&A - 사용자 댓글 등록
 ### qnaId는 실제 Q&A ID로 변경
 POST http://localhost:15000/api/v1/courses/3/qnas/1/comments
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -62,7 +62,7 @@ Content-Type: application/json
 ### 강의 Q&A - 관리자 댓글 등록
 ### 관리자/매니저 토큰 필요
 POST http://localhost:15000/api/v1/admin/courses/3/qnas/1/comments
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -72,4 +72,4 @@ Content-Type: application/json
 
 ### 강의 Q&A - 댓글 등록 후 상세 조회
 GET http://localhost:15000/api/v1/courses/3/qnas/1
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/10-review.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/10-review.http
@@ -11,7 +11,7 @@
 
 ### 강의 리뷰 - 리뷰 등록
 POST http://localhost:15000/api/v1/courses/3/reviews
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -22,9 +22,9 @@ Content-Type: application/json
 
 ### 강의 리뷰 - 리뷰 목록 조회
 GET http://localhost:15000/api/v1/courses/3/reviews
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 강의 리뷰 - 리뷰 요약 조회
 GET http://localhost:15000/api/v1/courses/3/reviews/summary
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/13-diagnosis-recommendation.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/13-diagnosis-recommendation.http
@@ -37,7 +37,6 @@ Accept: application/json
 ### ==========================================================
 
 GET http://localhost:15000/api/v1/diagnosis/questions?countryId=1
-Authorization: Bearer {{userAccessToken}}
 Accept: application/json
 
 
@@ -50,6 +49,25 @@ Accept: application/json
 ### 41~70점  -> INTERMEDIATE
 ### 71~100점 -> ADVANCED
 ### ==========================================================
+
+### 비로그인 제출 확인
+### 기대 결과: 401 / LMS_039
+POST http://localhost:15000/api/v1/diagnosis/result
+Content-Type: application/json
+Accept: application/json
+
+{
+  "countryId": 1,
+  "answers": [
+    {
+      "questionId": 1,
+      "selectedOption": 2
+    }
+  ]
+}
+
+
+### 로그인 후 결과 저장
 
 POST http://localhost:15000/api/v1/diagnosis/result
 Authorization: Bearer {{userAccessToken}}
@@ -99,7 +117,6 @@ Accept: application/json
 ### ==========================================================
 
 GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=1&level=BEGINNER
-Authorization: Bearer {{userAccessToken}}
 Accept: application/json
 
 
@@ -108,7 +125,6 @@ Accept: application/json
 ### ==========================================================
 
 GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=1&level=INTERMEDIATE
-Authorization: Bearer {{userAccessToken}}
 Accept: application/json
 
 
@@ -117,7 +133,6 @@ Accept: application/json
 ### ==========================================================
 
 GET http://localhost:15000/api/v1/diagnosis/recommendations?countryId=1&level=ADVANCED
-Authorization: Bearer {{userAccessToken}}
 Accept: application/json
 
 
@@ -165,4 +180,12 @@ Accept: application/json
 
 GET http://localhost:15000/api/v1/diagnosis/me/latest
 Authorization: Bearer {{userAccessToken}}
+Accept: application/json
+### ==========================================================
+### 관리자 진단평가 문제 즉시 삭제
+### 먼저 01-auth-map.http에서 콘텐츠 매니저 로그인을 실행하세요.
+### ==========================================================
+
+DELETE http://localhost:15000/api/v1/admin/diagnosis/questions/1
+Authorization: Bearer {{contentManagerAccessToken}}
 Accept: application/json

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/16-welcome-coupon.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/16-welcome-coupon.http
@@ -25,7 +25,7 @@ Content-Type: application/json
 
 {
   "email": "mac0616@naver.com",
-  "code": "576302"
+  "code": "551305"
 }
 
 > {%

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/99-exception-test.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/99-exception-test.http
@@ -7,27 +7,27 @@
 
 ### 지도 - 존재하지 않는 대륙 코드
 GET http://localhost:15000/api/v1/maps/continents/WRONG/countries
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 국가별 강의 목록 조회 - 존재하지 않는 국가
 GET http://localhost:15000/api/v1/courses/countries/9999
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 어드민 - 존재하지 않는 강의 상세 조회
 GET http://localhost:15000/api/v1/admin/courses/9999
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 챕터 관리 - 존재하지 않는 강의의 챕터 목록 조회
 GET http://localhost:15000/api/v1/admin/courses/9999/chapters
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 챕터 관리 - 존재하지 않는 챕터 수정
 PUT http://localhost:15000/api/v1/admin/courses/3/chapters/9999
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -45,7 +45,7 @@ Content-Type: application/json
 
 ### 강의 수강 - 존재하지 않는 강의
 POST http://localhost:15000/api/v1/admin/courses/9999/chapters/6/progress
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -55,7 +55,7 @@ Content-Type: application/json
 
 ### 강의 수강 - 존재하지 않는 챕터
 POST http://localhost:15000/api/v1/admin/courses/3/chapters/9999/progress
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -65,7 +65,7 @@ Content-Type: application/json
 
 ### 강의 수강 - 음수 시청 시간
 POST http://localhost:15000/api/v1/courses/3/chapters/5/progress
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -75,12 +75,12 @@ Content-Type: application/json
 
 ### 퀴즈 관리 - 존재하지 않는 강의의 퀴즈 목록 조회
 GET http://localhost:15000/api/v1/admin/courses/9999/quizzes
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 
 
 ### 퀴즈 관리 - 존재하지 않는 퀴즈 수정
 PUT http://localhost:15000/api/v1/admin/courses/3/quizzes/9999
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -96,7 +96,7 @@ Content-Type: application/json
 
 ### 퀴즈 관리 - 정답 번호 오류
 POST http://localhost:15000/api/v1/admin/courses/3/quizzes
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -112,7 +112,7 @@ Content-Type: application/json
 
 ### 퀴즈 관리 - 보기 누락
 POST http://localhost:15000/api/v1/admin/courses/3/quizzes
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -128,12 +128,12 @@ Content-Type: application/json
 
 ### 사용자 퀴즈 - 존재하지 않는 강의의 퀴즈 조회
 GET http://localhost:15000/api/v1/courses/9999/quiz
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 사용자 퀴즈 - 존재하지 않는 강의의 퀴즈 제출
 POST http://localhost:15000/api/v1/courses/9999/quiz/submit
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -148,7 +148,7 @@ Content-Type: application/json
 
 ### 사용자 퀴즈 - 잘못된 답안 번호
 POST http://localhost:15000/api/v1/courses/3/quiz/submit
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -163,7 +163,7 @@ Content-Type: application/json
 
 ### 사용자 퀴즈 - 답안 누락
 POST http://localhost:15000/api/v1/courses/3/quiz/submit
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -173,28 +173,28 @@ Content-Type: application/json
 
 ### 강의 이수 - 중복 이수 완료 예외
 POST http://localhost:15000/api/v1/courses/3/complete
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 강의 이수 - 존재하지 않는 강의
 POST http://localhost:15000/api/v1/courses/9999/complete
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 강의 이수 - 퀴즈 미제출 상태
 ### 아직 퀴즈 제출하지 않은 courseId로 변경해서 테스트
 POST http://localhost:15000/api/v1/courses/4/complete
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### 보상 지급 - 존재하지 않는 강의
 POST http://localhost:15000/api/v1/courses/9999/rewards
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 
 
 ### Q&A - 존재하지 않는 강의 질문 등록
 POST http://localhost:15000/api/v1/courses/9999/qnas
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -205,7 +205,7 @@ Content-Type: application/json
 
 ### Q&A - 존재하지 않는 Q&A 답변 등록
 POST http://localhost:15000/api/v1/admin/courses/3/qnas/9999/answer
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -216,7 +216,7 @@ Content-Type: application/json
 ### Q&A - 이미 답변된 Q&A 재답변
 ### qnaId를 이미 답변 등록 성공한 값으로 변경
 POST http://localhost:15000/api/v1/admin/courses/3/qnas/1/answer
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{managerAccessToken}}
 Content-Type: application/json
 
 {
@@ -226,7 +226,7 @@ Content-Type: application/json
 
 ### 리뷰 - 같은 강의에 리뷰 중복 등록
 POST http://localhost:15000/api/v1/courses/3/reviews
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -237,7 +237,7 @@ Content-Type: application/json
 
 ### 리뷰 - 잘못된 평점
 POST http://localhost:15000/api/v1/courses/3/reviews
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {
@@ -248,7 +248,7 @@ Content-Type: application/json
 
 ### 리뷰 - 이수하지 않은 강의 리뷰 등록
 POST http://localhost:15000/api/v1/courses/4/reviews
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{userAccessToken}}
 Content-Type: application/json
 
 {

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseClassroomResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseClassroomResponse.java
@@ -1,0 +1,80 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.CourseClassroomChapterResult;
+import com.kidmily.algoga_server.lms.application.result.CourseClassroomResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "수강생 강의실 상세 응답")
+public record CourseClassroomResponse(
+        @Schema(description = "강의 ID", example = "76")
+        Long courseId,
+
+        @Schema(description = "강의 제목", example = "오사카 여행 준비 마스터")
+        String title,
+
+        @Schema(description = "수강 가능 만료 일시", example = "2026-12-15T10:00:00")
+        LocalDateTime accessExpiresAt,
+
+        @Schema(description = "퀴즈 응시 가능 여부", example = "false")
+        boolean quizAvailable,
+
+        @Schema(description = "챕터 학습 목록")
+        List<ChapterLearningResponse> chapters
+) {
+    public static CourseClassroomResponse from(CourseClassroomResult result) {
+        return new CourseClassroomResponse(
+                result.courseId(),
+                result.title(),
+                result.accessExpiresAt(),
+                result.quizAvailable(),
+                result.chapters().stream().map(ChapterLearningResponse::from).toList()
+        );
+    }
+
+    @Schema(description = "수강생 챕터 학습 응답")
+    public record ChapterLearningResponse(
+            @Schema(description = "챕터 ID", example = "1")
+            Long chapterId,
+
+            @Schema(description = "챕터 제목", example = "1강. 여행 전 필수 준비")
+            String title,
+
+            @Schema(description = "영상 URL. 잠긴 챕터는 null")
+            String videoUrl,
+
+            @Schema(description = "영상 길이. 초 단위", example = "700")
+            int durationSeconds,
+
+            @Schema(description = "챕터 순서", example = "1")
+            int chapterOrder,
+
+            @Schema(description = "최대 시청 시간. 초 단위", example = "350")
+            int watchedSeconds,
+
+            @Schema(description = "학습 진도율", example = "50")
+            int progressRate,
+
+            @Schema(description = "챕터 완료 여부", example = "false")
+            boolean completed,
+
+            @Schema(description = "챕터 잠금 여부", example = "false")
+            boolean locked
+    ) {
+        public static ChapterLearningResponse from(CourseClassroomChapterResult result) {
+            return new ChapterLearningResponse(
+                    result.chapterId(),
+                    result.title(),
+                    result.videoUrl(),
+                    result.durationSeconds(),
+                    result.chapterOrder(),
+                    result.watchedSeconds(),
+                    result.progressRate(),
+                    result.completed(),
+                    result.locked()
+            );
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/support/CurrentUserIdResolver.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/support/CurrentUserIdResolver.java
@@ -1,10 +1,21 @@
 package com.kidmily.algoga_server.lms.presentation.support;
 
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+
 import java.lang.reflect.Method;
 
 public final class CurrentUserIdResolver {
 
     private CurrentUserIdResolver() {
+    }
+
+    public static Long resolveRequired(Object principal) {
+        Long userId = resolveNullable(principal);
+        if (userId == null) {
+            throw new LmsException(LmsErrorCode.DIAGNOSIS_LOGIN_REQUIRED);
+        }
+        return userId;
     }
 
     public static Long resolveNullable(Object principal) {

--- a/src/test/java/com/kidmily/algoga_server/benefit/domain/model/CouponPolicyTest.java
+++ b/src/test/java/com/kidmily/algoga_server/benefit/domain/model/CouponPolicyTest.java
@@ -1,0 +1,21 @@
+package com.kidmily.algoga_server.benefit.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CouponPolicyTest {
+
+    @Test
+    void fixesCouponValidityToThirtyDays() {
+        CouponPolicy policy = CouponPolicy.create(
+                1L,
+                2L,
+                "Course completion coupon",
+                "RATE",
+                10
+        );
+
+        assertEquals(30, policy.getValidDays());
+    }
+}

--- a/src/test/java/com/kidmily/algoga_server/lms/application/service/CourseServiceClassroomTest.java
+++ b/src/test/java/com/kidmily/algoga_server/lms/application/service/CourseServiceClassroomTest.java
@@ -39,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,7 +68,7 @@ class CourseServiceClassroomTest {
     private CourseService courseService;
 
     @Test
-    void 이전_챕터를_완료하지_않으면_다음_챕터가_잠긴다() {
+    void locksNextChapterUntilPreviousChapterIsCompleted() {
         Chapter first = chapter(1L, 1, "https://cdn.test/chapter-1.mp4");
         Chapter second = chapter(2L, 2, "https://cdn.test/chapter-2.mp4");
         mockClassroom(List.of(first, second), List.of());
@@ -81,7 +83,7 @@ class CourseServiceClassroomTest {
     }
 
     @Test
-    void 등록된_모든_챕터를_완료하면_퀴즈가_열린다() {
+    void opensQuizWhenAllRegisteredChaptersAreCompleted() {
         Chapter first = chapter(1L, 1, "https://cdn.test/chapter-1.mp4");
         Chapter second = chapter(2L, 2, "https://cdn.test/chapter-2.mp4");
         List<LearningProgress> progresses = List.of(
@@ -97,9 +99,7 @@ class CourseServiceClassroomTest {
     }
 
     @Test
-    void 수강_기간이_만료되면_강의실에_접근할_수_없다() {
-        Course course = mock(Course.class);
-        when(courseRepository.findByIdAndDeletedFalse(COURSE_ID)).thenReturn(Optional.of(course));
+    void rejectsClassroomAccessWhenEnrollmentExpired() {
         when(enrollmentRepository.findByUserIdAndCourseId(USER_ID, COURSE_ID))
                 .thenReturn(Optional.of(enrollment(LocalDateTime.now().minusSeconds(1))));
 
@@ -111,11 +111,34 @@ class CourseServiceClassroomTest {
         assertSame(LmsErrorCode.NOT_ENROLLED, exception.getErrorCode());
     }
 
+    @Test
+    void deletedCourseRemainsAvailableToEnrolledStudent() {
+        Chapter chapter = chapter(1L, 1, "https://cdn.test/chapter-1.mp4");
+        mockClassroom(List.of(chapter), List.of());
+
+        CourseClassroomResult result = courseService.getCourseClassroom(USER_ID, COURSE_ID);
+
+        assertEquals(COURSE_ID, result.courseId());
+        verify(courseRepository).findById(COURSE_ID);
+    }
+
+    @Test
+    void deletingCourseDoesNotDeleteStoredFiles() {
+        Course course = mock(Course.class);
+        when(courseRepository.findByIdAndDeletedFalse(COURSE_ID)).thenReturn(Optional.of(course));
+        when(courseRepository.softDelete(COURSE_ID)).thenReturn(true);
+
+        courseService.deleteCourse(COURSE_ID);
+
+        verify(courseRepository).softDelete(COURSE_ID);
+        verifyNoInteractions(fileStoragePort);
+    }
+
     private void mockClassroom(List<Chapter> chapters, List<LearningProgress> progresses) {
         Course course = mock(Course.class);
         when(course.getId()).thenReturn(COURSE_ID);
-        when(course.getTitle()).thenReturn("여행 준비 강의");
-        when(courseRepository.findByIdAndDeletedFalse(COURSE_ID)).thenReturn(Optional.of(course));
+        when(course.getTitle()).thenReturn("Travel course");
+        when(courseRepository.findById(COURSE_ID)).thenReturn(Optional.of(course));
         when(enrollmentRepository.findByUserIdAndCourseId(USER_ID, COURSE_ID))
                 .thenReturn(Optional.of(enrollment(LocalDateTime.now().plusMonths(6))));
         when(chapterRepository.findByCourseId(COURSE_ID)).thenReturn(chapters);
@@ -138,7 +161,7 @@ class CourseServiceClassroomTest {
         return Chapter.withId(
                 chapterId,
                 COURSE_ID,
-                chapterOrder + "강",
+                chapterOrder + " chapter",
                 videoUrl,
                 600,
                 chapterOrder,

--- a/src/test/java/com/kidmily/algoga_server/lms/application/service/CourseServiceClassroomTest.java
+++ b/src/test/java/com/kidmily/algoga_server/lms/application/service/CourseServiceClassroomTest.java
@@ -1,0 +1,148 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.global.port.out.FileStoragePort;
+import com.kidmily.algoga_server.lms.application.port.PaymentPort;
+import com.kidmily.algoga_server.lms.application.port.UserProfilePort;
+import com.kidmily.algoga_server.lms.application.result.CourseClassroomResult;
+import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.model.Enrollment;
+import com.kidmily.algoga_server.lms.domain.model.EnrollmentStatus;
+import com.kidmily.algoga_server.lms.domain.model.LearningProgress;
+import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseCompletionRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseQnaCommentRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseQnaRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseReviewRepository;
+import com.kidmily.algoga_server.lms.domain.repository.EnrollmentRepository;
+import com.kidmily.algoga_server.lms.domain.repository.LearningProgressRepository;
+import com.kidmily.algoga_server.lms.domain.repository.MapRepository;
+import com.kidmily.algoga_server.lms.domain.repository.QuizSubmissionRepository;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+import com.kidmily.algoga_server.lms.settings.LmsStorageSettings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CourseServiceClassroomTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long COURSE_ID = 76L;
+
+    @Mock private CourseRepository courseRepository;
+    @Mock private ChapterRepository chapterRepository;
+    @Mock private LearningProgressRepository learningProgressRepository;
+    @Mock private CourseCompletionRepository courseCompletionRepository;
+    @Mock private QuizSubmissionRepository quizSubmissionRepository;
+    @Mock private CourseReviewRepository courseReviewRepository;
+    @Mock private CourseQnaRepository courseQnaRepository;
+    @Mock private CourseQnaCommentRepository courseQnaCommentRepository;
+    @Mock private MapRepository mapRepository;
+    @Mock private EnrollmentRepository enrollmentRepository;
+    @Mock private PaymentPort paymentPort;
+    @Mock private UserProfilePort userProfilePort;
+    @Mock private FileStoragePort fileStoragePort;
+    @Mock private LmsStorageSettings storageSettings;
+
+    @InjectMocks
+    private CourseService courseService;
+
+    @Test
+    void 이전_챕터를_완료하지_않으면_다음_챕터가_잠긴다() {
+        Chapter first = chapter(1L, 1, "https://cdn.test/chapter-1.mp4");
+        Chapter second = chapter(2L, 2, "https://cdn.test/chapter-2.mp4");
+        mockClassroom(List.of(first, second), List.of());
+
+        CourseClassroomResult result = courseService.getCourseClassroom(USER_ID, COURSE_ID);
+
+        assertFalse(result.quizAvailable());
+        assertFalse(result.chapters().get(0).locked());
+        assertEquals(first.getVideoUrl(), result.chapters().get(0).videoUrl());
+        assertTrue(result.chapters().get(1).locked());
+        assertNull(result.chapters().get(1).videoUrl());
+    }
+
+    @Test
+    void 등록된_모든_챕터를_완료하면_퀴즈가_열린다() {
+        Chapter first = chapter(1L, 1, "https://cdn.test/chapter-1.mp4");
+        Chapter second = chapter(2L, 2, "https://cdn.test/chapter-2.mp4");
+        List<LearningProgress> progresses = List.of(
+                LearningProgress.withId(1L, USER_ID, COURSE_ID, first.getId(), 600, 100, true),
+                LearningProgress.withId(2L, USER_ID, COURSE_ID, second.getId(), 600, 100, true)
+        );
+        mockClassroom(List.of(first, second), progresses);
+
+        CourseClassroomResult result = courseService.getCourseClassroom(USER_ID, COURSE_ID);
+
+        assertTrue(result.quizAvailable());
+        assertTrue(result.chapters().stream().allMatch(chapter -> chapter.completed() && !chapter.locked()));
+    }
+
+    @Test
+    void 수강_기간이_만료되면_강의실에_접근할_수_없다() {
+        Course course = mock(Course.class);
+        when(courseRepository.findByIdAndDeletedFalse(COURSE_ID)).thenReturn(Optional.of(course));
+        when(enrollmentRepository.findByUserIdAndCourseId(USER_ID, COURSE_ID))
+                .thenReturn(Optional.of(enrollment(LocalDateTime.now().minusSeconds(1))));
+
+        LmsException exception = assertThrows(
+                LmsException.class,
+                () -> courseService.getCourseClassroom(USER_ID, COURSE_ID)
+        );
+
+        assertSame(LmsErrorCode.NOT_ENROLLED, exception.getErrorCode());
+    }
+
+    private void mockClassroom(List<Chapter> chapters, List<LearningProgress> progresses) {
+        Course course = mock(Course.class);
+        when(course.getId()).thenReturn(COURSE_ID);
+        when(course.getTitle()).thenReturn("여행 준비 강의");
+        when(courseRepository.findByIdAndDeletedFalse(COURSE_ID)).thenReturn(Optional.of(course));
+        when(enrollmentRepository.findByUserIdAndCourseId(USER_ID, COURSE_ID))
+                .thenReturn(Optional.of(enrollment(LocalDateTime.now().plusMonths(6))));
+        when(chapterRepository.findByCourseId(COURSE_ID)).thenReturn(chapters);
+        when(learningProgressRepository.findByUserIdAndCourseId(USER_ID, COURSE_ID)).thenReturn(progresses);
+    }
+
+    private Enrollment enrollment(LocalDateTime accessExpiresAt) {
+        return Enrollment.withId(
+                1L,
+                USER_ID,
+                COURSE_ID,
+                EnrollmentStatus.ENROLLED,
+                LocalDateTime.now().minusDays(1),
+                null,
+                accessExpiresAt
+        );
+    }
+
+    private Chapter chapter(Long chapterId, int chapterOrder, String videoUrl) {
+        return Chapter.withId(
+                chapterId,
+                COURSE_ID,
+                chapterOrder + "강",
+                videoUrl,
+                600,
+                chapterOrder,
+                false
+        );
+    }
+}

--- a/src/test/java/com/kidmily/algoga_server/lms/application/service/DiagnosisServiceTest.java
+++ b/src/test/java/com/kidmily/algoga_server/lms/application/service/DiagnosisServiceTest.java
@@ -1,0 +1,62 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.port.UserProfilePort;
+import com.kidmily.algoga_server.lms.application.usecase.CourseUseCase;
+import com.kidmily.algoga_server.lms.domain.repository.DiagnosisAnswerRepository;
+import com.kidmily.algoga_server.lms.domain.repository.DiagnosisQuestionRepository;
+import com.kidmily.algoga_server.lms.domain.repository.DiagnosisResultRepository;
+import com.kidmily.algoga_server.lms.domain.repository.MapRepository;
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DiagnosisServiceTest {
+
+    @Mock private DiagnosisQuestionRepository diagnosisQuestionRepository;
+    @Mock private DiagnosisResultRepository diagnosisResultRepository;
+    @Mock private DiagnosisAnswerRepository diagnosisAnswerRepository;
+    @Mock private MapRepository mapRepository;
+    @Mock private CourseUseCase courseUseCase;
+    @Mock private UserProfilePort userProfilePort;
+
+    @InjectMocks
+    private DiagnosisService diagnosisService;
+
+    @Test
+    void deletesAnswersBeforeDeletingQuestion() {
+        Long questionId = 1L;
+        when(diagnosisQuestionRepository.existsById(questionId)).thenReturn(true);
+
+        diagnosisService.deleteQuestion(questionId);
+
+        InOrder inOrder = inOrder(diagnosisAnswerRepository, diagnosisQuestionRepository);
+        inOrder.verify(diagnosisAnswerRepository).deleteByQuestionId(questionId);
+        inOrder.verify(diagnosisQuestionRepository).deleteById(questionId);
+    }
+
+    @Test
+    void throwsWhenDiagnosisQuestionDoesNotExist() {
+        Long questionId = 1L;
+        when(diagnosisQuestionRepository.existsById(questionId)).thenReturn(false);
+
+        LmsException exception = assertThrows(
+                LmsException.class,
+                () -> diagnosisService.deleteQuestion(questionId)
+        );
+
+        assertSame(LmsErrorCode.DIAGNOSIS_QUESTION_NOT_FOUND, exception.getErrorCode());
+        verifyNoInteractions(diagnosisAnswerRepository);
+    }
+}

--- a/src/test/java/com/kidmily/algoga_server/lms/presentation/support/CurrentUserIdResolverTest.java
+++ b/src/test/java/com/kidmily/algoga_server/lms/presentation/support/CurrentUserIdResolverTest.java
@@ -1,0 +1,45 @@
+package com.kidmily.algoga_server.lms.presentation.support;
+
+import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
+import com.kidmily.algoga_server.lms.exception.LmsException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CurrentUserIdResolverTest {
+
+    @Test
+    void requiresLoginWhenPrincipalIsMissing() {
+        LmsException exception = assertThrows(
+                LmsException.class,
+                () -> CurrentUserIdResolver.resolveRequired(null)
+        );
+
+        assertSame(LmsErrorCode.DIAGNOSIS_LOGIN_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    void resolvesUserIdFromAuthenticatedPrincipal() {
+        Long userId = CurrentUserIdResolver.resolveRequired(new TestPrincipal(new TestUser(2L)));
+
+        assertEquals(2L, userId);
+    }
+
+    public record TestPrincipal(TestUser user) {
+        public TestUser getUser() {
+            return user;
+        }
+    }
+
+    public record TestUser(Long id) {
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return "test user";
+        }
+    }
+}

--- a/src/test/java/com/kidmily/algoga_server/lms/tdd/ChapterRepositoryTest.java
+++ b/src/test/java/com/kidmily/algoga_server/lms/tdd/ChapterRepositoryTest.java
@@ -2,6 +2,8 @@ package com.kidmily.algoga_server.lms.tdd;
 
 import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.ChapterJpaEntity;
 import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.CourseJpaEntity;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.SpringDataChapterRepository;
+import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.SpringDataCourseRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성

## 🔗 Issue
Closes #239

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
## 작업 내용

### 수강생 강의실
- 결제한 강의의 강의실 상세 조회 기능 구현
- 등록된 챕터 영상을 이용한 수강 기능 구현
- 이전 챕터 완료 후 다음 챕터가 열리도록 순차 수강 처리
- 등록된 모든 챕터 완료 후 퀴즈 응시 가능
- 강의 수강 가능 기간을 구매일 기준 6개월로 적용
- 강의 삭제 후에도 기존 수강생은 수강할 수 있도록 처리
- 삭제된 강의는 공개 목록 및 신규 결제 대상에서 제외
- 강의 삭제 시 S3 자료 및 영상을 즉시 삭제하지 않도록 수정

### 진도 및 퀴즈
- 챕터별 시청 시간과 완료 상태 저장
- 잠긴 챕터 접근 방지
- 강의에 등록된 전체 챕터 완료 여부로 퀴즈 해제
- 퀴즈 및 진단평가를 soft delete 없이 즉시 삭제하도록 처리

### 진단평가
- 비로그인 사용자도 질문과 추천 결과를 조회할 수 있도록 수정
- 비로그인 상태에서 결과 제출 시 `401 / LMS_039` 반환
- 로그인 후 진단평가 결과를 사용자 계정에 저장
- 최근 진단평가 결과 조회 기능 유지
- 관리자 진단평가 질문 즉시 삭제 API 추가
- 질문 삭제 시 연결된 진단평가 답변도 함께 삭제

### 쿠폰 및 마일리지
- 쿠폰 유효기간을 발급일 기준 30일로 고정
- 쿠폰 정책 생성·수정 요청에서 `validDays` 제거
- 쿠폰 정책 soft delete 적용
- 삭제된 쿠폰 정책의 추가 발급 차단
- 마일리지 유효기간을 발급일 기준 1년으로 적용
- 강의 완료 마일리지 지급 가능 기간을 구매일 기준 한 달로 적용

### 구조 개선
- LMS/Benefit 내부 의존 방향을 클린 아키텍처 구조에 맞게 정리
- Presentation에서 Domain Model을 직접 사용하지 않도록 Application Result DTO 적용
- Controller, UseCase, Port, Adapter 계층 역할 분리
- LMS와 Benefit 외부 도메인 의존 최소화
- Swagger 응답 Schema 및 API 문서 보완
- HTTP 테스트 파일의 인증 토큰 저장 방식을 공통 형식으로 정리

## 주요 API

### 강의실
- `GET /api/v1/my/courses`
- `GET /api/v1/my/courses/{courseId}`
- `POST /api/v1/courses/{courseId}/chapters/{chapterId}/progress`
- `GET /api/v1/courses/{courseId}/quiz`
- `POST /api/v1/courses/{courseId}/quiz/submit`
- `POST /api/v1/courses/{courseId}/complete`

### 진단평가
- `GET /api/v1/diagnosis/questions`
- `POST /api/v1/diagnosis/result`
- `GET /api/v1/diagnosis/me/latest`
- `GET /api/v1/diagnosis/recommendations`
- `DELETE /api/v1/admin/diagnosis/questions/{questionId}`

### 쿠폰
- `POST /api/v1/admin/courses/{courseId}/coupon-policies`
- `PUT /api/v1/admin/courses/{courseId}/coupon-policies/{couponPolicyId}`
- `DELETE /api/v1/admin/courses/{courseId}/coupon-policies/{couponPolicyId}`
- `GET /api/v1/my/benefits/coupons`

## 변경된 요청 JSON

쿠폰 정책 생성 및 수정 요청에서 `validDays`를 제거했습니다.

```json
{
  "couponName": "강의 수료 할인 쿠폰",
  "discountType": "RATE",
  "discountValue": 10
}