### PR TITLE
[Feature] 401, 403 에러처리

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.kidmily.algoga_server.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        // 1. 상태 코드 403 (Forbidden)
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        // 2. 에러 내용 세팅
+        Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put("status", 403);
+        errorDetails.put("code", "FORBIDDEN");
+        errorDetails.put("message", "해당 요청에 대한 접근 권한이 없습니다.");
+
+        // 3. JSON으로 응답
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writeValue(response.getOutputStream(), errorDetails);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.kidmily.algoga_server.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        // 1. 프론트엔드에게 상태 코드 401과 JSON 포맷임을 알립니다.
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        // 2. 에러 내용을 프로젝트 공통 형식에 맞게 만듭니다.
+        Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put("status", 401);
+        errorDetails.put("code", "UNAUTHORIZED");
+        errorDetails.put("message", "로그인이 필요한 서비스입니다. 인증 토큰을 확인해 주세요.");
+
+        // 3. 자바의 Map을 JSON 문자열로 바꿔서 응답으로 쏴줍니다.
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writeValue(response.getOutputStream(), errorDetails);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/global/security/GlobalSecurityConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/GlobalSecurityConfig.java
@@ -26,16 +26,33 @@ public class GlobalSecurityConfig {
     // 소셜 로그인 성공 시 JWT 토큰을 발급하고 프론트엔드로 보내줄 핸들러
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // 🌟 요청하신 대로 모든 경로에 대해 일단 통과(permitAll)시키도록 변경
+                        // 1. 누구나 접근 가능해야 하는 곳 (로그인, 회원가입, 스웨거 등)
+                        .requestMatchers("/api/v1/auth/**", "/oauth2/**", "/login/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+                        // 2. [403 에러 유도] 관리자 페이지는 ADMIN 권한만 접근 가능
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+
+                        // 3. [401 에러 유도] 유저 관련 API는 반드시 로그인(인증) 필수!
+                        .requestMatchers("/api/v1/users/**").authenticated()
+                        // 모든 경로에 대해 일단 통과(permitAll)시키도록
                         // (세부 권한은 각 컨트롤러의 @PreAuthorize에서 처리)
                         .anyRequest().permitAll()
                 )
+
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint) // 401 (로그인 안 함)
+                        .accessDeniedHandler(accessDeniedHandler)           // 403 (권한 없음)
+                )
+
                 // OAuth2 소셜 로그인 설정 시작
                 .oauth2Login(oauth2 -> oauth2
                         // 구글 로그인 성공 후, 구글 서버에서 사용자 정보(이메일, 이름 등)를 가져온 상태에서 실행됨


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
스프링 시큐리티 인증/인가 예외 발생 시, 기본 제공되는 HTML 에러 페이지 대신 프로젝트 공통 JSON 포맷으로 에러 응답을 반환하도록 개선다.

401 Unauthorized (CustomAuthenticationEntryPoint): 인증 토큰이 없거나 만료된 사용자가 접근 시 발생.

403 Forbidden (CustomAccessDeniedHandler): 권한이 없는 사용자가 접근 시 발생.

GlobalSecurityConfig: 위 핸들러들을 시큐리티 필터 체인에 등록.

## 🔗 Issue
Closes #270

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ]  토큰 미포함 요청 시 401 Unauthorized JSON 응답 확인
- [ ] 권한 미달 요청 시 403 Forbidden JSON 응답 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 실패 시 표준화된 JSON 형식의 오류 응답(401) 제공으로 오류 처리 경험 개선
  * 접근 권한 부족 시 표준화된 JSON 형식의 오류 응답(403) 제공
  * 관리자 권한이 필요한 경로와 인증이 필요한 경로를 구분하여 세밀한 접근 제어 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->