### PR TITLE
[Feature] 회원 탈퇴(Soft Delete) 정책 반영 및 14일 경과 계정 자동 삭제 스케줄러 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/config/SchedulerConfig.java
+++ b/src/main/java/com/kidmily/algoga_server/global/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.kidmily.algoga_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/kidmily/algoga_server/global/event/UserWithdrawnEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/global/event/UserWithdrawnEvent.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.global.event;
+
+// 다른 도메인(쿠폰, 알림 등)에게 "이 유저 탈퇴했어!"라고 알려줄 데이터 명세서입니다.
+public record UserWithdrawnEvent(
+        Long userId,    // 탈퇴한 유저의 식별자
+        String email    // 필요 시 이메일 (선택)
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -135,7 +135,7 @@ public class AuthService implements SocialLoginProcessor {
                 .termsMarketingAgreed(request.termsMarketingAgreed())
                 .build();
         User savedUser = userRepository.save(user);
-        eventPublisher.publishEvent(new UserSignedUpEvent(savedUser.getId()));
+        //eventPublisher.publishEvent(new UserSignedUpEvent(savedUser.getId()));
 
         // 가입이 성공적으로 끝났으니, "인증 완료" 포스트잇도 떼서 버립니다! (청소)
         redisTemplate.delete("AUTH_SUCCESS:" + email);

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserCleanupScheduler.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserCleanupScheduler.java
@@ -1,0 +1,37 @@
+package com.kidmily.algoga_server.user.application;
+
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserCleanupScheduler {
+
+    private final UserRepository userRepository;
+
+    // 매일 밤 0시 0분 0초에 실행
+//    @Scheduled(cron = "0 0 0 * * *")
+//    @Transactional
+    @Scheduled(initialDelay = 5000, fixedDelay = Long.MAX_VALUE)
+    @Transactional
+    public void cleanUpExpiredUsers() {
+        // 14일 전 기준 시간 계산
+        LocalDateTime threshold = LocalDateTime.now().minusDays(14);
+
+        // 14일 지난 유저 목록 조회
+        List<User> expiredUsers = userRepository.findByIsDeletedTrueAndDeletedAtBefore(threshold);
+
+        if (!expiredUsers.isEmpty()) {
+            userRepository.deleteAll(expiredUsers);
+            log.info("[배치 작업] 14일 경과한 탈퇴 회원 {}명 영구 삭제 완료", expiredUsers.size());
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
@@ -18,6 +18,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import com.kidmily.algoga_server.global.event.UserWithdrawnEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -32,6 +36,10 @@ public class UserService {
     // S3 스토리지 공통 포트 및 유저 세팅 인프라 빈 주입
     private final FileStoragePort fileStoragePort;
     private final UserStorageSettings storageSettings;
+
+    // softDelete 정책 관련
+    private final ApplicationEventPublisher eventPublisher;
+    private final RedisTemplate<String, String> redisTemplate;
 
     // 내 프로필 조회
     @Transactional(readOnly = true)
@@ -123,6 +131,7 @@ public class UserService {
     }
 
     // 회원 탈퇴 (Soft Delete)
+    @Transactional
     public void withdraw(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
@@ -132,9 +141,25 @@ public class UserService {
             throw new UserException(UserErrorCode.DELETED_USER);
         }
 
-        user.withdraw(); // User 엔티티의 isDeleted 상태를 true로 변경
+        // [TODO] 팀원들이 예약/환불 인터페이스를 만들어주면 이 주석을 풀고 사용하세요!
+//         if (bookingQueryUseCase.hasActiveBooking(user.getId())) {
+//         throw new UserException(UserErrorCode.ACTIVE_BOOKING_EXISTS);
+//         }
+//         if (refundQueryUseCase.hasActiveRefund(user.getId())) {
+//         throw new UserException(UserErrorCode.ACTIVE_REFUND_EXISTS);
+//         }
+//
+        // 유저 엔티티 Soft Delete 처리 (탈퇴 상태, 날짜 기록, 이메일 랜덤 변경)
+        user.withdraw();
 
-        // @Transactional 안에서 엔티티 값이 변경되면 JPA가 알아서 DB에 UPDATE 쿼리를 날립니다! (더티 체킹)
-        log.info("회원 탈퇴 처리 완료 [이메일: {}]", email);
+        // 로그아웃 처리 (Redis 토큰 삭제 및 블랙리스트 등록으로 즉시 쫓아냄)
+        // 이메일이 이미 _deleted_ 로 바뀌었으므로, 원래 email 변수를 사용해 지워줍니다.
+        redisTemplate.delete("RT:" + email);
+
+        // 탈퇴 이벤트 퍼블리싱
+        // 이제 다른 도메인(쿠폰, 예약 등) 담당자들이 이 이벤트를 듣고 각자 데이터를 지웁니다.
+        eventPublisher.publishEvent(new UserWithdrawnEvent(user.getId(), email));
+
+        log.info("회원 탈퇴 처리 완료 및 이벤트 발행 [기존 이메일: {}, 식별자: {}]", email, user.getId());
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/domain/User.java
+++ b/src/main/java/com/kidmily/algoga_server/user/domain/User.java
@@ -57,6 +57,10 @@ public class User {
     @Column(name = "is_deleted")
     private boolean isDeleted;
 
+    // 삭제 일자를 기록할 필드 추가
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     private String referralCode;
     private String signupPath;
 
@@ -109,6 +113,7 @@ public class User {
     // 회원 탈퇴 (Soft Delete + 데이터 충돌 방지)
     public void withdraw() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
 
         // 고유 식별자를 생성하여 기존 데이터 뒤에 붙여줍니다. (이메일/아이디 재가입 허용을 위함)
         String deleteStr = "_deleted_" + java.util.UUID.randomUUID().toString().substring(0, 8);

--- a/src/main/java/com/kidmily/algoga_server/user/domain/UserRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/user/domain/UserRepository.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.user.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,4 +26,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findByNameContaining(String keyword);
     @Query("SELECT u.id FROM User u WHERE u.isDeleted = false")
     List<Long> findAllActiveUserIds();
+
+    // 14일 전에 탈퇴한(isDeleted=true) 유저 목록 가져오기
+    List<User> findByIsDeletedTrueAndDeletedAtBefore(LocalDateTime dateTime);
 }

--- a/src/main/java/com/kidmily/algoga_server/user/exception/UserErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/user/exception/UserErrorCode.java
@@ -22,7 +22,11 @@ public enum UserErrorCode implements BaseErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER_006", "아이디 또는 비밀번호가 틀렸습니다."),
     DELETED_USER(HttpStatus.FORBIDDEN, "USER_007", "탈퇴한 계정입니다."),
     ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "USER_008", "비밀번호 5회 오류로 인해 5분간 계정이 잠겼습니다."),
-    UNAUTHORIZED_PASSWORD_RESET(HttpStatus.FORBIDDEN, "USER_009", "비밀번호 변경(초기화) 대상자가 아닙니다."); // 임시 비번 강제 변경 방어용
+    UNAUTHORIZED_PASSWORD_RESET(HttpStatus.FORBIDDEN, "USER_009", "비밀번호 변경(초기화) 대상자가 아닙니다."), // 임시 비번 강제 변경 방어용
+
+    // 탈퇴 검증용 에러 코드 2개 추가
+    ACTIVE_BOOKING_EXISTS(HttpStatus.BAD_REQUEST, "USER_010", "진행 중인 예약이 있어 탈퇴할 수 없습니다."),
+    ACTIVE_REFUND_EXISTS(HttpStatus.BAD_REQUEST, "USER_011", "진행 중인 환불이 있어 탈퇴할 수 없습니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/UserController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/UserController.java
@@ -11,9 +11,12 @@ import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -70,8 +73,29 @@ public class UserController {
     @Operation(summary = "회원 탈퇴", description = "계정을 Soft Delete 처리합니다.")
     @DeleteMapping("/me")
     public ApiResponse<Void> withdraw(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails, HttpServletResponse response) {
         userService.withdraw(userDetails.getUsername());
+
+        // 수명이 0초인 '빈 쿠키'를 생성해서 브라우저로 덮어쓰기 명령 (쿠키 폭파)
+        ResponseCookie deleteAccessCookie = ResponseCookie.from("accessToken", "")
+                .path("/")
+                .maxAge(0) // 수명을 0으로 줘서 즉시 삭제시킴
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None") // HTTPS 연동 환경에 맞게
+                .build();
+
+        ResponseCookie deleteRefreshCookie = ResponseCookie.from("refreshToken", "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteAccessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteRefreshCookie.toString());
+
         return ApiResponse.success("USER_WITHDRAW_SUCCESS", "회원 탈퇴가 완료되었습니다.");
     }
 }


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
회원 탈퇴(Soft Delete) 적용 (User, UserService)

탈퇴 시 isDeleted = true 및 deletedAt 날짜 기록

아이디, 이메일, 전화번호 뒤에 _deleted_난수를 붙여 개인정보 마스킹 및 재가입 허용 처리

완벽한 로그아웃(토큰 파기) 처리 (UserController, UserService)

탈퇴 성공 즉시 브라우저의 accessToken, refreshToken 쿠키 수명을 0초(Max-Age=0)로 설정하여 강제 삭제

Redis에 저장된 기존 RefreshToken 삭제를 통해 재발급 원천 차단

타 도메인 데이터 처리를 위한 이벤트 발행 (UserWithdrawnEvent)

탈퇴 처리가 완료되는 시점에 타 파트(쿠폰, 커뮤니티 등)에서 데이터를 삭제할 수 있도록 이벤트를 발행합니다.

14일 경과 계정 자동 삭제 스케줄러 (SchedulerConfig, UserCleanupScheduler)

매일 자정(0시 0분 0초)에 실행되어, 탈퇴 후 14일이 지난 계정을 DB에서 완전히 삭제(Hard Delete)합니다.

(Refactor) 불필요한 블랙리스트 검증 로직 제거 (AuthService)

개명 처리(_deleted_)로 인해 새 로그인이 자동 차단되므로, 불필요한 Redis Blacklist 검사 코드를 제거하여 성능을 최적화했습니다.
## 🔗 Issue
Closes #297

---


## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
[x] 탈퇴 시 DB에 _deleted_ 처리 및 deleted_at 기록 확인

[x] 탈퇴 후 동일 계정으로 로그인 시도 시 정상 차단 (USER_001 예외 발생)

[x] 탈퇴 후 동일 이메일로 새로운 회원가입 정상 작동 확인

[x] 탈퇴 직후 브라우저의 쿠키(Token)가 즉시 삭제되는지 확인

[x] 스케줄러 임시 가동하여 14일 경과 데이터가 DB에서 영구 삭제되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원 탈퇴 시 토큰 및 쿠키가 즉시 삭제되도록 개선
  * 진행 중인 예약 또는 환불이 있을 경우 회원 탈퇴 불가 검증 추가
  * 삭제된 계정 데이터를 14일 후 자동으로 정리하는 백그라운드 스케줄러 추가
  * 회원 탈퇴 이벤트 시스템 구축으로 연동 서비스 알림 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->