### PR TITLE
[Fix] JWT 인증 필터 예외 처리 강화 및 직접 에러 응답(JSON) 로직 추가

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/security/GlobalJwtAuthenticationFilter.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/GlobalJwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.kidmily.algoga_server.global.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kidmily.algoga_server.admin.settings.CustomManagerDetails;
 import com.kidmily.algoga_server.user.settings.CustomUserDetails;
 import com.kidmily.algoga_server.user.settings.CustomUserDetailsService;
@@ -16,6 +17,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 
 import java.io.IOException;
 
@@ -32,13 +35,15 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String token = resolveToken(request);
+        // 🌟 여기서부터 try 블록 시작!
+        try {
+            String token = resolveToken(request);
 
-        if (token != null && globalJwtProvider.validateToken(token)) {
-            try {
+            if (token != null && globalJwtProvider.validateToken(token)) {
                 String type = globalJwtProvider.getType(token);
 
                 if ("ADMIN".equals(type)) {
+                    // ... 기존 ADMIN 로직 그대로 유지 ...
                     Long id = globalJwtProvider.getAdminId(token);
                     String loginId = globalJwtProvider.getSubject(token);
                     String role = globalJwtProvider.getAdminRole(token);
@@ -51,16 +56,17 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
 
                 } else if ("USER".equals(type)) {
+                    // ... 기존 USER 로직 그대로 유지 ...
                     String email = globalJwtProvider.getSubject(token);
 
-                    // 🌟 블랙리스트 등록된 유저인지 Redis 검증 (Access Token 무효화)
+                    // 블랙리스트 등록된 유저인지 Redis 검증 (Access Token 무효화)
                     String isBlacklisted = redisTemplate.opsForValue().get("BLACKLIST:" + email);
                     if ("true".equals(isBlacklisted)) {
                         log.warn("블랙리스트 유저의 비정상적 API 접근 시도 차단: {}", email);
-                        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                        response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
                         response.setContentType("application/json;charset=UTF-8");
                         response.getWriter().write("{\"code\":\"AUTH_015\",\"message\":\"블랙리스트에 등록되어 접근이 영구히 제한된 계정입니다. 고객센터에 문의하세요.\"}");
-                        return;
+                        return; // 🌟 중단!
                     }
 
                     CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
@@ -71,9 +77,28 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
                     authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
-            } catch (Exception e) {
-                log.error("JWT 인증 처리 중 에러 발생: {}", e.getMessage());
             }
+            // 🌟 여기서부터 에러를 낚아채서 프론트로 예외 응답을 쏴줍니다!
+        } catch (ExpiredJwtException e) {
+            log.warn("토큰 만료 에러 발생: {}", e.getMessage());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 에러
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"code\":\"AUTH_EXPIRED\",\"message\":\"토큰이 만료되었습니다. 다시 로그인해주세요.\"}");
+            return; // 🌟 필터 통과 못하게 막음
+
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("유효하지 않은 토큰 에러 발생: {}", e.getMessage());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 에러
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"code\":\"AUTH_INVALID\",\"message\":\"유효하지 않은 토큰입니다.\"}");
+            return; // 🌟 필터 통과 못하게 막음
+
+        } catch (Exception e) {
+            log.error("JWT 인증 처리 중 서버 에러 발생: {}", e.getMessage(), e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR); // 500 에러
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"code\":\"SYS_ERROR\",\"message\":\"인증 처리 중 서버 에러가 발생했습니다.\"}");
+            return; // 🌟 필터 통과 못하게 막음
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserCleanupScheduler.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserCleanupScheduler.java
@@ -18,9 +18,7 @@ public class UserCleanupScheduler {
     private final UserRepository userRepository;
 
     // 매일 밤 0시 0분 0초에 실행
-//    @Scheduled(cron = "0 0 0 * * *")
-//    @Transactional
-    @Scheduled(initialDelay = 5000, fixedDelay = Long.MAX_VALUE)
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void cleanUpExpiredUsers() {
         // 14일 전 기준 시간 계산


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
기존 GlobalJwtAuthenticationFilter에서 토큰 만료 및 변조 등의 예외가 발생할 경우, 에러 로그만 남고 프론트엔드로 적절한 에러 응답(401)이 내려가지 않는 현상을 수정했다.

프론트엔드에서 토큰 만료 여부를 정확히 인지하고 토큰 재발급(Refresh) 또는 로그아웃 처리를 할 수 있도록, 예외 발생 시 필터에서 직접 JSON 형태의 에러를 반환하고 요청을 차단하도록 개선했다.

## 🔗 Issue
Closes #301

---


## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
[x] 만료된 토큰으로 API 요청 시 401 상태 코드와 AUTH_EXPIRED 메시지 반환 확인

[x] 변조되거나 잘못된 토큰으로 요청 시 401 상태 코드와 AUTH_INVALID 메시지 반환 확인

[x] 블랙리스트에 등록된 유저 요청 시 403 상태 코드와 AUTH_015 메시지 반환 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JWT 토큰 만료, 잘못된 형식, 기타 검증 오류에 대한 예외 처리를 세분화하여 각각의 상황에 적절한 오류 응답 제공
  * 인증 필터에서 토큰 블랙리스트 확인 절차 강화

* **Chores**
  * 사용자 정리 작업 스케줄을 매일 자정(00:00:00)에 실행되도록 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->