### PR TITLE
그라파나수정및 내용추가

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/health/FlightApiHealthIndicator.java
+++ b/src/main/java/com/kidmily/algoga_server/global/health/FlightApiHealthIndicator.java
@@ -1,0 +1,52 @@
+package com.kidmily.algoga_server.global.health;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component("flightApi")
+@RequiredArgsConstructor
+public class FlightApiHealthIndicator implements HealthIndicator {
+
+    private static final String CB_NAME = "flight";
+
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Override
+    public Health health() {
+        CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker(CB_NAME);
+        CircuitBreaker.State state = cb.getState();
+        CircuitBreaker.Metrics metrics = cb.getMetrics();
+
+        return switch (state) {
+            case CLOSED -> Health.up()
+                    .withDetail("circuitBreaker", "CLOSED")
+                    .withDetail("failureRate", metrics.getFailureRate() + "%")
+                    .withDetail("bufferedCalls", metrics.getNumberOfBufferedCalls())
+                    .withDetail("failedCalls", metrics.getNumberOfFailedCalls())
+                    .build();
+
+            case OPEN -> Health.down()
+                    .withDetail("circuitBreaker", "OPEN")
+                    .withDetail("failureRate", metrics.getFailureRate() + "%")
+                    .withDetail("failedCalls", metrics.getNumberOfFailedCalls())
+                    .withDetail("reason", "항공편 API 장애로 서킷브레이커가 열렸습니다.")
+                    .build();
+
+            case HALF_OPEN -> Health.unknown()
+                    .withDetail("circuitBreaker", "HALF_OPEN")
+                    .withDetail("failureRate", metrics.getFailureRate() + "%")
+                    .withDetail("reason", "항공편 API 복구 여부 확인 중입니다.")
+                    .build();
+
+            default -> Health.unknown()
+                    .withDetail("circuitBreaker", state.name())
+                    .build();
+        };
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/global/health/PortOneHealthIndicator.java
+++ b/src/main/java/com/kidmily/algoga_server/global/health/PortOneHealthIndicator.java
@@ -1,0 +1,52 @@
+package com.kidmily.algoga_server.global.health;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component("portOne")
+@RequiredArgsConstructor
+public class PortOneHealthIndicator implements HealthIndicator {
+
+    private static final String CB_NAME = "portone";
+
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Override
+    public Health health() {
+        CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker(CB_NAME);
+        CircuitBreaker.State state = cb.getState();
+        CircuitBreaker.Metrics metrics = cb.getMetrics();
+
+        return switch (state) {
+            case CLOSED -> Health.up()
+                    .withDetail("circuitBreaker", "CLOSED")
+                    .withDetail("failureRate", metrics.getFailureRate() + "%")
+                    .withDetail("bufferedCalls", metrics.getNumberOfBufferedCalls())
+                    .withDetail("failedCalls", metrics.getNumberOfFailedCalls())
+                    .build();
+
+            case OPEN -> Health.down()
+                    .withDetail("circuitBreaker", "OPEN")
+                    .withDetail("failureRate", metrics.getFailureRate() + "%")
+                    .withDetail("failedCalls", metrics.getNumberOfFailedCalls())
+                    .withDetail("reason", "PortOne API 장애로 서킷브레이커가 열렸습니다.")
+                    .build();
+
+            case HALF_OPEN -> Health.unknown()
+                    .withDetail("circuitBreaker", "HALF_OPEN")
+                    .withDetail("failureRate", metrics.getFailureRate() + "%")
+                    .withDetail("reason", "PortOne API 복구 여부 확인 중입니다.")
+                    .build();
+
+            default -> Health.unknown()
+                    .withDetail("circuitBreaker", state.name())
+                    .build();
+        };
+    }
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
/actuator/health 엔드포인트에 PortOne, 항공편 외부 API 상태를 노출하는 커스텀 Health Indicator를 추가합니다.

실제 API를 매번 호출하는 대신 기존 서킷브레이커 상태를 읽어 판단하므로 추가 네트워크 비용 없이 동작합니다.

## 🔗 Issue
Closes #285 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
서버 기동 후 GET http://localhost:15000/actuator/health 응답에 portOne, flightApi 항목 노출 확인
서킷브레이커 OPEN 시 해당 항목 status: DOWN 으로 변경되는지 확인
기존 health 엔드포인트 정상 동작 회귀 없는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Flight API 및 PortOne 서비스 상태 모니터링 기능이 추가되었습니다.
* 각 서비스의 헬스 상태, 실패율, 호출 지표 등을 실시간으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->