### PR TITLE
[Feature] 소셜로그인 (카카오)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/CustomOAuth2UserService.java
@@ -1,12 +1,16 @@
 package com.kidmily.algoga_server.global.security;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -15,17 +19,41 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        // 1. 구글 서버와 통신하여 유저 정보 가져오기
+        // 1. 소셜 서버(구글/카카오)와 통신하여 유저 정보 가져오기
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        // 2. 데이터 확인
-        Map<String, Object> attributes = oAuth2User.getAttributes();
+        // 2. 어떤 소셜 로그인인지 식별 ("google" or "kakao")
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // 3. 반환받은 데이터를 우리가 수정할 수 있도록 새로운 Map으로 복사 (불변 객체 에러 방지)
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+
+        // 4. 카카오 로그인일 경우 데이터 평탄화 (껍질 벗기기)
+        if ("kakao".equals(registrationId)) {
+            // 카카오는 kakao_account 객체 안에 이메일이 들어있음
+            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+            // 카카오는 kakao_account.profile 객체 안에 닉네임(이름)이 들어있음
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+            // 구글과 똑같은 Key("email", "name")로 최상단에 꺼내놓음
+            attributes.put("email", kakaoAccount.get("email"));
+            attributes.put("name", profile.get("nickname"));
+        }
+
+        // 평탄화된 데이터 확인용 로그
         String email = (String) attributes.get("email");
         String name = (String) attributes.get("name");
+        log.info("[{}] 소셜 로그인 시도 - 이메일: {}, 이름: {}", registrationId.toUpperCase(), email, name);
 
-        log.info("구글 로그인 시도 - 이메일: {}, 이름: {}", email, name);
+        // 5. 로그인 제공자별로 유저 식별 기준값(PK) 가져오기 (구글="sub", 카카오="id")
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
 
-        // 3. 어떠한 DB 접근 로직도 없이 스프링 시큐리티 객체 그대로 반환
-        return oAuth2User;
+        // 6. 평탄화가 완료된 속성들(attributes)을 시큐리티 전용 객체에 담아서 반환!
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                attributes,
+                userNameAttributeName
+        );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/global/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/OAuth2SuccessHandler.java
@@ -30,7 +30,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String email = oAuth2User.getAttribute("email");
         String name = oAuth2User.getAttribute("name");
 
-        SocialAuthResult authResult = socialLoginProcessor.processLoginAndGetRedirectUrl(email, name);
+        // 🌟 1. 어떤 소셜(구글, 카카오)로 로그인했는지 추출!
+        org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken oauthToken =
+                (org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken) authentication;
+        String socialType = oauthToken.getAuthorizedClientRegistrationId().toUpperCase(); // "GOOGLE" 또는 "KAKAO"
+
+        // 🌟 2. 추출한 socialType을 같이 넘겨줍니다.
+        SocialAuthResult authResult = socialLoginProcessor.processLoginAndGetRedirectUrl(email, name, socialType);
 
         // 기존 유저여서 토큰이 발급된 경우 HttpOnly 쿠키 2개 생성
         if (authResult.accessToken() != null && authResult.refreshToken() != null) {

--- a/src/main/java/com/kidmily/algoga_server/global/security/port/SocialLoginProcessor.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/port/SocialLoginProcessor.java
@@ -5,5 +5,5 @@ import com.kidmily.algoga_server.global.security.dto.SocialAuthResult;
 public interface SocialLoginProcessor {
     // 🌟 리다이렉트 주소와 두 가지 토큰(Access, Refresh)을 모두 담아 핸들러로 넘기기 위해
     // 반환 타입을 String에서 SocialAuthResult로 변경했습니다.
-    SocialAuthResult processLoginAndGetRedirectUrl(String email, String name);
+    SocialAuthResult processLoginAndGetRedirectUrl(String email, String name, String socialType);
 }

--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -308,7 +308,7 @@ public class AuthService implements SocialLoginProcessor {
 
     // 🌟 소셜로그인 리다이렉트 및 토큰 발급 (최신 쿠키 전용 버전)
     @Override
-    public SocialAuthResult processLoginAndGetRedirectUrl(String email, String name) {
+    public SocialAuthResult processLoginAndGetRedirectUrl(String email, String name, String socialType) {
         // 이미 가입된 유저인지 DB 확인
         boolean isExistingUser = userRepository.findByEmailAndIsDeletedFalse(email).isPresent();
 
@@ -329,7 +329,7 @@ public class AuthService implements SocialLoginProcessor {
             String redirectUrl = UriComponentsBuilder.fromUriString(frontendBaseUrl + "/auth/register")
                     .queryParam("email", email)
                     .queryParam("name", name)
-                    .queryParam("socialType", "GOOGLE")
+                    .queryParam("socialType", socialType)
                     .build().toUriString();
             return new SocialAuthResult(redirectUrl, null, null);
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,23 @@ spring:
             scope:
               - profile
               - email
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID} # 카카오 디벨로퍼스 REST API 키
+            client-secret: ${KAKAO_CLIENT_SECRET} # (선택) 카카오 보안 설정에서 발급받은 코드
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - account_email
+            client-name: Kakao
+        # 👇 카카오 통신 주소 (구글은 생략 가능하지만 카카오는 필수)
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
   data:
     redis:


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
카카오(Kakao) 및 구글(Google) 소셜 로그인 기능 구현 및 프론트엔드 리다이렉트 연동

## 🔗 Issue
Closes #259

---

## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
[ ] [백엔드] AuthService의 processLoginAndGetRedirectUrl 내 신규/기존 유저 분기 로직과 쿠키 발급이 의도대로 동작하는지 확인해 주세요.

[ ] [백엔드] 로컬에서 카카오 로그인 테스트 시, 카카오 디벨로퍼스의 Redirect URI가 http://localhost:15000/login/oauth2/code/kakao로 설정되어 있어야 정상 작동합니다.

[ ] [프론트엔드] 신규 유저가 소셜 로그인을 시도할 시 /auth/register?email=...&name=...&socialType=... 로 튕겨져 나옵니다. 주소창의 파라미터를 파싱해서 회원가입 폼 기본값으로 적용해 주세요!

[ ] [프론트엔드] 기존 유저가 로그인 성공하여 /auth/oauth-callback으로 떨어졌을 때, 개발자 도구 Application 탭에 쿠키(accessToken, refreshToken)가 정상적으로 들어와 있는지 테스트 부탁드립니다. (요청 시 credentials: 'include' 필수!)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 카카오 소셜 로그인 기능이 추가되었습니다. 기존의 Google 로그인에 더불어 카카오 계정으로 로그인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->