### PR TITLE
[FIX] 매니저 refresh token 활용 로직 추가 및 redis 활용 추가 및 반환타입 role 만 넘겨줌.

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerAuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerAuthService.java
@@ -10,44 +10,79 @@ import com.kidmily.algoga_server.admin.presentation.api.response.AdminAuthTokenR
 import com.kidmily.algoga_server.global.security.GlobalJwtProvider;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.concurrent.TimeUnit;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 로그인은 조회만 하므로 readOnly 적용하여 성능 최적화
+@Transactional(readOnly = true)
 public class ManagerAuthService implements ManagerAuthUseCase {
 
     private final ManagerRepository managerRepository;
     private final PasswordEncoder passwordEncoder;
-    private final GlobalJwtProvider globalJwtProvider; // 앞서 만든 어드민 전용 JWT 프로바이더
+    private final GlobalJwtProvider globalJwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public AdminAuthTokenResponse login(LoginManagerCommand command) {
 
-        // 1. 아이디로 매니저 조회
         Manager manager = managerRepository.findByLoginId(command.loginId())
                 .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
 
-        // 2. 삭제(Soft Delete)된 계정인지 확인
         if (manager.isDeleted()) {
             throw new ManagerException(ManagerErrorCode.DELETED_MANAGER);
         }
 
-        // 3. 비밀번호 검증
         if (!passwordEncoder.matches(command.password(), manager.getPassword())) {
             throw new ManagerException(ManagerErrorCode.INVALID_PASSWORD);
         }
 
-        // 4. JWT 토큰 발급 (시큐리티 표준인 'ROLE_' 접두사 추가)
         String roleName = "ROLE_" + manager.getRole().name();
 
-        // 주의: AdminJwtProvider에는 PK(manager.getId())를 함께 넣도록 앞서 구현해 두었습니다.
         String accessToken = globalJwtProvider.createAdminAccessToken(manager.getId(), manager.getLoginId(), roleName);
         String refreshToken = globalJwtProvider.createAdminRefreshToken(manager.getLoginId());
 
+        // Redis에 Refresh Token 저장 (7일)
+        redisTemplate.opsForValue().set(
+                "ADMIN_RT:" + manager.getLoginId(),
+                refreshToken,
+                604800000,
+                TimeUnit.MILLISECONDS
+        );
+
         return new AdminAuthTokenResponse(accessToken, refreshToken, manager.getRole());
+    }
+
+    @Override
+    public void logout(String loginId) {
+        redisTemplate.delete("ADMIN_RT:" + loginId);
+    }
+
+    // 🌟 변경: 토큰 재발급 시에도 매니저 정보를 조회해 진짜 권한(Role)을 함께 반환함
+    @Override
+    public AdminAuthTokenResponse refreshAccessToken(String loginId, String refreshToken) {
+        // Redis 토큰 검증
+        String savedRefreshToken = redisTemplate.opsForValue().get("ADMIN_RT:" + loginId);
+
+        if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+            throw new ManagerException(ManagerErrorCode.ACCESS_DENIED);
+        }
+
+        // 매니저 권한 조회를 위해 DB 탐색
+        Manager manager = managerRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
+
+        String roleName = "ROLE_" + manager.getRole().name();
+
+        // 새로운 Access Token 발급
+        String newAccessToken = globalJwtProvider.createAdminAccessToken(manager.getId(), manager.getLoginId(), roleName);
+
+        // 쿠키용 토큰과 응답 바디용 Role을 세트로 묶어서 반환
+        return new AdminAuthTokenResponse(newAccessToken, refreshToken, manager.getRole());
     }
 
     @PostConstruct

--- a/src/main/java/com/kidmily/algoga_server/admin/application/usecase/ManagerAuthUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/usecase/ManagerAuthUseCase.java
@@ -2,6 +2,13 @@ package com.kidmily.algoga_server.admin.application.usecase;
 
 import com.kidmily.algoga_server.admin.application.command.LoginManagerCommand;
 import com.kidmily.algoga_server.admin.presentation.api.response.AdminAuthTokenResponse;
+
 public interface ManagerAuthUseCase {
     AdminAuthTokenResponse login(LoginManagerCommand command);
+
+    // 로그아웃 (Redis 토큰 삭제)
+    void logout(String loginId);
+
+    // 🌟 변경: 로그인과 동일하게 Role 정보를 함께 넘겨주기 위해 반환 타입 수정
+    AdminAuthTokenResponse refreshAccessToken(String loginId, String refreshToken);
 }

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
@@ -3,18 +3,23 @@ package com.kidmily.algoga_server.admin.presentation.api;
 import com.kidmily.algoga_server.admin.application.command.LoginManagerCommand;
 import com.kidmily.algoga_server.admin.application.usecase.ManagerAuthUseCase;
 import com.kidmily.algoga_server.admin.exception.ManagerErrorCode;
+import com.kidmily.algoga_server.admin.exception.ManagerException;
 import com.kidmily.algoga_server.admin.presentation.api.request.ManagerLoginRequest;
 import com.kidmily.algoga_server.admin.presentation.api.response.AdminAuthTokenResponse;
+import com.kidmily.algoga_server.admin.presentation.api.response.AdminLoginResponse;
 import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.security.GlobalJwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse; // 🌟 추가
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;     // 🌟 추가
-import org.springframework.http.ResponseCookie;  // 🌟 추가
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -25,13 +30,14 @@ import org.springframework.web.bind.annotation.*;
 public class ManagerAuthController {
 
     private final ManagerAuthUseCase managerAuthUseCase;
+    private final GlobalJwtProvider globalJwtProvider;
 
-    @Operation(summary = "매니저 로그인", description = "어드민 계정으로 로그인하여 토큰을 발급받습니다.")
+    @Operation(summary = "매니저 로그인", description = "어드민 계정으로 로그인하여 토큰 쿠키를 발급받습니다.")
     @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"MANAGER_NOT_FOUND", "DELETED_MANAGER", "INVALID_PASSWORD"})
     @PostMapping("/login")
-    public ApiResponse<AdminAuthTokenResponse> login( // 🌟 반환 타입을 ApiResponse<Void> 로 변경
-                                                      @RequestBody @Valid ManagerLoginRequest request,
-                                                      HttpServletResponse response // 🌟 쿠키 주입을 위해 추가
+    public ApiResponse<AdminLoginResponse> login(
+            @RequestBody @Valid ManagerLoginRequest request,
+            HttpServletResponse response
     ) {
 
         log.info("[Manager Login] 관리자 로그인 시도 - ID: {}", request.loginId());
@@ -39,20 +45,19 @@ public class ManagerAuthController {
         LoginManagerCommand command = new LoginManagerCommand(request.loginId(), request.password());
         AdminAuthTokenResponse tokenResponse = managerAuthUseCase.login(command);
 
-        // 🌟 유저 도메인과 완전히 동일하게 쿠키 세팅 생성
         ResponseCookie accessCookie = ResponseCookie.from("accessToken", tokenResponse.accessToken())
                 .httpOnly(true)
-                .secure(true) // HTTPS 운영 서버 배포 시 true로 변경
+                .secure(true)
                 .path("/")
-                .maxAge(30 * 60) // 30분
+                .maxAge(30 * 60)
                 .sameSite("None")
                 .build();
 
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokenResponse.refreshToken())
                 .httpOnly(true)
-                .secure(true) // HTTPS 운영 서버 배포 시 true로 변경
+                .secure(true)
                 .path("/")
-                .maxAge(7 * 24 * 60 * 60) // 7일
+                .maxAge(7 * 24 * 60 * 60)
                 .sameSite("None")
                 .build();
 
@@ -61,45 +66,96 @@ public class ManagerAuthController {
 
         log.info("[Manager Login] 관리자 로그인 성공 - ID: {}", request.loginId());
 
-        // 🌟 맨 마지막에 데이터를 응답 결과에 포함하지 않고 null로 반환하여 JSON에 출력되지 않게 합니다.
-        return ApiResponse.success("MANAGER_LOGIN_SUCCESS", "관리자 로그인에 성공했습니다.", tokenResponse);
+        AdminLoginResponse responseBody = new AdminLoginResponse(tokenResponse.role());
+        return ApiResponse.success("MANAGER_LOGIN_SUCCESS", "관리자 로그인에 성공했습니다.", responseBody);
     }
 
-    @Operation(summary = "매니저 로그아웃", description = "토큰 쿠키를 만료시켜 로그아웃 처리합니다.")
+    @Operation(summary = "매니저 로그아웃", description = "토큰 쿠키를 만료시키고 DB(Redis)의 Refresh Token을 폐기합니다.")
     @PostMapping("/logout")
     public ApiResponse<Void> logout(
-            // @CurrentManager Long managerId, // (선택) 만약 Redis/DB에서 리프레시 토큰을 지워야 한다면 주석 해제 후 사용
+            HttpServletRequest request,
             HttpServletResponse response
     ) {
         log.info("[Manager Logout] 관리자 로그아웃 요청");
 
-        // 🌟 (선택) Redis나 DB에 저장된 Refresh Token을 폐기하는 로직이 있다면 여기서 UseCase를 호출하세요.
-        // managerAuthUseCase.logout(managerId);
+        String accessToken = null;
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    accessToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
 
-        // 🌟 1. Access Token 쿠키 즉시 만료 (maxAge = 0)
+        if (accessToken != null && globalJwtProvider.validateToken(accessToken)) {
+            String loginId = globalJwtProvider.getSubject(accessToken);
+            managerAuthUseCase.logout(loginId);
+        }
+
         ResponseCookie accessCookie = ResponseCookie.from("accessToken", "")
                 .httpOnly(true)
-                .secure(true) // HTTPS 운영 서버 배포 시 true로 변경
+                .secure(true)
                 .path("/")
-                .maxAge(0) // 0으로 설정하여 브라우저에서 즉시 삭제되도록 유도
+                .maxAge(0)
                 .sameSite("None")
                 .build();
 
-        // 🌟 2. Refresh Token 쿠키 즉시 만료 (maxAge = 0)
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
-                .secure(true) // HTTPS 운영 서버 배포 시 true로 변경
+                .secure(true)
                 .path("/")
-                .maxAge(0) // 0으로 설정하여 브라우저에서 즉시 삭제되도록 유도
+                .maxAge(0)
                 .sameSite("None")
                 .build();
 
-        // 🌟 3. 응답 헤더에 만료된 쿠키를 세팅하여 기존 쿠키 덮어쓰기
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         log.info("[Manager Logout] 관리자 로그아웃 성공 (쿠키 만료 완료)");
 
         return ApiResponse.success("MANAGER_LOGOUT_SUCCESS", "관리자 로그아웃에 성공했습니다.", null);
+    }
+
+    // 🌟 변경: 반환 타입을 ApiResponse<AdminLoginResponse>로 교체하여 로그인과 똑같이 맞춤
+    @Operation(summary = "어드민 토큰 재발급", description = "만료된 Access Token을 수명이 남아있는 Refresh Token 쿠키를 이용해 자동으로 연장하고 최신 Role 정보를 반환합니다.")
+    @PostMapping("/refresh")
+    public ApiResponse<AdminLoginResponse> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = null;
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    refreshToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        if (refreshToken == null) {
+            throw new ManagerException(ManagerErrorCode.ACCESS_DENIED);
+        }
+
+        String loginId = globalJwtProvider.getSubject(refreshToken);
+
+        // 1. 서비스단 호출 (신규 Access Token 및 현재 매니저의 Role 획득)
+        AdminAuthTokenResponse tokenResponse = managerAuthUseCase.refreshAccessToken(loginId, refreshToken);
+
+        // 2. 새 Access Token을 쿠키에 설정
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", tokenResponse.accessToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(30 * 60) // 30분
+                .sameSite("None")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+
+        log.info("[Manager Refresh] 관리자 토큰 및 권한 재발급 완료 - ID: {}", loginId);
+
+        // 3. 로그인 성공 응답과 일치하게 JSON 바디에 최신 role 값을 담아 응답 처리 🌟
+        AdminLoginResponse responseBody = new AdminLoginResponse(tokenResponse.role());
+        return ApiResponse.success("MANAGER_REFRESH_SUCCESS", "관리자 토큰이 성공적으로 재발급되었습니다.", responseBody);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/response/AdminLoginResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/response/AdminLoginResponse.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.admin.presentation.api.response;
+
+import com.kidmily.algoga_server.admin.domain.model.ManagerRole;
+
+public record AdminLoginResponse(
+        ManagerRole role
+) {
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
 매니저 refresh token 활용 로직 추가 및 redis 활용 추가 및 반환타입 role 만 넘겨줌.
POST
/api/v1/auth/admin/refresh
추가

## 🔗 Issue
Closes #310 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 매니저 로그인 정상작동하는지 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그아웃 기능 추가: 사용자가 안전하게 세션 종료 가능
  * 토큰 갱신 기능 추가: 만료된 접근 토큰을 자동으로 갱신
  * 쿠키 기반 보안 강화: 토큰을 보안이 강화된 쿠키로 관리
  * 역할 정보 통합: 로그인 및 토큰 갱신 시 사용자 역할 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->