### PR TITLE
[FIX] 배너 사진 유효성 검증 추가

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/banner/presentation/api/request/CreateBannerRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/presentation/api/request/CreateBannerRequest.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.banner.presentation.api.request;
 
+import com.kidmily.algoga_server.banner.presentation.api.validation.ValidBannerImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
@@ -7,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Schema(description = "배너 등록 요청 DTO (multipart/form-data)")
 public record CreateBannerRequest(
         @NotNull(message = "배너 이미지는 필수입니다.")
+        @ValidBannerImage
         @Schema(description = "업로드할 배너 이미지 파일")
         MultipartFile image,
 

--- a/src/main/java/com/kidmily/algoga_server/banner/presentation/api/validation/BannerImageValidator.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/presentation/api/validation/BannerImageValidator.java
@@ -1,0 +1,59 @@
+// 경로: banner/presentation/api/validation/BannerImageValidator.java
+package com.kidmily.algoga_server.banner.presentation.api.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+public class BannerImageValidator implements ConstraintValidator<ValidBannerImage, MultipartFile> {
+
+    private static final long MAX_FILE_SIZE = 5L * 1024 * 1024; // 5MB
+
+    @Override
+    public boolean isValid(MultipartFile file, ConstraintValidatorContext context) {
+        // 파일이 없는 경우는 @NotNull 같은 다른 어노테이션으로 처리하거나 통과시킴 (수정 API 등을 고려)
+        if (file == null || file.isEmpty()) {
+            return true; 
+        }
+
+        context.disableDefaultConstraintViolation();
+
+        // 1. 용량 검사
+        if (file.getSize() >= MAX_FILE_SIZE) {
+            addConstraintViolation(context, "배너 이미지의 크기는 5MB 미만이어야 합니다.");
+            return false;
+        }
+
+        // 2. 해상도 및 형식 검사
+        try {
+            BufferedImage image = ImageIO.read(file.getInputStream());
+            
+            // ImageIO가 읽지 못하는 파일 (확장자 변조 등)
+            if (image == null) {
+                addConstraintViolation(context, "올바른 이미지 파일 형식이 아닙니다. (PNG, JPG, JPEG 권장)");
+                return false;
+            }
+
+            // 해상도 검사 (896 x 200)
+            if (image.getWidth() != 896 || image.getHeight() != 200) {
+                addConstraintViolation(context, "배너 이미지의 해상도는 896x200 이어야 합니다. (현재: " + image.getWidth() + "x" + image.getHeight() + ")");
+                return false;
+            }
+
+        } catch (IOException e) {
+            addConstraintViolation(context, "이미지 파일을 읽는 중 오류가 발생했습니다.");
+            return false;
+        }
+
+        return true;
+    }
+
+    // 커스텀 에러 메시지를 응답으로 보내기 위한 유틸 메서드
+    private void addConstraintViolation(ConstraintValidatorContext context, String errorMessage) {
+        context.buildConstraintViolationWithTemplate(errorMessage)
+               .addConstraintViolation();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/banner/presentation/api/validation/ValidBannerImage.java
+++ b/src/main/java/com/kidmily/algoga_server/banner/presentation/api/validation/ValidBannerImage.java
@@ -1,0 +1,19 @@
+// 경로: banner/presentation/api/validation/ValidBannerImage.java
+package com.kidmily.algoga_server.banner.presentation.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = BannerImageValidator.class) // 이 어노테이션의 로직을 처리할 클래스 지정
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidBannerImage {
+
+    String message() default "배너 이미지는 5MB 미만, 896x200 해상도의 (PNG, JPG, JPEG) 형식이어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
배너 유효성 검증추가
사진 5mb 미만
사진 파일만 첨부가능. PNG, JPG, JPEG

## 🔗 Issue
Closes #267 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 
- [ ]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신기능**
  * 배너 이미지 업로드 시 자동 유효성 검증 기능이 추가되었습니다.
  * 업로드되는 이미지는 PNG 또는 JPG 형식, 5MB 이하 크기, 정확히 896x200 픽셀의 해상도를 만족해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->