### PR TITLE
feat(community): 댓글 좋아요/싫어요 수 반환 추가 및 이미지 형식 검증 강화

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/service/PostQueryService.java
@@ -210,6 +210,8 @@ public class PostQueryService implements PostQueryUseCase {
                         communityQueryPolicy.resolveProfileImageUrl(c.getUserId()),
                         c.getContent(),
                         c.getCreatedAt(),
+                        likeDislikeRepository.countLikes(TargetType.COMMENT, c.getCommentId()),
+                        likeDislikeRepository.countDislikes(TargetType.COMMENT, c.getCommentId()),
                         // 해당 댓글의 대댓글 붙이기
                         comments.stream()
                                 .filter(r -> c.getCommentId().equals(r.getParentId()))
@@ -220,6 +222,8 @@ public class PostQueryService implements PostQueryUseCase {
                                         communityQueryPolicy.resolveProfileImageUrl(r.getUserId()),
                                         r.getContent(),
                                         r.getCreatedAt(),
+                                        likeDislikeRepository.countLikes(TargetType.COMMENT, c.getCommentId()),
+                                        likeDislikeRepository.countDislikes(TargetType.COMMENT, c.getCommentId()),
                                         List.of()
                                 ))
                                 .toList()

--- a/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/community/exception/PostErrorCode.java
@@ -47,7 +47,9 @@ public enum PostErrorCode implements BaseErrorCode {
 
     // 404
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_018", "게시글을 찾을 수 없습니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_019", "댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_019", "댓글을 찾을 수 없습니다."),
+
+    POST_IMAGE_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "POST_026", "이미지 형식은 jpg, jpeg, png, webp만 허용됩니다.");
 
 
 

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/CommunityController.java
@@ -26,9 +26,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,6 +42,10 @@ public class CommunityController {
     private final PostQueryUseCase postQueryUseCase;
     private final CommentCommandUseCase commentCommandUseCase;
     private final UserPort userPort;
+    private static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024L; // 10MB
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp"
+    );
 
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -52,7 +58,8 @@ public class CommunityController {
             "POST_COURSE_TAG_LIMIT_EXCEEDED",
             "POST_IMAGE_COUNT_EXCEEDED",
             "POST_IMAGE_SIZE_EXCEEDED",
-            "ACCOUNT_TYPE_FORBIDDEN"
+            "ACCOUNT_TYPE_FORBIDDEN",
+            "POST_IMAGE_INVALID_FORMAT",
     })
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
             @Valid @ModelAttribute CreatePostRequest request,
@@ -62,6 +69,8 @@ public class CommunityController {
             throw new PostException(PostErrorCode.ACCOUNT_TYPE_FORBIDDEN);
         }
         Long currentUserId = userDetails.getUser().getId();
+
+        validateImages(request.images());
 
         CreatePostCommand command = new CreatePostCommand(
                 currentUserId,
@@ -124,7 +133,8 @@ public class CommunityController {
             "POST_UPDATE_FORBIDDEN",
             "POST_CATEGORY_INVALID",
             "POST_FREE_TAG_LIMIT_EXCEEDED",
-            "ACCOUNT_TYPE_FORBIDDEN"
+            "ACCOUNT_TYPE_FORBIDDEN",
+            "POST_IMAGE_INVALID_FORMAT",
     })
     public ResponseEntity<ApiResponse<UpdatePostResponse>> updatePost(
             @Parameter(description = "게시글 ID", example = "1")
@@ -136,6 +146,8 @@ public class CommunityController {
             throw new PostException(PostErrorCode.ACCOUNT_TYPE_FORBIDDEN);
         }
         Long currentUserId = userDetails.getUser().getId();
+
+        validateImages(request.images());
 
         UpdatePostCommand command = new UpdatePostCommand(
                 postId,
@@ -278,4 +290,17 @@ public class CommunityController {
         return ResponseEntity.noContent().build();
     }
 
+    private void validateImages(List<MultipartFile> images) {
+        if (images == null || images.isEmpty()) return;
+        for (MultipartFile image : images) {
+            if (image == null || image.isEmpty()) continue;
+            if (image.getSize() > MAX_IMAGE_SIZE) {
+                throw new PostException(PostErrorCode.POST_IMAGE_SIZE_EXCEEDED);
+            }
+            String contentType = image.getContentType();
+            if (contentType == null || !ALLOWED_MIME_TYPES.contains(contentType.toLowerCase())) {
+                throw new PostException(PostErrorCode.POST_IMAGE_INVALID_FORMAT);
+            }
+        }
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CommentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/community/presentation/api/response/CommentResponse.java
@@ -25,6 +25,13 @@ public record CommentResponse(
         @Schema(description = "작성일시")
         LocalDateTime createdAt,
 
+        @Schema(description = "좋아요 수", example = "5")
+        Long likeCount,
+
+        @Schema(description = "싫어요 수", example = "1")
+        Long dislikeCount,
+
+
         @Schema(description = "대댓글 목록")
         List<CommentResponse> replies
 ) {}

--- a/src/main/java/com/kidmily/algoga_server/notification/application/service/NotificationQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/service/NotificationQueryService.java
@@ -58,7 +58,9 @@ public class NotificationQueryService implements NotificationQueryUseCase {
                 unreadCount > 0,
                 notifications,
                 notificationPage.hasNext(),
-                notificationPage.getTotalElements()
+                notificationPage.getTotalElements(),
+                notificationPage.getTotalPages(),
+                page
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationListResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/presentation/api/response/NotificationListResponse.java
@@ -19,5 +19,11 @@ public record NotificationListResponse(
         boolean hasNext,
 
         @Schema(description = "전체 알림 수", example = "8")
-        long totalElements
+        long totalElements,
+
+        @Schema(description = "전체 페이지 수", example = "3")
+        int totalPages,
+
+        @Schema(description = "현재 페이지 번호 (1부터 시작)", example = "1")
+        int currentPage
 ) {}


### PR DESCRIPTION
## 설명
커뮤니티 이미지 업로드 유효성 검사 추가 및 댓글 좋아요/싫어요 수 반환 기능을 구현했습니다.

## 🔗 Issue
Closes #277

---

## 확인할 사항
- [ ] 게시글 작성/수정 시 이미지 형식(jpg, png, webp) 및 크기(10MB) 초과 시 에러 응답 확인
- [ ] 게시글 상세 조회 시 댓글 및 대댓글에 likeCount, dislikeCount 포함 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 댓글에 좋아요 및 싫어요 카운트 표시 기능 추가
  * 게시글 이미지 검증 추가 (파일 크기 10MB 제한, jpg/jpeg/png/webp 형식만 지원)
  * 알림 목록에 페이징 정보(전체 항목 수, 전체 페이지 수, 현재 페이지) 표시

* **Documentation**
  * 알림 목록 응답 필드 문서화 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->