### PR TITLE
[Feature] 슈퍼어드민 - 블랙리스트 기능 추가 (유저 도메인 담당자 확인필요)

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/blacklist/application/command/RegisterBlacklistCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/application/command/RegisterBlacklistCommand.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.blacklist.application.command;
+
+public record RegisterBlacklistCommand(
+    Long userId,
+    String reason
+) {
+    public static RegisterBlacklistCommand of(Long userId, String reason) {
+        return new RegisterBlacklistCommand(userId, reason);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/application/port/BlacklistReportPort.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/application/port/BlacklistReportPort.java
@@ -1,0 +1,5 @@
+package com.kidmily.algoga_server.blacklist.application.port;
+
+public interface BlacklistReportPort {
+    long getCompletedReportCount(Long userId);
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/application/service/BlacklistAdminQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/application/service/BlacklistAdminQueryService.java
@@ -1,0 +1,36 @@
+package com.kidmily.algoga_server.blacklist.application.service;
+
+import com.kidmily.algoga_server.blacklist.exception.BlacklistErrorCode;
+import com.kidmily.algoga_server.blacklist.exception.BlacklistException;
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.repository.BlacklistQueryRepository;
+import com.kidmily.algoga_server.blacklist.presentation.api.response.BlacklistCandidateDetailResponse;
+import com.kidmily.algoga_server.global.common.api.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlacklistAdminQueryService {
+
+    private final BlacklistQueryRepository queryRepository;
+
+    public PageResponse<BlacklistCandidateDetailResponse> getCandidateUserList(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(Math.max(0, page - 1), size);
+        
+        Page<BlacklistCandidateDetailResponse> result = queryRepository.findAllCandidateUsers(pageRequest)
+                .map(BlacklistCandidateDetailResponse::from);
+
+        return PageResponse.from(result);
+    }
+
+    public BlacklistCandidateDetailResponse getCandidateUserDetail(Long userId) {
+        // 예외 처리 4: 후보 유저 상세조회 시 데이터 없으면 예외 발생
+        return queryRepository.findCandidateUserDetailById(userId)
+                .map(BlacklistCandidateDetailResponse::from)
+                .orElseThrow(() -> new BlacklistException(BlacklistErrorCode.CANDIDATE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/application/service/BlacklistCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/application/service/BlacklistCommandService.java
@@ -1,0 +1,57 @@
+package com.kidmily.algoga_server.blacklist.application.service;
+
+import com.kidmily.algoga_server.blacklist.application.command.RegisterBlacklistCommand;
+import com.kidmily.algoga_server.blacklist.application.port.BlacklistReportPort;
+import com.kidmily.algoga_server.blacklist.application.usecase.BlacklistCommandUseCase;
+import com.kidmily.algoga_server.blacklist.domain.model.Blacklist;
+import com.kidmily.algoga_server.blacklist.domain.model.BlacklistStatus;
+import com.kidmily.algoga_server.blacklist.domain.repository.BlacklistRepository;
+import com.kidmily.algoga_server.blacklist.exception.BlacklistErrorCode;
+import com.kidmily.algoga_server.blacklist.exception.BlacklistException;
+import com.kidmily.algoga_server.global.event.UserBlacklistedEvent;
+import com.kidmily.algoga_server.global.event.UserUnblacklistedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BlacklistCommandService implements BlacklistCommandUseCase {
+
+    private final BlacklistRepository blacklistRepository;
+    private final BlacklistReportPort reportPort;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void registerBlacklist(RegisterBlacklistCommand command) {
+        // 예외 처리 1: 이미 블랙리스트인지 검증
+        if (blacklistRepository.existsByUserIdAndStatus(command.userId(), BlacklistStatus.ACTIVE)) {
+            throw new BlacklistException(BlacklistErrorCode.ALREADY_BLACKLISTED);
+        }
+
+        // 예외 처리 2: 신고 횟수 5회 이상 검증
+        long reportCount = reportPort.getCompletedReportCount(command.userId());
+        if (reportCount < 5) {
+            throw new BlacklistException(BlacklistErrorCode.NOT_ENOUGH_REPORTS);
+        }
+
+        Blacklist blacklist = Blacklist.create(command.userId(), command.reason());
+        blacklistRepository.save(blacklist);
+
+        eventPublisher.publishEvent(new UserBlacklistedEvent(command.userId()));
+    }
+
+    @Override
+    public void deregisterBlacklist(Long userId) {
+        // 예외 처리 3: 등록된 블랙리스트 내역이 없으면 해제 불가
+        Blacklist blacklist = blacklistRepository.findByUserIdAndStatus(userId, BlacklistStatus.ACTIVE)
+                .orElseThrow(() -> new BlacklistException(BlacklistErrorCode.BLACKLIST_NOT_FOUND));
+
+        blacklist.deregister();
+        blacklistRepository.save(blacklist);
+
+        eventPublisher.publishEvent(new UserUnblacklistedEvent(userId));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/application/usecase/BlacklistCommandUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/application/usecase/BlacklistCommandUseCase.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.blacklist.application.usecase;
+
+import com.kidmily.algoga_server.blacklist.application.command.RegisterBlacklistCommand;
+
+public interface BlacklistCommandUseCase {
+    void registerBlacklist(RegisterBlacklistCommand command);
+    void deregisterBlacklist(Long userId);
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/domain/model/Blacklist.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/domain/model/Blacklist.java
@@ -1,0 +1,39 @@
+package com.kidmily.algoga_server.blacklist.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class Blacklist {
+    private final Long id;
+    private final Long userId;
+    private final String reason;
+    private BlacklistStatus status;
+    private final LocalDateTime createdAt;
+    private LocalDateTime unblacklistedAt;
+
+    @Builder
+    public Blacklist(Long id, Long userId, String reason, BlacklistStatus status, LocalDateTime createdAt, LocalDateTime unblacklistedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.reason = reason;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.unblacklistedAt = unblacklistedAt;
+    }
+
+    public static Blacklist create(Long userId, String reason) {
+        return Blacklist.builder()
+                .userId(userId)
+                .reason(reason)
+                .status(BlacklistStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void deregister() {
+        this.status = BlacklistStatus.INACTIVE;
+        this.unblacklistedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/domain/model/BlacklistStatus.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/domain/model/BlacklistStatus.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.blacklist.domain.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "블랙리스트 상태 (ACTIVE: 적용 중, INACTIVE: 해제됨)")
+public enum BlacklistStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/domain/repository/BlacklistRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/domain/repository/BlacklistRepository.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.blacklist.domain.repository;
+
+import com.kidmily.algoga_server.blacklist.domain.model.Blacklist;
+import com.kidmily.algoga_server.blacklist.domain.model.BlacklistStatus;
+
+import java.util.Optional;
+
+public interface BlacklistRepository {
+    Blacklist save(Blacklist blacklist);
+    boolean existsByUserIdAndStatus(Long userId, BlacklistStatus status);
+    Optional<Blacklist> findByUserIdAndStatus(Long userId, BlacklistStatus status);
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/exception/BlacklistErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/exception/BlacklistErrorCode.java
@@ -1,0 +1,19 @@
+package com.kidmily.algoga_server.blacklist.exception;
+
+import com.kidmily.algoga_server.global.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BlacklistErrorCode implements BaseErrorCode {
+    ALREADY_BLACKLISTED(HttpStatus.CONFLICT, "BLACKLIST_001", "이미 블랙리스트에 등록된 유저입니다."),
+    BLACKLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "BLACKLIST_002", "현재 블랙리스트에 등록되어 있지 않은 유저입니다."),
+    NOT_ENOUGH_REPORTS(HttpStatus.BAD_REQUEST, "BLACKLIST_003", "처리 완료된 신고 횟수가 부족하여(5회 미만) 블랙리스트로 등록할 수 없습니다."),
+    CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "BLACKLIST_004", "해당하는 블랙리스트 후보 유저 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/exception/BlacklistException.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/exception/BlacklistException.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.blacklist.exception;
+
+import com.kidmily.algoga_server.global.exception.BusinessException;
+
+public class BlacklistException extends BusinessException {
+    public BlacklistException(BlacklistErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/mapper/BlacklistMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/mapper/BlacklistMapper.java
@@ -1,0 +1,33 @@
+package com.kidmily.algoga_server.blacklist.infrastructure.mapper;
+
+import com.kidmily.algoga_server.blacklist.domain.model.Blacklist;
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.entity.BlacklistJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BlacklistMapper {
+
+    public BlacklistJpaEntity toJpaEntity(Blacklist domain) {
+        if (domain == null) return null;
+        return BlacklistJpaEntity.builder()
+                .id(domain.getId())
+                .userId(domain.getUserId())
+                .reason(domain.getReason())
+                .status(domain.getStatus())
+                .createdAt(domain.getCreatedAt())
+                .unblacklistedAt(domain.getUnblacklistedAt())
+                .build();
+    }
+
+    public Blacklist toDomain(BlacklistJpaEntity entity) {
+        if (entity == null) return null;
+        return Blacklist.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .reason(entity.getReason())
+                .status(entity.getStatus())
+                .createdAt(entity.getCreatedAt())
+                .unblacklistedAt(entity.getUnblacklistedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/BlacklistReportAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/BlacklistReportAdapter.java
@@ -1,0 +1,19 @@
+package com.kidmily.algoga_server.blacklist.infrastructure.persistence;
+
+import com.kidmily.algoga_server.blacklist.application.port.BlacklistReportPort;
+import com.kidmily.algoga_server.report.domain.model.ReportStatus;
+import com.kidmily.algoga_server.report.domain.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BlacklistReportAdapter implements BlacklistReportPort {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    public long getCompletedReportCount(Long userId) {
+        return reportRepository.countByReportedUserIdAndStatus(userId, ReportStatus.COMPLETED);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/BlacklistRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/BlacklistRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package com.kidmily.algoga_server.blacklist.infrastructure.persistence;
+
+import com.kidmily.algoga_server.blacklist.domain.model.Blacklist;
+import com.kidmily.algoga_server.blacklist.domain.model.BlacklistStatus;
+import com.kidmily.algoga_server.blacklist.domain.repository.BlacklistRepository;
+import com.kidmily.algoga_server.blacklist.infrastructure.mapper.BlacklistMapper;
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.entity.BlacklistJpaEntity;
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.repository.SpringDataBlacklistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class BlacklistRepositoryAdapter implements BlacklistRepository {
+
+    private final SpringDataBlacklistRepository springDataRepository;
+    private final BlacklistMapper mapper;
+
+    @Override
+    public Blacklist save(Blacklist blacklist) {
+        BlacklistJpaEntity entity = mapper.toJpaEntity(blacklist);
+        BlacklistJpaEntity savedEntity = springDataRepository.save(entity);
+        return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public boolean existsByUserIdAndStatus(Long userId, BlacklistStatus status) {
+        return springDataRepository.existsByUserIdAndStatus(userId, status);
+    }
+
+    @Override
+    public Optional<Blacklist> findByUserIdAndStatus(Long userId, BlacklistStatus status) {
+        return springDataRepository.findByUserIdAndStatus(userId, status)
+                .map(mapper::toDomain);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/entity/BlacklistJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/entity/BlacklistJpaEntity.java
@@ -1,0 +1,45 @@
+package com.kidmily.algoga_server.blacklist.infrastructure.persistence.entity;
+
+import com.kidmily.algoga_server.blacklist.domain.model.BlacklistStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "blacklists")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlacklistJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, name = "user_id")
+    private Long userId;
+
+    @Column(nullable = false, length = 500)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BlacklistStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime unblacklistedAt;
+
+    @Builder
+    public BlacklistJpaEntity(Long id, Long userId, String reason, BlacklistStatus status, LocalDateTime createdAt, LocalDateTime unblacklistedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.reason = reason;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.unblacklistedAt = unblacklistedAt;
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/query/BlacklistUserQueryProjection.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/query/BlacklistUserQueryProjection.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.blacklist.infrastructure.persistence.query;
+
+import java.time.LocalDateTime;
+
+public interface BlacklistUserQueryProjection {
+    Long getUserId();
+    String getUsername();
+    String getName();
+    String getNickname();
+    String getEmail();
+    Long getReportCount();
+    LocalDateTime getLastReportedAt();
+    Integer getIsBlacklisted();
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/repository/BlacklistQueryRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/repository/BlacklistQueryRepository.java
@@ -1,0 +1,46 @@
+package com.kidmily.algoga_server.blacklist.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.entity.BlacklistJpaEntity;
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.query.BlacklistUserQueryProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface BlacklistQueryRepository extends JpaRepository<BlacklistJpaEntity, Long> {
+
+    @Query(value = """
+            SELECT 
+                u.user_id AS userId, u.username AS username, u.name AS name, 
+                u.nickname AS nickname, u.email AS email,
+                (SELECT COUNT(r.report_id) FROM reports r WHERE r.reported_user_id = u.user_id AND r.status = 'COMPLETED') AS reportCount,
+                (SELECT MAX(r.created_at) FROM reports r WHERE r.reported_user_id = u.user_id AND r.status = 'COMPLETED') AS lastReportedAt,
+                (SELECT COUNT(b.id) FROM blacklists b WHERE b.user_id = u.user_id AND b.status = 'ACTIVE') AS isBlacklisted
+            FROM users u
+            WHERE u.is_deleted = false
+              AND (SELECT COUNT(r.report_id) FROM reports r WHERE r.reported_user_id = u.user_id AND r.status = 'COMPLETED') >= 5
+            """,
+            countQuery = """
+            SELECT COUNT(u.user_id) 
+            FROM users u 
+            WHERE u.is_deleted = false 
+              AND (SELECT COUNT(r.report_id) FROM reports r WHERE r.reported_user_id = u.user_id AND r.status = 'COMPLETED') >= 5
+            """,
+            nativeQuery = true)
+    Page<BlacklistUserQueryProjection> findAllCandidateUsers(Pageable pageable);
+
+    @Query(value = """
+            SELECT 
+                u.user_id AS userId, u.username AS username, u.name AS name, 
+                u.nickname AS nickname, u.email AS email,
+                (SELECT COUNT(r.report_id) FROM reports r WHERE r.reported_user_id = u.user_id AND r.status = 'COMPLETED') AS reportCount,
+                (SELECT MAX(r.created_at) FROM reports r WHERE r.reported_user_id = u.user_id AND r.status = 'COMPLETED') AS lastReportedAt,
+                (SELECT COUNT(b.id) FROM blacklists b WHERE b.user_id = u.user_id AND b.status = 'ACTIVE') AS isBlacklisted
+            FROM users u
+            WHERE u.user_id = :userId AND u.is_deleted = false
+            """, nativeQuery = true)
+    Optional<BlacklistUserQueryProjection> findCandidateUserDetailById(@Param("userId") Long userId);
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/repository/SpringDataBlacklistRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/infrastructure/persistence/repository/SpringDataBlacklistRepository.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.blacklist.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.blacklist.domain.model.BlacklistStatus;
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.entity.BlacklistJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataBlacklistRepository extends JpaRepository<BlacklistJpaEntity, Long> {
+    boolean existsByUserIdAndStatus(Long userId, BlacklistStatus status);
+    Optional<BlacklistJpaEntity> findByUserIdAndStatus(Long userId, BlacklistStatus status);
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/AdminBlacklistController.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/AdminBlacklistController.java
@@ -1,0 +1,72 @@
+package com.kidmily.algoga_server.blacklist.presentation.api;
+
+import com.kidmily.algoga_server.blacklist.application.command.RegisterBlacklistCommand;
+import com.kidmily.algoga_server.blacklist.application.service.BlacklistAdminQueryService;
+import com.kidmily.algoga_server.blacklist.application.usecase.BlacklistCommandUseCase;
+import com.kidmily.algoga_server.blacklist.exception.BlacklistErrorCode;
+import com.kidmily.algoga_server.blacklist.presentation.api.request.RegisterBlacklistRequest;
+import com.kidmily.algoga_server.blacklist.presentation.api.response.BlacklistCandidateDetailResponse;
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.common.api.response.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/blacklists")
+@PreAuthorize("hasAnyRole('CS_MANAGER', 'SUPER_ADMIN')")
+@Tag(name = "Admin Blacklist", description = "관리자 전용 블랙리스트 조회 및 관리 API")
+public class AdminBlacklistController {
+
+    private final BlacklistCommandUseCase commandUseCase;
+    private final BlacklistAdminQueryService adminQueryService;
+
+    @Operation(summary = "블랙리스트 후보 유저 전체 목록 페이징 조회", description = "신고 횟수가 5회 이상인 유저들의 목록을 페이징하여 조회합니다. (블랙리스트 등록 화면용 데이터)")
+    @GetMapping("/candidates")
+    public ApiResponse<PageResponse<BlacklistCandidateDetailResponse>> getCandidateList(
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1") @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지당 항목 수", example = "10") @RequestParam(defaultValue = "10") int size
+    ) {
+        PageResponse<BlacklistCandidateDetailResponse> response = adminQueryService.getCandidateUserList(page, size);
+        return ApiResponse.success("BLACKLIST_CANDIDATES_SUCCESS", "블랙리스트 후보 목록을 성공적으로 조회했습니다.", response);
+    }
+
+    @Operation(summary = "블랙리스트 후보 단일 유저 상세 조회", description = "신고 5회 이상 유저 1명의 정보(유저 정보, 누적 신고 횟수, 현재 블랙리스트 여부)를 상세 조회합니다.")
+    @ApiErrorCodeExample(domain = BlacklistErrorCode.class, value = {"CANDIDATE_NOT_FOUND"})
+    @GetMapping("/candidates/{userId}")
+    public ApiResponse<BlacklistCandidateDetailResponse> getCandidateDetail(
+            @Parameter(description = "조회할 유저 ID", example = "105") @PathVariable Long userId
+    ) {
+        BlacklistCandidateDetailResponse response = adminQueryService.getCandidateUserDetail(userId);
+        return ApiResponse.success("BLACKLIST_CANDIDATE_DETAIL_SUCCESS", "블랙리스트 후보 상세 정보를 성공적으로 조회했습니다.", response);
+    }
+
+    @Operation(summary = "유저 블랙리스트 등록", description = "신고 횟수 조건을 검증한 뒤 해당 유저를 블랙리스트에 등록하고, 접속 중인 토큰을 즉시 만료시킵니다.")
+    @ApiErrorCodeExample(domain = BlacklistErrorCode.class, value = {
+            "ALREADY_BLACKLISTED",
+            "NOT_ENOUGH_REPORTS"
+    })
+    @PostMapping("/{userId}")
+    public ApiResponse<Void> registerBlacklist(
+            @Parameter(description = "블랙리스트에 등록할 유저 ID", example = "105") @PathVariable Long userId,
+            @Valid @RequestBody RegisterBlacklistRequest request) {
+        commandUseCase.registerBlacklist(RegisterBlacklistCommand.of(userId, request.reason()));
+        return ApiResponse.success("BLACKLIST_REGISTER_SUCCESS", "해당 유저를 블랙리스트에 성공적으로 등록했습니다.");
+    }
+
+    @Operation(summary = "유저 블랙리스트 해제", description = "블랙리스트에 등록된 유저의 상태를 해제하여 다시 서비스 이용 및 로그인이 가능하도록 조치합니다.")
+    @ApiErrorCodeExample(domain = BlacklistErrorCode.class, value = {"BLACKLIST_NOT_FOUND"})
+    @PatchMapping("/{userId}/deregister")
+    public ApiResponse<Void> deregisterBlacklist(
+            @Parameter(description = "블랙리스트를 해제할 유저 ID", example = "105") @PathVariable Long userId
+    ) {
+        commandUseCase.deregisterBlacklist(userId);
+        return ApiResponse.success("BLACKLIST_DEREGISTER_SUCCESS", "유저의 블랙리스트 등록이 해제되었습니다.");
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/AdminBlacklistController.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/AdminBlacklistController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/blacklists")
-@PreAuthorize("hasAnyRole('CS_MANAGER', 'SUPER_ADMIN')")
+@PreAuthorize("hasAnyRole('SUPER_ADMIN')")
 @Tag(name = "Admin Blacklist", description = "관리자 전용 블랙리스트 조회 및 관리 API")
 public class AdminBlacklistController {
 

--- a/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/request/RegisterBlacklistRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/request/RegisterBlacklistRequest.java
@@ -1,0 +1,10 @@
+package com.kidmily.algoga_server.blacklist.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterBlacklistRequest(
+    @Schema(description = "블랙리스트에 등록하는 상세 사유", example = "운영정책 5회 이상 위반 및 지속적인 악성 스팸 댓글 게시")
+    @NotBlank(message = "블랙리스트 등록 사유는 누락될 수 없습니다.")
+    String reason
+) {}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/response/BlacklistCandidateDetailResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/response/BlacklistCandidateDetailResponse.java
@@ -1,0 +1,44 @@
+package com.kidmily.algoga_server.blacklist.presentation.api.response;
+
+import com.kidmily.algoga_server.blacklist.infrastructure.persistence.query.BlacklistUserQueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record BlacklistCandidateDetailResponse(
+        @Schema(description = "유저 고유 PK", example = "105")
+        Long userId,
+
+        @Schema(description = "로그인 아이디", example = "baduser123")
+        String username,
+
+        @Schema(description = "유저 실명", example = "홍길동")
+        String name,
+
+        @Schema(description = "유저 닉네임", example = "악플러킬러")
+        String nickname,
+
+        @Schema(description = "유저 이메일", example = "baduser@example.com")
+        String email,
+
+        @Schema(description = "처리 완료된 누적 신고 횟수", example = "7")
+        long reportCount,
+
+        @Schema(description = "마지막 신고 접수/처리 일시", example = "2026-06-16T15:30:00")
+        LocalDateTime lastReportedAt,
+
+        @Schema(description = "현재 블랙리스트 등록 상태 여부 (true: 정지됨, false: 정상 이용중)", example = "false")
+        boolean isBlacklisted
+) {
+    public static BlacklistCandidateDetailResponse from(BlacklistUserQueryProjection p) {
+        return new BlacklistCandidateDetailResponse(
+                p.getUserId(),
+                p.getUsername(),
+                p.getName(),
+                p.getNickname(),
+                p.getEmail(),
+                p.getReportCount() != null ? p.getReportCount() : 0L,
+                p.getLastReportedAt(),
+                p.getIsBlacklisted() != null && p.getIsBlacklisted() > 0
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/response/BlacklistResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/blacklist/presentation/api/response/BlacklistResponse.java
@@ -1,0 +1,42 @@
+package com.kidmily.algoga_server.blacklist.presentation.api.response;
+
+import com.kidmily.algoga_server.blacklist.domain.model.Blacklist;
+import com.kidmily.algoga_server.blacklist.domain.model.BlacklistStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "블랙리스트 단건 기본 응답 DTO")
+public record BlacklistResponse(
+        @Schema(description = "블랙리스트 내역 고유 ID (PK)", example = "1")
+        Long id,
+
+        @Schema(description = "블랙리스트에 제재된 유저 ID", example = "105")
+        Long userId,
+
+        @Schema(description = "블랙리스트 등록 상세 사유", example = "운영정책 5회 이상 위반 및 지속적인 악성 스팸 댓글 게시")
+        String reason,
+
+        @Schema(description = "현재 블랙리스트 상태 (ACTIVE: 적용 중, INACTIVE: 해제됨)", example = "ACTIVE")
+        BlacklistStatus status,
+
+        @Schema(description = "블랙리스트 등록 일시", example = "2026-06-16T15:30:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "블랙리스트 해제 일시 (아직 해제되지 않은 경우 null)", nullable = true, example = "null")
+        LocalDateTime unblacklistedAt
+) {
+    public static BlacklistResponse from(Blacklist domain) {
+        if (domain == null) {
+            return null;
+        }
+        return new BlacklistResponse(
+                domain.getId(),
+                domain.getUserId(),
+                domain.getReason(),
+                domain.getStatus(),
+                domain.getCreatedAt(),
+                domain.getUnblacklistedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/global/event/UserBlacklistedEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/global/event/UserBlacklistedEvent.java
@@ -1,0 +1,3 @@
+package com.kidmily.algoga_server.global.event;
+
+public record UserBlacklistedEvent(Long userId) {}

--- a/src/main/java/com/kidmily/algoga_server/global/event/UserUnblacklistedEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/global/event/UserUnblacklistedEvent.java
@@ -1,0 +1,3 @@
+package com.kidmily.algoga_server.global.event;
+
+public record UserUnblacklistedEvent(Long userId) {}

--- a/src/main/java/com/kidmily/algoga_server/global/security/GlobalJwtAuthenticationFilter.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/GlobalJwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -25,6 +26,7 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final GlobalJwtProvider globalJwtProvider;
     private final CustomUserDetailsService customUserDetailsService;
+    private final RedisTemplate<String, String> redisTemplate; // 🌟 블랙리스트 검증용 Redis 추가
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -50,6 +52,17 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
 
                 } else if ("USER".equals(type)) {
                     String email = globalJwtProvider.getSubject(token);
+
+                    // 🌟 블랙리스트 등록된 유저인지 Redis 검증 (Access Token 무효화)
+                    String isBlacklisted = redisTemplate.opsForValue().get("BLACKLIST:" + email);
+                    if ("true".equals(isBlacklisted)) {
+                        log.warn("블랙리스트 유저의 비정상적 API 접근 시도 차단: {}", email);
+                        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                        response.setContentType("application/json;charset=UTF-8");
+                        response.getWriter().write("{\"code\":\"AUTH_015\",\"message\":\"블랙리스트에 등록되어 접근이 영구히 제한된 계정입니다. 고객센터에 문의하세요.\"}");
+                        return;
+                    }
+
                     CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
 
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -159,6 +159,13 @@ public class AuthService implements SocialLoginProcessor {
             throw new UserException(UserErrorCode.ACCOUNT_LOCKED);
         }
 
+        // 🌟 블랙리스트 여부 확인하여 로그인 원천 차단
+        String isBlacklisted = redisTemplate.opsForValue().get("BLACKLIST:" + user.getEmail());
+        if ("true".equals(isBlacklisted)) {
+            log.warn("블랙리스트 유저의 로그인 시도 차단 [아이디: {}]", user.getUsername());
+            throw new AuthException(AuthErrorCode.BLACKLISTED_USER);
+        }
+
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             user.increaseLoginFailure();
             userRepository.save(user);
@@ -254,6 +261,13 @@ public class AuthService implements SocialLoginProcessor {
 
     // 토큰 재발급을 위한 검증 메서드
     public String refreshAccessToken(String email, String refreshToken) {
+        // 🌟 블랙리스트 여부 확인하여 재발급 차단
+        String isBlacklisted = redisTemplate.opsForValue().get("BLACKLIST:" + email);
+        if ("true".equals(isBlacklisted)) {
+            log.warn("블랙리스트 유저의 토큰 재발급 시도 차단 [이메일: {}]", email);
+            throw new AuthException(AuthErrorCode.BLACKLISTED_USER);
+        }
+
         String savedRefreshToken = redisTemplate.opsForValue().get("RT:" + email);
 
         if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
@@ -315,6 +329,14 @@ public class AuthService implements SocialLoginProcessor {
         boolean isExistingUser = userRepository.findByEmailAndIsDeletedFalse(email).isPresent();
 
         if (isExistingUser) {
+            // 🌟 블랙리스트 여부 확인
+            String isBlacklisted = redisTemplate.opsForValue().get("BLACKLIST:" + email);
+            if ("true".equals(isBlacklisted)) {
+                log.warn("블랙리스트 유저의 소셜 로그인 시도 차단 [이메일: {}]", email);
+                // 블랙리스트 차단 시 프론트엔드의 에러 페이지나 처리 화면으로 리다이렉트 (선택 사항)
+                return new SocialAuthResult(frontendBaseUrl + "/login?error=blacklisted", null, null);
+            }
+
             String accessToken = globalJwtProvider.createUserAccessToken(email);
             String refreshToken = globalJwtProvider.createUserRefreshToken(email);
 
@@ -339,4 +361,3 @@ public class AuthService implements SocialLoginProcessor {
         }
     }
 }
-

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserEventListener.java
@@ -1,0 +1,51 @@
+package com.kidmily.algoga_server.user.application;
+
+import com.kidmily.algoga_server.global.event.UserBlacklistedEvent;
+import com.kidmily.algoga_server.global.event.UserUnblacklistedEvent; // 🌟 추가
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserEventListener {
+
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // --- 기존: 블랙리스트 등록 시 차단 ---
+    @EventListener
+    public void handleUserBlacklisted(UserBlacklistedEvent event) {
+        User user = userRepository.findById(event.userId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        redisTemplate.delete("RT:" + user.getEmail());
+
+        redisTemplate.opsForValue().set(
+                "BLACKLIST:" + user.getEmail(),
+                "true",
+                30,
+                TimeUnit.MINUTES
+        );
+
+        log.info("[Security Event Hook] 유저 토큰 즉시 무효화 및 로그인 제한 설정 완료: {}", user.getEmail());
+    }
+
+    // --- 🌟 추가: 블랙리스트 해제 시 Redis 차단 즉시 삭제 ---
+    @EventListener
+    public void handleUserUnblacklisted(UserUnblacklistedEvent event) {
+        User user = userRepository.findById(event.userId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        // Redis에서 블랙리스트 상태값을 삭제하여 즉시 로그인 가능하도록 조치
+        redisTemplate.delete("BLACKLIST:" + user.getEmail());
+
+        log.info("[Security Event Hook] 유저 블랙리스트 해제 완료, 로그인 제한 해제: {}", user.getEmail());
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/exception/AuthErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/user/exception/AuthErrorCode.java
@@ -28,8 +28,8 @@ public enum AuthErrorCode implements BaseErrorCode {
     // 4. 이메일 인증 관련 (추가하신다면 필수!)
     EMAIL_AUTH_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH_012", "인증번호가 만료되었습니다."),
     EMAIL_AUTH_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_013", "인증번호가 일치하지 않습니다."),
-    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH_014", "이메일 인증이 완료되지 않았습니다.");
-    
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH_014", "이메일 인증이 완료되지 않았습니다."),
+    BLACKLISTED_USER(HttpStatus.FORBIDDEN, "AUTH_015", "블랙리스트에 등록되어 접근이 영구히 제한된 계정입니다. 고객센터에 문의하세요.");
     private final HttpStatus status;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
user 도메인을 포트로 이벤트 발행하여 블랙리스트한 유저의 토큰을 만료시킴. (프론트에서 403 상태가 되면 로그인페이지로 가는 예외처리 필요)
두 개 이상의 도메인에서 얻어오기에 쿼리문으로 갖고옴. (로직이 복잡하게 되어있음. 쿼리로 코드 로직 단순화)


## 🔗 Issue
Closes #202 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 유저 도메인 이외에 건든 도메인이 있는지 확인
- [ ] 유저 도메인 그대로 작동하는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user blacklist management system for administrators
  * Implemented candidate user review list with report count and blacklist status
  * Added blacklist registration and deregistration endpoints
  * Integrated real-time blacklist validation during login and token refresh
  * Blacklisted users are now immediately prevented from accessing the platform

* **Bug Fixes**
  * Added authentication validation to prevent blacklisted users from obtaining new tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->