### PR TITLE
예약 결제 동시서 제어및 분삭락

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ dependencies {
 
     annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
     implementation 'com.bucket4j:bucket4j-redis:8.10.1'
+    implementation 'org.redisson:redisson:3.27.2'
    
 }
 

--- a/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/booking/application/service/BookingCommandService.java
@@ -11,6 +11,7 @@ import com.kidmily.algoga_server.booking.domain.model.BookingStatus;
 import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
 import com.kidmily.algoga_server.booking.exception.BookingErrorCode;
 import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.global.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -33,6 +34,7 @@ public class BookingCommandService implements BookingCommandUseCase {
     private final AccommodationRepository accommodationRepository;
     private final ApplicationEventPublisher eventPublisher;
 
+    @DistributedLock(key = "'booking:' + #command.userId() + ':' + #command.accommodationId() + ':' + #command.checkInDate()")
     @CacheEvict(value = "myBookings", key = "#command.userId()")
     @Override
     public Long handle(CreateBookingCommand command) {

--- a/src/main/java/com/kidmily/algoga_server/global/config/RedissonConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/RedissonConfig.java
@@ -1,0 +1,26 @@
+package com.kidmily.algoga_server.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/global/exception/GlobalErrorCode.java
@@ -11,7 +11,8 @@ public enum GlobalErrorCode implements BaseErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "GLOBAL_002", "잘못된 요청입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "GLOBAL_003", "지원하지 않는 HTTP 메서드입니다."),
     API_NOT_FOUND(HttpStatus.NOT_FOUND, "GLOBAL_004", "요청하신 API 경로를 찾을 수 없습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "GLOBAL_005", "접근 권한이 없습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "GLOBAL_005", "접근 권한이 없습니다."),
+    CONCURRENT_REQUEST(HttpStatus.CONFLICT, "GLOBAL_006", "요청이 처리 중입니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kidmily/algoga_server/global/lock/DistributedLock.java
+++ b/src/main/java/com/kidmily/algoga_server/global/lock/DistributedLock.java
@@ -1,0 +1,14 @@
+package com.kidmily.algoga_server.global.lock;
+
+import java.lang.annotation.*;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DistributedLock {
+    String key();
+    long waitTime() default 5L;
+    long leaseTime() default 3L;
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/com/kidmily/algoga_server/global/lock/DistributedLockAspect.java
+++ b/src/main/java/com/kidmily/algoga_server/global/lock/DistributedLockAspect.java
@@ -1,0 +1,69 @@
+package com.kidmily.algoga_server.global.lock;
+
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Order(1)
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private static final String LOCK_PREFIX = "lock:";
+    private final RedissonClient redissonClient;
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(distributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        String lockKey = LOCK_PREFIX + resolveKey(joinPoint, distributedLock.key());
+        RLock lock = redissonClient.getLock(lockKey);
+
+        boolean acquired = lock.tryLock(
+                distributedLock.waitTime(),
+                distributedLock.leaseTime(),
+                distributedLock.timeUnit()
+        );
+
+        if (!acquired) {
+            log.warn("[DistributedLock] 락 획득 실패 - key: {}", lockKey);
+            throw new BusinessException(GlobalErrorCode.CONCURRENT_REQUEST);
+        }
+
+        log.info("[DistributedLock] 락 획득 - key: {}", lockKey);
+        try {
+            return joinPoint.proceed();
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("[DistributedLock] 락 해제 - key: {}", lockKey);
+            }
+        }
+    }
+
+    private String resolveKey(ProceedingJoinPoint joinPoint, String keyExpression) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandService.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.payment.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.kidmily.algoga_server.global.lock.DistributedLock;
 import com.kidmily.algoga_server.payment.application.command.CreateLecturePaymentCommand;
 import com.kidmily.algoga_server.payment.application.command.CreatePaymentCommand;
 import com.kidmily.algoga_server.payment.application.usecase.PaymentCommandUseCase;
@@ -31,6 +32,7 @@ public class PaymentCommandService implements PaymentCommandUseCase {
     private final Counter paymentFailedTotal;
     private final Timer portoneApiDurationSeconds;
 
+    @DistributedLock(key = "'payment:' + #command.bookingId()")
     @Override
     public Long handle(CreatePaymentCommand command) {
         log.info("[PaymentCommandService] 결제 요청 - bookingId: {}, type: {}, amount: {}",
@@ -57,6 +59,7 @@ public class PaymentCommandService implements PaymentCommandUseCase {
         });
     }
 
+    @DistributedLock(key = "'payment:lecture:' + #command.courseId() + ':' + #command.userId()")
     @Override
     public Long handleLecturePayment(CreateLecturePaymentCommand command) {
         log.info("[PaymentCommandService] 강의 단독 결제 요청 - courseId: {}, userId: {}, amount: {}",


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
Redisson 분산 락을 도입해 예약/결제 동시 요청 시 발생할 수 있는 중복 처리 문제를 방지합니다.

주요 변경 사항

build.gradle — redisson:3.27.2 의존성 추가 (기존 Redis 재사용, 별도 인프라 불필요)
global/config/RedissonConfig.java — RedissonClient 빈 등록 (SingleServer, localhost:6379)
global/lock/DistributedLock.java — 커스텀 어노테이션 (SpEL key 표현식, waitTime 5s, leaseTime 3s)
global/lock/DistributedLockAspect.java — AOP @Order(1) 적용, 락 바깥에서 트랜잭션이 감싸지도록 순서 설정
GlobalErrorCode.CONCURRENT_REQUEST (GLOBAL_006, 409) 추가
락 적용 대상
## 🔗 Issue
Closes #284

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
동일 조건으로 예약 동시 요청 시 하나만 성공하고 나머지는 409 반환되는지 확인
미완료
동일 bookingId로 결제 동시 요청 시 중복 결제 없이 409 반환되는지 확인
미완료
락 획득 실패 시 CONCURRENT_REQUEST (GLOBAL_006, 409) 에러코드 정상 반환되는지 확인
미완료
기존 예약/결제 단건 정상 흐름 회귀 없는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 예약 생성 시 동시 요청 처리 개선
  * 결제 처리 시 동시 요청 제어 강화

* **새로운 기능**
  * 동시 요청 발생 시 사용자 안내 메시지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->