### PR TITLE
[Feature] 챕터 설명 추가하기

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateChapterCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/CreateChapterCommand.java
@@ -5,6 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 public record CreateChapterCommand(
         Long courseId,
         String title,
+        String description,
         MultipartFile videoFile,
         int durationSeconds,
         int chapterOrder

--- a/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateChapterCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/command/UpdateChapterCommand.java
@@ -4,6 +4,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public record UpdateChapterCommand(
         String title,
+        String description,
         MultipartFile videoFile,
         int durationSeconds,
         int chapterOrder

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/ChapterResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/ChapterResult.java
@@ -6,6 +6,7 @@ public record ChapterResult(
         Long chapterId,
         Long courseId,
         String title,
+        String description,
         String videoUrl,
         int durationSeconds,
         int chapterOrder
@@ -15,6 +16,7 @@ public record ChapterResult(
                 chapter.getId(),
                 chapter.getCourseId(),
                 chapter.getTitle(),
+                chapter.getDescription(),
                 chapter.getVideoUrl(),
                 chapter.getDurationSeconds(),
                 chapter.getChapterOrder()

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseClassroomChapterResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseClassroomChapterResult.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.lms.application.result;
 public record CourseClassroomChapterResult(
         Long chapterId,
         String title,
+        String description,
         String videoUrl,
         int durationSeconds,
         int chapterOrder,

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/ChapterService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/ChapterService.java
@@ -58,11 +58,11 @@ public class ChapterService implements ChapterUseCase {
         Chapter savedChapter = chapterRepository.save(Chapter.create(
                 command.courseId(),
                 command.title(),
+                command.description(),
                 videoUrl,
                 command.durationSeconds(),
                 command.chapterOrder()
         ));
-
         return ChapterResult.from(savedChapter);
     }
 
@@ -93,6 +93,7 @@ public class ChapterService implements ChapterUseCase {
                 chapterId,
                 courseId,
                 command.title(),
+                command.description(),
                 targetVideoUrl,
                 command.durationSeconds(),
                 command.chapterOrder()

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
@@ -237,6 +237,7 @@ public class CourseService implements CourseUseCase {
             chapterResults.add(new CourseClassroomChapterResult(
                     chapter.getId(),
                     chapter.getTitle(),
+                    chapter.getDescription(),
                     locked ? null : chapter.getVideoUrl(),
                     chapter.getDurationSeconds(),
                     chapter.getChapterOrder(),

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/model/Chapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/model/Chapter.java
@@ -5,6 +5,7 @@ public class Chapter {
     private final Long id;
     private final Long courseId;
     private final String title;
+    private final String description;
     private final String videoUrl;
     private final int durationSeconds;
     private final int chapterOrder;
@@ -14,6 +15,7 @@ public class Chapter {
             Long id,
             Long courseId,
             String title,
+            String description,
             String videoUrl,
             int durationSeconds,
             int chapterOrder,
@@ -22,6 +24,7 @@ public class Chapter {
         this.id = id;
         this.courseId = courseId;
         this.title = title;
+        this.description = description;
         this.videoUrl = videoUrl;
         this.durationSeconds = durationSeconds;
         this.chapterOrder = chapterOrder;
@@ -31,6 +34,7 @@ public class Chapter {
     public static Chapter create(
             Long courseId,
             String title,
+            String description,
             String videoUrl,
             int durationSeconds,
             int chapterOrder
@@ -39,6 +43,7 @@ public class Chapter {
                 null,
                 courseId,
                 title,
+                description,
                 videoUrl,
                 durationSeconds,
                 chapterOrder,
@@ -56,10 +61,33 @@ public class Chapter {
                 null,
                 null,
                 title,
+                null,
                 videoUrl,
                 durationSeconds,
                 chapterOrder,
                 false
+        );
+    }
+
+    public static Chapter withId(
+            Long id,
+            Long courseId,
+            String title,
+            String description,
+            String videoUrl,
+            int durationSeconds,
+            int chapterOrder,
+            boolean deleted
+    ) {
+        return new Chapter(
+                id,
+                courseId,
+                title,
+                description,
+                videoUrl,
+                durationSeconds,
+                chapterOrder,
+                deleted
         );
     }
 
@@ -74,30 +102,11 @@ public class Chapter {
                 id,
                 null,
                 title,
+                null,
                 videoUrl,
                 durationSeconds,
                 chapterOrder,
                 false
-        );
-    }
-
-    public static Chapter withId(
-            Long id,
-            Long courseId,
-            String title,
-            String videoUrl,
-            int durationSeconds,
-            int chapterOrder,
-            boolean deleted
-    ) {
-        return new Chapter(
-                id,
-                courseId,
-                title,
-                videoUrl,
-                durationSeconds,
-                chapterOrder,
-                deleted
         );
     }
 
@@ -112,6 +121,7 @@ public class Chapter {
     public String getTitle() {
         return title;
     }
+    public String getDescription() {return description;  }
 
     public String getVideoUrl() {
         return videoUrl;

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/ChapterRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/ChapterRepository.java
@@ -17,6 +17,7 @@ public interface ChapterRepository {
             Long chapterId,
             Long courseId,
             String title,
+            String description,
             String videoUrl,
             int durationSeconds,
             int chapterOrder

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/mapper/CourseMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/mapper/CourseMapper.java
@@ -106,6 +106,7 @@ public class CourseMapper {
                 entity.getId(),
                 entity.getCourseId(),
                 entity.getTitle(),
+                entity.getDescription(),
                 entity.getVideoUrl(),
                 entity.getDurationSeconds(),
                 entity.getOrderNum(),

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/ChapterRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/ChapterRepositoryAdapter.java
@@ -21,6 +21,7 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
         ChapterJpaEntity entity = new ChapterJpaEntity(
                 chapter.getCourseId(),
                 chapter.getTitle(),
+                chapter.getDescription(),
                 chapter.getVideoUrl(),
                 chapter.getDurationSeconds(),
                 chapter.getChapterOrder()
@@ -50,6 +51,7 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
             Long chapterId,
             Long courseId,
             String title,
+            String description,
             String videoUrl,
             int durationSeconds,
             int chapterOrder
@@ -58,6 +60,7 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
                 .map(entity -> {
                     entity.updateBasicInfo(
                             title,
+                            description,
                             videoUrl,
                             durationSeconds,
                             chapterOrder
@@ -108,6 +111,7 @@ public class ChapterRepositoryAdapter implements ChapterRepository {
                 entity.getId(),
                 entity.getCourseId(),
                 entity.getTitle(),
+                entity.getDescription(),
                 entity.getVideoUrl(),
                 entity.getDurationSeconds(),
                 entity.getOrderNum(),

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/ChapterJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/entity/ChapterJpaEntity.java
@@ -22,6 +22,9 @@ public class ChapterJpaEntity {
     @Column(nullable = false, length = 255)
     private String title;
 
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
     @Column(name = "video_url", nullable = false, length = 500)
     private String videoUrl;
 
@@ -37,12 +40,14 @@ public class ChapterJpaEntity {
     public ChapterJpaEntity(
             Long courseId,
             String title,
+            String description,
             String videoUrl,
             int durationSeconds,
             int orderNum
     ) {
         this.courseId = courseId;
         this.title = title;
+        this.description = description;
         this.videoUrl = videoUrl;
         this.durationSeconds = durationSeconds;
         this.orderNum = orderNum;
@@ -56,6 +61,7 @@ public class ChapterJpaEntity {
             int orderNum
     ) {
         this.title = title;
+        this.description = null;
         this.videoUrl = videoUrl;
         this.durationSeconds = durationSeconds;
         this.orderNum = orderNum;
@@ -64,11 +70,13 @@ public class ChapterJpaEntity {
 
     public void updateBasicInfo(
             String title,
+            String description,
             String videoUrl,
             int durationSeconds,
             int orderNum
     ) {
         this.title = title;
+        this.description = description;
 
         if (videoUrl != null) {
             this.videoUrl = videoUrl;

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminChapterController.java
@@ -89,6 +89,7 @@ public class AdminChapterController {
         CreateChapterCommand command = new CreateChapterCommand(
                 courseId,
                 request.title(),
+                request.description(),
                 videoFile,
                 request.durationSeconds(),
                 request.chapterOrder()
@@ -136,6 +137,7 @@ public class AdminChapterController {
 
         UpdateChapterCommand command = new UpdateChapterCommand(
                 request.title(),
+                request.description(),
                 videoFile,
                 request.durationSeconds(),
                 request.chapterOrder()

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/01-auth-map.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/01-auth-map.http
@@ -1,37 +1,18 @@
 ### ==========================================================
-### 01. 인증 + 지도/국가별 강의 조회
-### 사용 순서:
-### 1) 로그인 실행
-### 2) accessToken 저장 확인
-### 3) 아래 지도/국가별 강의 조회 실행
+### 01. Auth setup for HTTP Client tests
+###
+### Run order:
+### 1. Run "Super admin login"
+### 2. Run "Create content manager" only when the account does not exist
+### 3. Run "Content manager login"
+### 4. Use {{managerAccessToken}} in other .http files
+###
+### Admin login returns accessToken in Set-Cookie, not response body.
+### The scripts below save accessToken from Set-Cookie into global variables.
 ### ==========================================================
 
 
-### 회원가입
-### 이미 가입된 계정이면 건너뛰어도 됨
-POST http://localhost:15000/api/v1/auth/admin/signup
-Content-Type: application/json
-Accept: application/json
-
-{
-  "username": "test2",
-  "email": "test2@algoga.com",
-  "password": "test1234",
-  "name": "라프윤",
-  "phone": "010-4343-9999",
-  "birthDate": "2022-11-26",
-  "gender": "MALE",
-  "nickname": "윤라프",
-  "referralCode": "REF003",
-  "signupPath": "인스타그램"
-}
-
-
-### ==========================================================
-### 관리자/매니저 로그인
-### ==========================================================
-
-### 슈퍼 관리자 로그인
+### Super admin login
 POST http://localhost:15000/api/v1/auth/admin/login
 Content-Type: application/json
 Accept: application/json
@@ -43,29 +24,42 @@ Accept: application/json
 
 > {%
     if (response.status === 200) {
-        client.global.set("adminToken", response.body.data.accessToken);
-        client.global.set("managerAccessToken", response.body.data.accessToken);
-        client.log("Admin Token 저장 완료: " + client.global.get("adminToken"));
-        client.log("Manager Token 저장 완료: " + client.global.get("managerAccessToken"));
+        const setCookie = response.headers.valuesOf
+            ? response.headers.valuesOf("Set-Cookie").join("; ")
+            : response.headers.valueOf("Set-Cookie");
+        const match = setCookie && setCookie.match(/accessToken=([^;]+)/);
+
+        if (match) {
+            client.global.set("adminToken", match[1]);
+            client.global.set("managerAccessToken", match[1]);
+            client.log("adminToken saved: " + client.global.get("adminToken"));
+            client.log("managerAccessToken saved: " + client.global.get("managerAccessToken"));
+        } else {
+            client.log("Admin accessToken cookie not found.");
+            client.log("Set-Cookie: " + setCookie);
+        }
     }
 %}
 
-### 콘텐츠 매니저 계정 생성
+
+### Create content manager
+### If this account already exists, skip this request and run content manager login.
 POST http://localhost:15000/api/v1/admin/managers
 Content-Type: application/json
 Authorization: Bearer {{adminToken}}
+Cookie: accessToken={{adminToken}}
 
 {
   "loginId": "content_manager_01",
   "password": "password123",
-  "name": "콘텐츠매니저",
+  "name": "content-manager",
   "phone": "010-9999-9999",
   "email": "content_manager_01@algoga.com",
   "role": "CONTENT_MANAGER"
 }
 
 
-### 콘텐츠 매니저 로그인
+### Content manager login
 POST http://localhost:15000/api/v1/auth/admin/login
 Content-Type: application/json
 Accept: application/json
@@ -77,13 +71,23 @@ Accept: application/json
 
 > {%
     if (response.status === 200) {
-        client.global.set("managerAccessToken", response.body.data.accessToken);
-        client.log("Manager Token 저장 완료: " + client.global.get("managerAccessToken"));
+        const setCookie = response.headers.valuesOf
+            ? response.headers.valuesOf("Set-Cookie").join("; ")
+            : response.headers.valueOf("Set-Cookie");
+        const match = setCookie && setCookie.match(/accessToken=([^;]+)/);
+
+        if (match) {
+            client.global.set("managerAccessToken", match[1]);
+            client.log("managerAccessToken saved: " + client.global.get("managerAccessToken"));
+        } else {
+            client.log("Manager accessToken cookie not found.");
+            client.log("Set-Cookie: " + setCookie);
+        }
     }
 %}
 
 
-### 일반 사용자 로그인
+### User login
 POST http://localhost:15000/api/v1/auth/login
 Content-Type: application/json
 Accept: application/json
@@ -95,28 +99,49 @@ Accept: application/json
 
 > {%
     if (response.status === 200) {
-        client.global.set("userAccessToken", response.body.data.accessToken);
-        client.global.set("userRefreshToken", response.body.data.refreshToken);
-        client.log("User Access Token 저장 완료: " + client.global.get("userAccessToken"));
+        const bodyToken = response.body && response.body.data && response.body.data.accessToken;
+
+        if (bodyToken) {
+            client.global.set("userAccessToken", bodyToken);
+            client.global.set("userRefreshToken", response.body.data.refreshToken);
+            client.log("userAccessToken saved from body: " + client.global.get("userAccessToken"));
+        } else {
+            const setCookie = response.headers.valuesOf
+                ? response.headers.valuesOf("Set-Cookie").join("; ")
+                : response.headers.valueOf("Set-Cookie");
+            const match = setCookie && setCookie.match(/accessToken=([^;]+)/);
+
+            if (match) {
+                client.global.set("userAccessToken", match[1]);
+                client.log("userAccessToken saved from cookie: " + client.global.get("userAccessToken"));
+            } else {
+                client.log("User accessToken not found.");
+                client.log("Set-Cookie: " + setCookie);
+            }
+        }
     }
 %}
 
-### ----------------------------------------------------------
-### 지도 - 대륙 목록 조회
+
+### Map - continents
 GET http://localhost:15000/api/v1/maps/continents
 Authorization: Bearer {{managerAccessToken}}
+Cookie: accessToken={{managerAccessToken}}
 
 
-### 지도 - 아시아 국가 목록 조회
+### Map - Asia countries
 GET http://localhost:15000/api/v1/maps/continents/ASIA/countries
 Authorization: Bearer {{userAccessToken}}
+Cookie: accessToken={{userAccessToken}}
 
 
-### 지도 - 유럽 국가 목록 조회
+### Map - Europe countries
 GET http://localhost:15000/api/v1/maps/continents/EUROPE/countries
 Authorization: Bearer {{userAccessToken}}
+Cookie: accessToken={{userAccessToken}}
 
 
-### 국가별 강의 목록 조회 - 일본
+### Course list by country - Japan
 GET http://localhost:15000/api/v1/courses/countries/1
 Authorization: Bearer {{userAccessToken}}
+Cookie: accessToken={{userAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/03-admin-chapter.http
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/03-admin-chapter.http
@@ -6,14 +6,16 @@
 
 
 ### 챕터 관리 - 챕터 목록 조회
-GET http://localhost:15000/api/v1/admin/courses/76/chapters
+GET http://localhost:15000/api/v1/admin/courses/62/chapters
 Authorization: Bearer {{managerAccessToken}}
+Cookie: accessToken={{managerAccessToken}}
 
 
 ### 챕터 관리 - 챕터 등록
 ### 응답의 data.chapterId를 수정/삭제 테스트에 사용
-POST http://localhost:15000/api/v1/admin/courses/76/chapters
+POST http://localhost:15000/api/v1/admin/courses/62/chapters
 Authorization: Bearer {{managerAccessToken}}
+Cookie: accessToken={{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -21,10 +23,10 @@ Content-Disposition: form-data; name="request"; filename="request.json"
 Content-Type: application/json
 
 {
-  "title": "s3강. 여행 전 필수 준비",
+  "title": "라프의 일상 1강",
+  "description": "이 챕터에서 배울 내용을 입력합니다.",
   "durationSeconds": 700,
   "chapterOrder": 4
-
 }
 
 --boundary
@@ -37,14 +39,16 @@ Content-Type: video/mp4
 
 
 ### 챕터 관리 - 챕터 등록 후 목록 조회
-GET http://localhost:15000/api/v1/admin/courses/76/chapters
+GET http://localhost:15000/api/v1/admin/courses/62/chapters
 Authorization: Bearer {{managerAccessToken}}
+Cookie: accessToken={{managerAccessToken}}
 
 
 ### 챕터 관리 - 챕터 수정
 ### 아래 chapterId를 실제 챕터 ID로 변경
-PUT http://localhost:15000/api/v1/admin/courses/76/chapters/1
+PUT http://localhost:15000/api/v1/admin/courses/62/chapters/5
 Authorization: Bearer {{managerAccessToken}}
+Cookie: accessToken={{managerAccessToken}}
 Content-Type: multipart/form-data; boundary=boundary
 
 --boundary
@@ -52,7 +56,8 @@ Content-Disposition: form-data; name="request"; filename="request.json"
 Content-Type: application/json
 
 {
-  "title": "1강. 여행 전 필수 준비 수정본",
+  "title": "라프의 일상 1강 수정",
+  "description": "수정된 챕터 설명입니다.",
   "durationSeconds": 720,
   "chapterOrder": 4
 }
@@ -70,8 +75,10 @@ Content-Type: video/mp4
 ### 삭제 테스트가 필요할 때만 실행
 DELETE http://localhost:15000/api/v1/admin/courses/76/chapters/1
 Authorization: Bearer {{managerAccessToken}}
+Cookie: accessToken={{managerAccessToken}}
 
 
 ### 챕터 관리 - 삭제 후 목록 조회
 GET http://localhost:15000/api/v1/admin/courses/76/chapters
 Authorization: Bearer {{managerAccessToken}}
+Cookie: accessToken={{managerAccessToken}}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateChapterRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/CreateChapterRequest.java
@@ -13,6 +13,9 @@ public record CreateChapterRequest(
         @NotBlank(message = "챕터 제목은 필수입니다.")
         String title,
 
+        @Schema(description = "챕터 설명", example = "이 챕터에서 배울 내용을 입력합니다.")
+        String description,
+
         @Schema(description = "영상 재생 시간. 초 단위", example = "600")
         @NotNull(message = "영상 재생 시간은 필수입니다.")
         @Min(value = 1, message = "영상 재생 시간은 1초 이상이어야 합니다.")

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateChapterRequest.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/request/admin/UpdateChapterRequest.java
@@ -13,6 +13,9 @@ public record UpdateChapterRequest(
         @NotBlank(message = "챕터 제목은 필수입니다.")
         String title,
 
+        @Schema(description = "수정할 챕터 설명", example = "수정된 챕터 설명입니다.")
+        String description,
+
         @Schema(description = "수정할 영상 재생 시간. 초 단위", example = "720")
         @NotNull(message = "영상 재생 시간은 필수입니다.")
         @Min(value = 1, message = "영상 재생 시간은 1초 이상이어야 합니다.")

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminChapterResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminChapterResponse.java
@@ -14,6 +14,9 @@ public record AdminChapterResponse(
         @Schema(description = "챕터 제목", example = "출국 전 준비사항")
         String title,
 
+        @Schema(description = "챕터 설명", example = "이 챕터에서 배울 내용을 입력합니다.")
+        String description,
+
         @Schema(description = "강의 영상 URL")
         String videoUrl,
 
@@ -28,6 +31,7 @@ public record AdminChapterResponse(
                 chapter.chapterId(),
                 chapter.courseId(),
                 chapter.title(),
+                chapter.description(),
                 chapter.videoUrl(),
                 chapter.durationSeconds(),
                 chapter.chapterOrder()

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseClassroomResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseClassroomResponse.java
@@ -42,6 +42,9 @@ public record CourseClassroomResponse(
             @Schema(description = "챕터 제목", example = "1강. 여행 전 필수 준비")
             String title,
 
+            @Schema(description = "챕터 설명", example = "이 챕터에서 배울 내용을 입력합니다.")
+            String description,
+
             @Schema(description = "영상 URL. 잠긴 챕터는 null")
             String videoUrl,
 
@@ -67,6 +70,7 @@ public record CourseClassroomResponse(
             return new ChapterLearningResponse(
                     result.chapterId(),
                     result.title(),
+                    result.description(),
                     result.videoUrl(),
                     result.durationSeconds(),
                     result.chapterOrder(),


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명
챕터 등록/수정 시 입력한 챕터 설명이 저장되지 않던 문제를 수정했습니다.
chapters 테이블에 챕터 설명 컬럼 추가
챕터 도메인 모델, JPA 엔티티, Repository, Service 계층에 description 필드 반영
챕터 등록/수정 요청 DTO에 description 추가
관리자 챕터 응답 JSON에 description 추가
수강 화면 챕터 응답에도 챕터 설명이 내려가도록 반영
.http 테스트 파일에서 관리자 로그인 토큰을 쿠키 기반으로 저장하도록 수정
챕터 API 테스트 요청에 Cookie: accessToken={{managerAccessToken}} 추가
## 🔗 Issue
Closes #313

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 관리자 챕터 등록 시 description이 DB chapters.description에 저장되는지 확인
- [ ] 관리자 챕터 목록/등록/수정 응
- [ ] 답 JSON에 description이 포함되는지 확인
- [ ] 프론트에서 multipart request JSON에 description을 포함해도 정상 등록/수정되는지 확인
- [ ] 01-auth-map.http에서 로그인 후 managerAccessToken이 정상 저장되는지 확인
- [ ] 03-admin-chapter.http의 챕터 조회/등록/수정 요청이 인증 오류 없이 실행되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 챕터에 설명 필드를 추가하여 과정 콘텐츠 상세 정보를 더욱 풍부하게 표현할 수 있습니다.
  * 챕터 생성 및 수정 시 설명 정보를 포함할 수 있도록 API가 확장되었습니다.
  * 과정 조회 화면에서 각 챕터의 설명이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->