### PR TITLE
[Feature] 통계 매니저 수강률 분석 API 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/benefit/presentation/api/admin/CouponStatisticsController.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/presentation/api/admin/CouponStatisticsController.java
@@ -34,7 +34,7 @@ public class CouponStatisticsController {
             "COURSE_NOT_FOUND",
             "COUNTRY_NOT_FOUND"
     })
-    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('STATISTICS_MANAGER', 'ROLE_STATISTICS_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<CouponStatisticsResponse>> getCouponStatistics(
             @Parameter(description = "강의 ID 필터", example = "3")

--- a/src/main/java/com/kidmily/algoga_server/lms/application/port/CourseStatisticsQueryPort.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/port/CourseStatisticsQueryPort.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.lms.application.port;
+
+import com.kidmily.algoga_server.lms.application.result.CourseEnrollmentStatisticsPageResult;
+
+public interface CourseStatisticsQueryPort {
+
+    CourseEnrollmentStatisticsPageResult findCourseEnrollmentStatistics(
+            String keyword,
+            int page,
+            int size
+    );
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseEnrollmentStatisticsPageResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseEnrollmentStatisticsPageResult.java
@@ -1,0 +1,11 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import java.util.List;
+
+public record CourseEnrollmentStatisticsPageResult(
+        long totalElements,
+        int page,
+        int size,
+        List<CourseEnrollmentStatisticsResult> content
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseEnrollmentStatisticsResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseEnrollmentStatisticsResult.java
@@ -1,0 +1,11 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+public record CourseEnrollmentStatisticsResult(
+        Long courseId,
+        String courseTitle,
+        long studentCount,
+        int averageProgressRate,
+        int completionRate,
+        double averageLearningHours
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseStatisticsService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseStatisticsService.java
@@ -1,0 +1,25 @@
+package com.kidmily.algoga_server.lms.application.service;
+
+import com.kidmily.algoga_server.lms.application.port.CourseStatisticsQueryPort;
+import com.kidmily.algoga_server.lms.application.result.CourseEnrollmentStatisticsPageResult;
+import com.kidmily.algoga_server.lms.application.usecase.CourseStatisticsUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseStatisticsService implements CourseStatisticsUseCase {
+
+    private final CourseStatisticsQueryPort courseStatisticsQueryPort;
+
+    @Override
+    public CourseEnrollmentStatisticsPageResult getCourseEnrollmentStatistics(
+            String keyword,
+            int page,
+            int size
+    ) {
+        return courseStatisticsQueryPort.findCourseEnrollmentStatistics(keyword, page, size);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseStatisticsUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseStatisticsUseCase.java
@@ -1,0 +1,12 @@
+package com.kidmily.algoga_server.lms.application.usecase;
+
+import com.kidmily.algoga_server.lms.application.result.CourseEnrollmentStatisticsPageResult;
+
+public interface CourseStatisticsUseCase {
+
+    CourseEnrollmentStatisticsPageResult getCourseEnrollmentStatistics(
+            String keyword,
+            int page,
+            int size
+    );
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/CourseStatisticsQueryRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/CourseStatisticsQueryRepository.java
@@ -1,0 +1,109 @@
+package com.kidmily.algoga_server.lms.infrastructure.persistence.repository;
+
+import com.kidmily.algoga_server.lms.application.port.CourseStatisticsQueryPort;
+import com.kidmily.algoga_server.lms.application.result.CourseEnrollmentStatisticsPageResult;
+import com.kidmily.algoga_server.lms.application.result.CourseEnrollmentStatisticsResult;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CourseStatisticsQueryRepository implements CourseStatisticsQueryPort {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public CourseEnrollmentStatisticsPageResult findCourseEnrollmentStatistics(
+            String keyword,
+            int page,
+            int size
+    ) {
+        boolean hasKeyword = keyword != null && !keyword.isBlank();
+        String keywordLike = hasKeyword ? "%" + keyword.trim() + "%" : null;
+        int offset = page * size;
+
+        String whereSql = hasKeyword
+                ? " WHERE l.is_deleted = 0 AND l.title LIKE :keyword "
+                : " WHERE l.is_deleted = 0 ";
+
+        String contentSql = """
+                SELECT
+                    l.lecture_id,
+                    l.title,
+                    COUNT(DISTINCT e.user_id),
+                    COALESCE(ROUND(AVG(up.user_progress_rate)), 0),
+                    CASE
+                        WHEN COUNT(DISTINCT e.user_id) = 0 THEN 0
+                        ELSE ROUND(COUNT(DISTINCT cc.user_id) * 100.0 / COUNT(DISTINCT e.user_id))
+                    END,
+                    COALESCE(ROUND(SUM(COALESCE(up.user_watched_seconds, 0)) / 3600.0 / NULLIF(COUNT(DISTINCT e.user_id), 0), 1), 0)
+                FROM lectures l
+                LEFT JOIN enrollments e
+                    ON e.lecture_id = l.lecture_id
+                LEFT JOIN (
+                    SELECT
+                        lecture_id,
+                        user_id,
+                        AVG(progress_rate) AS user_progress_rate,
+                        SUM(watched_seconds) AS user_watched_seconds
+                    FROM learning_progresses
+                    GROUP BY lecture_id, user_id
+                ) up
+                    ON up.lecture_id = l.lecture_id
+                   AND up.user_id = e.user_id
+                LEFT JOIN course_completions cc
+                    ON cc.lecture_id = l.lecture_id
+                   AND cc.user_id = e.user_id
+                """ + whereSql + """
+                GROUP BY l.lecture_id, l.title
+                ORDER BY COUNT(DISTINCT e.user_id) DESC, l.lecture_id DESC
+                LIMIT :limit OFFSET :offset
+                """;
+
+        Query contentQuery = entityManager.createNativeQuery(contentSql)
+                .setParameter("limit", size)
+                .setParameter("offset", offset);
+
+        if (hasKeyword) {
+            contentQuery.setParameter("keyword", keywordLike);
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = contentQuery.getResultList();
+
+        List<CourseEnrollmentStatisticsResult> content = rows.stream()
+                .map(row -> new CourseEnrollmentStatisticsResult(
+                        ((Number) row[0]).longValue(),
+                        (String) row[1],
+                        ((Number) row[2]).longValue(),
+                        ((Number) row[3]).intValue(),
+                        ((Number) row[4]).intValue(),
+                        ((Number) row[5]).doubleValue()
+                ))
+                .toList();
+
+        String countSql = """
+                SELECT COUNT(*)
+                FROM lectures l
+                """ + whereSql;
+
+        Query countQuery = entityManager.createNativeQuery(countSql);
+
+        if (hasKeyword) {
+            countQuery.setParameter("keyword", keywordLike);
+        }
+
+        long totalElements = ((Number) countQuery.getSingleResult()).longValue();
+
+        return new CourseEnrollmentStatisticsPageResult(
+                totalElements,
+                page,
+                size,
+                content
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseStatisticsController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseStatisticsController.java
@@ -1,0 +1,33 @@
+package com.kidmily.algoga_server.lms.presentation.api.admin;
+
+import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.lms.application.usecase.CourseStatisticsUseCase;
+import com.kidmily.algoga_server.lms.presentation.response.CourseEnrollmentStatisticsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/statistics/courses")
+@RequiredArgsConstructor
+public class AdminCourseStatisticsController {
+
+    private final CourseStatisticsUseCase courseStatisticsUseCase;
+
+    @GetMapping("/enrollment")
+    @PreAuthorize("hasAnyAuthority('STATISTICS_MANAGER', 'ROLE_STATISTICS_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    public ResponseEntity<ApiResponse<CourseEnrollmentStatisticsResponse>> getCourseEnrollmentStatistics(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        var result = courseStatisticsUseCase.getCourseEnrollmentStatistics(keyword, page, size);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                "COURSE_ENROLLMENT_STATISTICS_FOUND",
+                "수강률 통계 조회에 성공했습니다.",
+                CourseEnrollmentStatisticsResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/98-admin-course-statistics.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/98-admin-course-statistics.http
@@ -1,0 +1,12 @@
+### 통계 매니저 로그인 먼저 실행 후 사용
+
+### 수강률 통계 조회
+GET http://localhost:15000/api/v1/admin/statistics/courses/enrollment?page=0&size=10
+Cookie: accessToken={{managerAccessToken}}
+Accept: application/json
+
+
+### 수강률 통계 검색
+GET http://localhost:15000/api/v1/admin/statistics/courses/enrollment?keyword=도쿄&page=0&size=10
+Cookie: accessToken={{managerAccessToken}}
+Accept: application/json

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseEnrollmentStatisticsResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseEnrollmentStatisticsResponse.java
@@ -1,0 +1,46 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.CourseEnrollmentStatisticsPageResult;
+import com.kidmily.algoga_server.lms.application.result.CourseEnrollmentStatisticsResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "수강률 통계 응답")
+public record CourseEnrollmentStatisticsResponse(
+        long totalElements,
+        int page,
+        int size,
+        List<CourseEnrollmentStatisticsItemResponse> content
+) {
+    public static CourseEnrollmentStatisticsResponse from(CourseEnrollmentStatisticsPageResult result) {
+        return new CourseEnrollmentStatisticsResponse(
+                result.totalElements(),
+                result.page(),
+                result.size(),
+                result.content().stream()
+                        .map(CourseEnrollmentStatisticsItemResponse::from)
+                        .toList()
+        );
+    }
+
+    public record CourseEnrollmentStatisticsItemResponse(
+            Long courseId,
+            String courseTitle,
+            long studentCount,
+            int averageProgressRate,
+            int completionRate,
+            double averageLearningHours
+    ) {
+        public static CourseEnrollmentStatisticsItemResponse from(CourseEnrollmentStatisticsResult result) {
+            return new CourseEnrollmentStatisticsItemResponse(
+                    result.courseId(),
+                    result.courseTitle(),
+                    result.studentCount(),
+                    result.averageProgressRate(),
+                    result.completionRate(),
+                    result.averageLearningHours()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
통계 매니저 페이지에서 사용할 수강률 분석 API를 추가했습니다.

## 🔗 Issue
Closes #304 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
### 수강률 분석 API
- 강의별 수강생 수 조회
- 강의별 평균 진도율 조회
- 강의별 수료율 조회
- 강의별 평균 학습 시간 조회
- 강의명 검색 지원
- 페이지네이션 지원

### 클린 아키텍처 구조 적용
- Controller는 UseCase만 의존하도록 구성
- Application Service는 Port만 의존하도록 구성
- 통계 조회 SQL은 Infrastructure Repository에서 처리
- Infrastructure Repository가 Application Port를 구현하도록 분리

## API

```http
GET /api/v1/admin/statistics/courses/enrollment?page=0&size=10
GET /api/v1/admin/statistics/courses/enrollment?keyword=도쿄&page=0&size=10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 강의 수강 및 등록 통계 조회 기능 추가
  * 관리자 대시보드용 통계 조회 API 엔드포인트 추가 (키워드 검색 및 페이지네이션 지원)

* **Chores**
  * 기존 통계 관련 권한 설정 정책 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->