### PR TITLE
[Feature] 통계매니저용 유저 리스트 및 상세 정보(친구 탭 포함) 조회 API 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/friend/application/service/FriendQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/friend/application/service/FriendQueryService.java
@@ -74,4 +74,39 @@ FriendQueryService implements FriendQueryUseCase {
                 user.getProfileImageUrl()
         );
     }
+
+    @Override
+    public long countFriends(Long userId) {
+        // 친구 레포지토리에서 바로 카운트
+        return friendRepository.countAcceptedFriends(userId);
+    }
+
+    @Override
+    public List<com.kidmily.algoga_server.user.presentation.response.AdminFriendDetailResponse> getAdminFriendDetails(Long userId) {
+
+        // 1. 수락 완료된 친구 관계 리스트 가져오기
+        List<FriendRelation> relations = friendRepository.findAcceptedFriends(userId);
+
+        // 2. 친구들의 User ID 추출
+        List<Long> friendIds = relations.stream()
+                .map(rel -> rel.getRequesterId().equals(userId) ? rel.getReceiverId() : rel.getRequesterId())
+                .toList();
+
+        // 3. (옵션) 최적화를 위해 UserRepository에서 닉네임만 맵으로 가져오는 로직
+        // (이 부분을 위해 FriendQueryService 상단에 UserRepository 주입이 필요합니다)
+        java.util.Map<Long, String> friendNicknameMap = userRepository.findAllById(friendIds).stream()
+                .collect(java.util.stream.Collectors.toMap(User::getId, User::getNickname));
+
+        // 4. 스키마 규격으로 매핑
+        return relations.stream().map(rel -> {
+            Long friendId = rel.getRequesterId().equals(userId) ? rel.getReceiverId() : rel.getRequesterId();
+            String nickname = friendNicknameMap.getOrDefault(friendId, "알 수 없음(탈퇴유저)");
+
+            return com.kidmily.algoga_server.user.presentation.response.AdminFriendDetailResponse.of(
+                    friendId,
+                    nickname,
+                    rel.getUpdatedAt()
+            );
+        }).toList();
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/friend/application/service/FriendQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/friend/application/service/FriendQueryService.java
@@ -19,7 +19,8 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class FriendQueryService implements FriendQueryUseCase {
+public class
+FriendQueryService implements FriendQueryUseCase {
 
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;

--- a/src/main/java/com/kidmily/algoga_server/friend/application/usecase/FriendQueryUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/friend/application/usecase/FriendQueryUseCase.java
@@ -7,6 +7,12 @@ public interface FriendQueryUseCase {
     List<FriendView> getReceivedRequests(Long myId);
     FriendView searchUserByCode(String code);
 
+    // 🌟 1. 추가: 관리자 페이지 리스트용 친구 수 카운트 기능
+    long countFriends(Long userId);
+
+    // 🌟 2. 추가: 관리자 페이지 상세조회용 친구 탭 목록 반환 (이전 UserService에서 옮겨올 로직)
+    List<com.kidmily.algoga_server.user.presentation.response.AdminFriendDetailResponse> getAdminFriendDetails(Long userId);
+
     // 강사님 패턴: DTO 폴더를 만들지 않고 UseCase 내부에 View 객체 선언
     record FriendView(
             Long relationId,

--- a/src/main/java/com/kidmily/algoga_server/friend/domain/repository/FriendRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/friend/domain/repository/FriendRepository.java
@@ -21,4 +21,5 @@ public interface FriendRepository {
 
     // 삭제 시 필요 (이미 save/findById가 있다면 추가)
     void delete(FriendRelation relation);
+
 }

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
@@ -48,8 +48,6 @@ public class UserService {
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, String> redisTemplate;
 
-    private final FriendRepository friendRepository;
-
     // 내 프로필 조회
     @Transactional(readOnly = true)
     public UserProfileResponse getMyProfile(String email) {
@@ -181,65 +179,20 @@ public class UserService {
     }
 
     // 🌟 관리자용: 전체 유저 리스트 조회 로직
-    // ==========================================
     @Transactional(readOnly = true)
-    public Page<AdminUserListResponse> getAdminUserList(Pageable pageable) {
-
-        // 1. 삭제되지 않은 유저 목록을 DB에서 페이징(10개씩 등)해서 가져옵니다.
-        Page<User> users = userRepository.findByIsDeletedFalse(pageable); // (UserRepository에 이 메서드가 없다면 만들어주세요!)
-
-        // 2. 가져온 유저들을 하나씩 돌면서 DTO로 예쁘게 변환합니다.
-        return users.map(user -> {
-
-            // 🌟 내 담당: DB에서 숫자(카운트)만 아주 가볍게 쏙 빼옵니다!
-            long friendCount = friendRepository.countAcceptedFriends(user.getId());
-
-            // 🤝 타 팀원 담당: 게시글 파트 담당자가 나중에 자기 Repository 주입해서 채울 자리 (일단 0)
-            long postCount = 0L;
-            long commentCount = 0L;
-
-            return AdminUserListResponse.of(user, friendCount, postCount, commentCount);
-        });
+    public Page<User> getAdminUserListRaw(Pageable pageable) {
+        return userRepository.findByIsDeletedFalse(pageable);
     }
 
     // 🌟 관리자용: 특정 유저 상세 조회 (기본 정보 + 로그인상태 + 친구 목록)
-    // ==========================================
     @Transactional(readOnly = true)
-    public com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse getAdminUserDetail(Long targetUserId) {
-
-        // 1. 대상 유저 기본 정보 조회
-        User user = userRepository.findById(targetUserId)
+    public User getAdminUserDetailRaw(Long targetUserId) {
+        return userRepository.findById(targetUserId)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
-
-        // 2. 실무 정답: Redis에 로그인 시 쌓이는 Access Token 세션 키가 존재하는지 판단하여 활동상태 정의!
-        // (원래 로그인 필터 규격에 맞춰 "RT:이메일" 혹은 로그인 세션 키 이름으로 대조하면 됩니다)
-        boolean isOnline = Boolean.TRUE.equals(redisTemplate.hasKey("RT:" + user.getEmail()));
-
-        // 3. 이 유저의 수락 완료된 친구 관계 리스트 가져오기 (기존에 만들어두신 완벽한 메서드 활용)
-        List<com.kidmily.algoga_server.friend.domain.model.FriendRelation> relations = friendRepository.findAcceptedFriends(targetUserId);
-
-        // 4. 친구들의 User ID 추출 (내가 요청했으면 상대방ID, 내가 받았으면 요청자ID)
-        List<Long> friendIds = relations.stream()
-                .map(rel -> rel.getRequesterId().equals(targetUserId) ? rel.getReceiverId() : rel.getRequesterId())
-                .toList();
-
-        // 5. 한 번에 친구들의 닉네임을 뺴오기 위해 배치 조회 후 Map 변환 (성능 최적화 정석)
-        java.util.Map<Long, String> friendNicknameMap = userRepository.findAllById(friendIds).stream()
-                .collect(java.util.stream.Collectors.toMap(User::getId, User::getNickname));
-
-        // 6. 스키마 규격(AdminFriendDetailResponse)으로 예쁘게 매핑
-        List<com.kidmily.algoga_server.user.presentation.response.AdminFriendDetailResponse> friendDetails = relations.stream().map(rel -> {
-            Long friendId = rel.getRequesterId().equals(targetUserId) ? rel.getReceiverId() : rel.getRequesterId();
-            String nickname = friendNicknameMap.getOrDefault(friendId, "알 수 없음(탈퇴유저)");
-
-            return com.kidmily.algoga_server.user.presentation.response.AdminFriendDetailResponse.of(
-                    friendId,
-                    nickname,
-                    rel.getUpdatedAt() // 친구 관계가 최신 승인된 날짜 (또는 createdAt)
-            );
-        }).toList();
-
-        // 7. 최상위 상세 DTO로 최종 조립하여 반환
-        return com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse.of(user, isOnline, friendDetails);
     }
+
+    public boolean isUserOnline(String email) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey("RT:" + email));
+    }
+
 }

--- a/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/UserService.java
@@ -1,5 +1,7 @@
 package com.kidmily.algoga_server.user.application;
 
+import com.kidmily.algoga_server.friend.domain.model.RelationStatus;
+import com.kidmily.algoga_server.friend.domain.repository.FriendRepository;
 import com.kidmily.algoga_server.global.port.out.FileStoragePort;
 import com.kidmily.algoga_server.global.security.GlobalJwtProvider;
 import com.kidmily.algoga_server.user.domain.User;
@@ -9,12 +11,15 @@ import com.kidmily.algoga_server.user.exception.UserException;
 import com.kidmily.algoga_server.user.presentation.request.UpdatePasswordRequest;
 import com.kidmily.algoga_server.user.presentation.request.UpdateProfileRequest;
 import com.kidmily.algoga_server.user.presentation.request.VerifyPasswordRequest;
+import com.kidmily.algoga_server.user.presentation.response.AdminUserListResponse;
 import com.kidmily.algoga_server.user.presentation.response.AuthTokenResponse;
 import com.kidmily.algoga_server.user.presentation.response.SignupPathStatResponse;
 import com.kidmily.algoga_server.user.presentation.response.UserProfileResponse;
 import com.kidmily.algoga_server.user.settings.UserStorageSettings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +27,6 @@ import org.springframework.web.multipart.MultipartFile;
 import com.kidmily.algoga_server.global.event.UserWithdrawnEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +47,8 @@ public class UserService {
     // softDelete 정책 관련
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, String> redisTemplate;
+
+    private final FriendRepository friendRepository;
 
     // 내 프로필 조회
     @Transactional(readOnly = true)
@@ -172,5 +178,68 @@ public class UserService {
         return userRepository.countUsersBySignupPath().stream()
                 .map(SignupPathStatResponse::from)
                 .toList();
+    }
+
+    // 🌟 관리자용: 전체 유저 리스트 조회 로직
+    // ==========================================
+    @Transactional(readOnly = true)
+    public Page<AdminUserListResponse> getAdminUserList(Pageable pageable) {
+
+        // 1. 삭제되지 않은 유저 목록을 DB에서 페이징(10개씩 등)해서 가져옵니다.
+        Page<User> users = userRepository.findByIsDeletedFalse(pageable); // (UserRepository에 이 메서드가 없다면 만들어주세요!)
+
+        // 2. 가져온 유저들을 하나씩 돌면서 DTO로 예쁘게 변환합니다.
+        return users.map(user -> {
+
+            // 🌟 내 담당: DB에서 숫자(카운트)만 아주 가볍게 쏙 빼옵니다!
+            long friendCount = friendRepository.countAcceptedFriends(user.getId());
+
+            // 🤝 타 팀원 담당: 게시글 파트 담당자가 나중에 자기 Repository 주입해서 채울 자리 (일단 0)
+            long postCount = 0L;
+            long commentCount = 0L;
+
+            return AdminUserListResponse.of(user, friendCount, postCount, commentCount);
+        });
+    }
+
+    // 🌟 관리자용: 특정 유저 상세 조회 (기본 정보 + 로그인상태 + 친구 목록)
+    // ==========================================
+    @Transactional(readOnly = true)
+    public com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse getAdminUserDetail(Long targetUserId) {
+
+        // 1. 대상 유저 기본 정보 조회
+        User user = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        // 2. 실무 정답: Redis에 로그인 시 쌓이는 Access Token 세션 키가 존재하는지 판단하여 활동상태 정의!
+        // (원래 로그인 필터 규격에 맞춰 "RT:이메일" 혹은 로그인 세션 키 이름으로 대조하면 됩니다)
+        boolean isOnline = Boolean.TRUE.equals(redisTemplate.hasKey("RT:" + user.getEmail()));
+
+        // 3. 이 유저의 수락 완료된 친구 관계 리스트 가져오기 (기존에 만들어두신 완벽한 메서드 활용)
+        List<com.kidmily.algoga_server.friend.domain.model.FriendRelation> relations = friendRepository.findAcceptedFriends(targetUserId);
+
+        // 4. 친구들의 User ID 추출 (내가 요청했으면 상대방ID, 내가 받았으면 요청자ID)
+        List<Long> friendIds = relations.stream()
+                .map(rel -> rel.getRequesterId().equals(targetUserId) ? rel.getReceiverId() : rel.getRequesterId())
+                .toList();
+
+        // 5. 한 번에 친구들의 닉네임을 뺴오기 위해 배치 조회 후 Map 변환 (성능 최적화 정석)
+        java.util.Map<Long, String> friendNicknameMap = userRepository.findAllById(friendIds).stream()
+                .collect(java.util.stream.Collectors.toMap(User::getId, User::getNickname));
+
+        // 6. 스키마 규격(AdminFriendDetailResponse)으로 예쁘게 매핑
+        List<com.kidmily.algoga_server.user.presentation.response.AdminFriendDetailResponse> friendDetails = relations.stream().map(rel -> {
+            Long friendId = rel.getRequesterId().equals(targetUserId) ? rel.getReceiverId() : rel.getRequesterId();
+            String nickname = friendNicknameMap.getOrDefault(friendId, "알 수 없음(탈퇴유저)");
+
+            return com.kidmily.algoga_server.user.presentation.response.AdminFriendDetailResponse.of(
+                    friendId,
+                    nickname,
+                    rel.getUpdatedAt() // 친구 관계가 최신 승인된 날짜 (또는 createdAt)
+            );
+        }).toList();
+
+        // 7. 최상위 상세 DTO로 최종 조립하여 반환
+        return com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse.of(user, isOnline, friendDetails);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/domain/UserRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/user/domain/UserRepository.java
@@ -1,11 +1,13 @@
 package com.kidmily.algoga_server.user.domain;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일과 삭제 여부로 유저 조회
@@ -29,6 +31,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 14일 전에 탈퇴한(isDeleted=true) 유저 목록 가져오기
     List<User> findByIsDeletedTrueAndDeletedAtBefore(LocalDateTime dateTime);
+
+    // 관리자용: 탈퇴하지 않은 전체 유저 목록을 페이징하여 조회
+    Page<User> findByIsDeletedFalse(Pageable pageable);
 
     // 결과를 담을 아주 얇은 바구니(인터페이스)를 하나 선언합니다.
     interface SignupPathStat {

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/UserAdminController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/UserAdminController.java
@@ -2,30 +2,53 @@ package com.kidmily.algoga_server.user.presentation;
 
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.user.application.UserService;
+import com.kidmily.algoga_server.user.presentation.response.AdminUserListResponse;
 import com.kidmily.algoga_server.user.presentation.response.SignupPathStatResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.List;
 
 @Tag(name = "Admin-Statistics", description = "관리자 전용 통계 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/admin/statistics/users")
+@RequestMapping("/api/v1/admin/users")
 public class UserAdminController {
 
     private final UserService userService;
 
     @Operation(summary = "유저 유입(가입) 경로 통계", description = "어떤 경로(검색, 지인추천 등)를 통해 유저들이 가입했는지 비율과 수치를 집계합니다.")
-    @GetMapping("/signup-paths")
+    @GetMapping("/statistics/signup-paths")
     public ApiResponse<List<SignupPathStatResponse>> getSignupPathStats() {
 
         List<SignupPathStatResponse> stats = userService.getSignupPathStats();
 
         return ApiResponse.success("STAT_SIGNUP_PATH_SUCCESS", "유저 가입 경로 통계 조회를 성공했습니다.", stats);
+    }
+
+    @Operation(summary = "유저 리스트 전체 조회 (관리자용)", description = "CS 매니저가 유저 리스트와 통계(친구/게시글 수)를 페이징하여 조회합니다.")
+    @GetMapping
+    public ApiResponse<Page<AdminUserListResponse>> getUserList(
+            @PageableDefault(size = 10) Pageable pageable) { // 한 페이지에 10명씩 가져옴
+
+        Page<AdminUserListResponse> response = userService.getAdminUserList(pageable);
+
+        return ApiResponse.success("ADMIN_USER_LIST_SUCCESS", "유저 목록 조회를 성공했습니다.", response);
+    }
+
+    @Operation(summary = "유저 상세 정보 및 친구 탭 조회 (관리자용)", description = "특정 유저의 상세 기본 정보, 실시간 로그인 상태, 친구 목록 탭에 들어갈 데이터를 한 번에 조회합니다.")
+    @GetMapping("/{userId}")
+    public ApiResponse<com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse> getUserDetail(
+            @org.springframework.web.bind.annotation.PathVariable("userId") Long userId) {
+
+        com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse response = userService.getAdminUserDetail(userId);
+
+        return ApiResponse.success("ADMIN_USER_DETAIL_SUCCESS", "유저 상세 정보 조회를 성공했습니다.", response);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/UserAdminController.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/UserAdminController.java
@@ -1,21 +1,26 @@
 package com.kidmily.algoga_server.user.presentation;
 
+// 🌟 커뮤니티 파트의 UseCase와 Response Import 추가
+import com.kidmily.algoga_server.community.application.usecase.PostQueryUseCase;
+import com.kidmily.algoga_server.community.application.usecase.CommentQueryUseCase;
+import com.kidmily.algoga_server.community.presentation.api.response.AdminPostListResponse;
+import com.kidmily.algoga_server.community.presentation.api.response.AdminCommentListResponse;
+
+import com.kidmily.algoga_server.friend.application.usecase.FriendQueryUseCase;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
 import com.kidmily.algoga_server.user.application.UserService;
-import com.kidmily.algoga_server.user.presentation.response.AdminUserListResponse;
-import com.kidmily.algoga_server.user.presentation.response.SignupPathStatResponse;
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.presentation.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
-@Tag(name = "Admin-Statistics", description = "관리자 전용 통계 API")
+@Tag(name = "Admin-User", description = "관리자 전용 유저 관리 및 통계 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/users")
@@ -23,32 +28,53 @@ public class UserAdminController {
 
     private final UserService userService;
 
-    @Operation(summary = "유저 유입(가입) 경로 통계", description = "어떤 경로(검색, 지인추천 등)를 통해 유저들이 가입했는지 비율과 수치를 집계합니다.")
+    private final FriendQueryUseCase friendQueryUseCase;
+    private final PostQueryUseCase postQueryUseCase;
+    private final CommentQueryUseCase commentQueryUseCase;
+
+    @Operation(summary = "유저 유입(가입) 경로 통계")
     @GetMapping("/statistics/signup-paths")
     public ApiResponse<List<SignupPathStatResponse>> getSignupPathStats() {
-
         List<SignupPathStatResponse> stats = userService.getSignupPathStats();
-
-        return ApiResponse.success("STAT_SIGNUP_PATH_SUCCESS", "유저 가입 경로 통계 조회를 성공했습니다.", stats);
+        return ApiResponse.success("STAT_SIGNUP_PATH_SUCCESS", "유저 가입 경로 통계 조회 성공", stats);
     }
 
-    @Operation(summary = "유저 리스트 전체 조회 (관리자용)", description = "CS 매니저가 유저 리스트와 통계(친구/게시글 수)를 페이징하여 조회합니다.")
+    @Operation(summary = "유저 리스트 전체 조회 (관리자용)")
     @GetMapping
     public ApiResponse<Page<AdminUserListResponse>> getUserList(
-            @PageableDefault(size = 10) Pageable pageable) { // 한 페이지에 10명씩 가져옴
+            @PageableDefault(size = 10) Pageable pageable) {
 
-        Page<AdminUserListResponse> response = userService.getAdminUserList(pageable);
+        Page<User> users = userService.getAdminUserListRaw(pageable);
 
-        return ApiResponse.success("ADMIN_USER_LIST_SUCCESS", "유저 목록 조회를 성공했습니다.", response);
+        Page<AdminUserListResponse> response = users.map(user -> {
+            long friendCount = friendQueryUseCase.countFriends(user.getId());
+
+            // 🌟 팀원이 만든 페이징 조회 메서드(1페이지)를 호출한 뒤, 그 안에 있는 전체 개수(totalElements)만 쏙 빼옵니다!
+            long postCount = postQueryUseCase.getMyPostsByPage(user.getId(), 1, null).totalElements();
+            long commentCount = commentQueryUseCase.getMyCommentsByPage(user.getId(), 1).totalElements();
+
+            return AdminUserListResponse.of(user, friendCount, postCount, commentCount);
+        });
+
+        return ApiResponse.success("ADMIN_USER_LIST_SUCCESS", "유저 목록 조회 성공", response);
     }
 
-    @Operation(summary = "유저 상세 정보 및 친구 탭 조회 (관리자용)", description = "특정 유저의 상세 기본 정보, 실시간 로그인 상태, 친구 목록 탭에 들어갈 데이터를 한 번에 조회합니다.")
+    @Operation(summary = "유저 상세 정보 및 탭 조회 (관리자용)")
     @GetMapping("/{userId}")
-    public ApiResponse<com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse> getUserDetail(
-            @org.springframework.web.bind.annotation.PathVariable("userId") Long userId) {
+    public ApiResponse<AdminUserDetailResponse> getUserDetail(@PathVariable("userId") Long userId) {
 
-        com.kidmily.algoga_server.user.presentation.response.AdminUserDetailResponse response = userService.getAdminUserDetail(userId);
+        User user = userService.getAdminUserDetailRaw(userId);
+        boolean isOnline = userService.isUserOnline(user.getEmail());
 
-        return ApiResponse.success("ADMIN_USER_DETAIL_SUCCESS", "유저 상세 정보 조회를 성공했습니다.", response);
+        List<AdminFriendDetailResponse> friends = friendQueryUseCase.getAdminFriendDetails(userId);
+
+        // 🌟 팀원이 만든 목록 데이터 자체(1페이지 기준)를 몽땅 가져옵니다!
+        AdminPostListResponse postData = postQueryUseCase.getMyPostsByPage(userId, 1, null);
+        AdminCommentListResponse commentData = commentQueryUseCase.getMyCommentsByPage(userId, 1);
+
+        // 🌟 DTO에 한 번에 묶어서 반환
+        AdminUserDetailResponse response = AdminUserDetailResponse.of(user, isOnline, friends, postData, commentData);
+
+        return ApiResponse.success("ADMIN_USER_DETAIL_SUCCESS", "유저 상세 정보 조회 성공", response);
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminFriendDetailResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminFriendDetailResponse.java
@@ -1,0 +1,23 @@
+package com.kidmily.algoga_server.user.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자용 회원의 친구 상세 정보 응답")
+public record AdminFriendDetailResponse(
+        @Schema(description = "친구의 회원 고유 ID", example = "5")
+        Long friendId,
+
+        @Schema(description = "친구의 닉네임", example = "수원불주먹")
+        String friendNickname,
+
+        @Schema(description = "친구 관계 성립(추가) 일시", example = "2026-06-15T14:30:00")
+        LocalDateTime addedAt
+) {
+    /**
+     * 🌟 UserService에서 호출할 때 사용하는 정적 팩토리 메서드 'of'
+     */
+    public static AdminFriendDetailResponse of(Long friendId, String friendNickname, LocalDateTime addedAt) {
+        return new AdminFriendDetailResponse(friendId, friendNickname, addedAt);
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminUserDetailResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminUserDetailResponse.java
@@ -1,5 +1,9 @@
 package com.kidmily.algoga_server.user.presentation.response;
 
+// 🌟 커뮤니티 파트의 Response 객체 Import
+import com.kidmily.algoga_server.community.presentation.api.response.AdminPostListResponse;
+import com.kidmily.algoga_server.community.presentation.api.response.AdminCommentListResponse;
+
 import com.kidmily.algoga_server.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -25,13 +29,20 @@ public record AdminUserDetailResponse(
         @Schema(description = "회원의 친구 목록")
         List<AdminFriendDetailResponse> friends,
 
-        @Schema(description = "🤝 타 팀원 담당: 회원이 작성한 게시글 목록 (임시 타입)")
-        List<Object> posts,
+        // 🌟 타입을 Object에서 팀원이 만든 전용 페이징 객체로 변경!
+        @Schema(description = "회원이 작성한 게시글 목록 데이터")
+        AdminPostListResponse posts,
 
-        @Schema(description = "🤝 타 팀원 담당: 회원이 작성한 댓글 목록 (임시 타입)")
-        List<Object> comments
+        @Schema(description = "회원이 작성한 댓글 목록 데이터")
+        AdminCommentListResponse comments
 ) {
-    public static AdminUserDetailResponse of(User user, boolean isOnline, List<AdminFriendDetailResponse> friends) {
+    public static AdminUserDetailResponse of(
+            User user,
+            boolean isOnline,
+            List<AdminFriendDetailResponse> friends,
+            AdminPostListResponse posts,
+            AdminCommentListResponse comments) {
+
         return new AdminUserDetailResponse(
                 user.getId(),
                 user.getNickname(),
@@ -39,8 +50,8 @@ public record AdminUserDetailResponse(
                 user.getCreatedAt(),
                 isOnline,
                 friends,
-                List.of(), // 타 팀원 담당 영역
-                List.of()  // 타 팀원 담당 영역
+                posts,
+                comments
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminUserDetailResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminUserDetailResponse.java
@@ -1,0 +1,46 @@
+package com.kidmily.algoga_server.user.presentation.response;
+
+import com.kidmily.algoga_server.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "관리자용 회원 상세 정보 및 활동 목록 응답")
+public record AdminUserDetailResponse(
+        @Schema(description = "회원 고유 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "회원 닉네임", example = "알고가매니아")
+        String nickname,
+
+        @Schema(description = "회원 이메일", example = "user1@test.com")
+        String email,
+
+        @Schema(description = "회원 가입 일시", example = "2026-06-01T10:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "현재 실시간 접속(활동) 여부", example = "true")
+        boolean isOnline,
+
+        @Schema(description = "회원의 친구 목록")
+        List<AdminFriendDetailResponse> friends,
+
+        @Schema(description = "🤝 타 팀원 담당: 회원이 작성한 게시글 목록 (임시 타입)")
+        List<Object> posts,
+
+        @Schema(description = "🤝 타 팀원 담당: 회원이 작성한 댓글 목록 (임시 타입)")
+        List<Object> comments
+) {
+    public static AdminUserDetailResponse of(User user, boolean isOnline, List<AdminFriendDetailResponse> friends) {
+        return new AdminUserDetailResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getCreatedAt(),
+                isOnline,
+                friends,
+                List.of(), // 타 팀원 담당 영역
+                List.of()  // 타 팀원 담당 영역
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminUserListResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/response/AdminUserListResponse.java
@@ -1,0 +1,45 @@
+package com.kidmily.algoga_server.user.presentation.response;
+
+import com.kidmily.algoga_server.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자용 전체 회원 목록 조회 응답")
+public record AdminUserListResponse(
+        @Schema(description = "회원 고유 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "회원 닉네임", example = "알고가매니아")
+        String nickname,
+
+        @Schema(description = "회원 이메일", example = "user1@test.com")
+        String email,
+
+        @Schema(description = "회원 가입 일시", example = "2026-06-01T10:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "회원이 맺은 친구 수", example = "5")
+        long friendCount,
+
+        @Schema(description = "🤝 타 팀원 담당: 회원이 작성한 게시글 수", example = "12")
+        long postCount,
+
+        @Schema(description = "🤝 타 팀원 담당: 회원이 작성한 댓글 수", example = "34")
+        long commentCount
+) {
+    /**
+     * 🌟 UserService에서 호출할 때 사용하는 정적 팩토리 메서드 'of'
+     * 매개변수: User 엔티티, 친구 수, 게시글 수, 댓글 수 순서대로 받습니다.
+     */
+    public static AdminUserListResponse of(User user, long friendCount, long postCount, long commentCount) {
+        return new AdminUserListResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getCreatedAt(),
+                friendCount,
+                postCount,
+                commentCount
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/response/SignupPathStatResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/response/SignupPathStatResponse.java
@@ -1,11 +1,21 @@
 package com.kidmily.algoga_server.user.presentation.response;
 
 import com.kidmily.algoga_server.user.domain.UserRepository.SignupPathStat;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "관리자용 가입 경로별 유입 통계 응답")
 public record SignupPathStatResponse(
-        String path,  // 가입 경로 (예: "검색", "지인추천", "광고" 등)
-        Long count    // 해당 경로로 가입한 사람 수
+
+        @Schema(description = "가입 경로 (빈 값일 경우 '기타'로 처리됨)", example = "검색")
+        String path,
+
+        @Schema(description = "해당 경로를 통해 가입한 유저 수", example = "125")
+        Long count
+
 ) {
+    /**
+     * 🌟 DB 통계 인터페이스 결과를 프론트엔드 응답용 DTO로 변환
+     */
     public static SignupPathStatResponse from(SignupPathStat stat) {
         // 만약 가입 경로가 비어있다면 "기타"로 묶어주는 센스!
         String pathName = (stat.getPath() != null && !stat.getPath().isBlank())

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/signupPaths_statistics_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/signupPaths_statistics_test.http
@@ -1,9 +1,7 @@
 ### 환경변수 세팅
 @baseUrl = http://localhost:15000
 
-### 1. 매니저 로그인 (사전 준비)
-# 🌟 요청 주소를 완전히 매치시켰습니다.
-# 🌟 성공하면 인텔리제이가 내부적으로 쿠키를 기억합니다.
+### 1. 매니저 로그인 (여기서 나온 accessToken 값을 복사하세요!)
 POST {{baseUrl}}/api/v1/auth/admin/login
 Content-Type: application/json
 
@@ -12,12 +10,22 @@ Content-Type: application/json
   "password": "password123!"
 }
 
-
 ### --------------------------------------------------
-# 🌟 각 요청 사이에는 반드시 이렇게 ### 분리선이 명확해야 초록색 재생 버튼(▶)이 활성화됩니다.
-### --------------------------------------------------
-
 
 ### 2. 유저 가입 경로 통계 조회 API 테스트
-# 🌟 1번을 성공한 직후 바로 이 버튼을 누르시면 쿠키가 자동으로 실려 날아갑니다!
 GET {{baseUrl}}/api/v1/admin/statistics/users/signup-paths
+Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg0MjMyMSwiZXhwIjoxNzgxODQ0MTIxfQ.csUp-P4IBqCCBJe2zoF_-YdiRSNY23TZDtf6W7JFa2Kz_nWwdhbrZbd0o3Nh35AT
+
+
+### --------------------------------------------------
+
+### 3. 유저 리스트 전체 조회 API 테스트 (관리자용)
+GET {{baseUrl}}/api/v1/admin/statistics/users?page=0&size=10
+Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg0MjMyMSwiZXhwIjoxNzgxODQ0MTIxfQ.csUp-P4IBqCCBJe2zoF_-YdiRSNY23TZDtf6W7JFa2Kz_nWwdhbrZbd0o3Nh35AT
+
+
+### --------------------------------------------------
+
+### 4. 특정 유저 상세 및 친구 목록 탭 조회 테스트
+GET {{baseUrl}}/api/v1/admin/statistics/users/1
+Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg0MjMyMSwiZXhwIjoxNzgxODQ0MTIxfQ.csUp-P4IBqCCBJe2zoF_-YdiRSNY23TZDtf6W7JFa2Kz_nWwdhbrZbd0o3Nh35AT

--- a/src/main/java/com/kidmily/algoga_server/user/presentation/signupPaths_statistics_test.http
+++ b/src/main/java/com/kidmily/algoga_server/user/presentation/signupPaths_statistics_test.http
@@ -12,20 +12,24 @@ Content-Type: application/json
 
 ### --------------------------------------------------
 
-### 2. 유저 가입 경로 통계 조회 API 테스트
-GET {{baseUrl}}/api/v1/admin/statistics/users/signup-paths
-Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg0MjMyMSwiZXhwIjoxNzgxODQ0MTIxfQ.csUp-P4IBqCCBJe2zoF_-YdiRSNY23TZDtf6W7JFa2Kz_nWwdhbrZbd0o3Nh35AT
+### 2. 유저 리스트 전체 조회 API 통합 테스트
+# 🌟 기대 결과: 각 유저 정보 안에 friendCount, postCount, commentCount가 실제 숫자로 찍혀야 합니다!
+GET {{baseUrl}}/api/v1/admin/users?page=1&size=10
+Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg1NjIzMSwiZXhwIjoxNzgxODU4MDMxfQ.Th4dwnwi6i5RDKRpkZqzJGW8t_avotFjGj46klJH78QT126BcW9l6VaIeiyzAPWs
 
 
 ### --------------------------------------------------
 
-### 3. 유저 리스트 전체 조회 API 테스트 (관리자용)
-GET {{baseUrl}}/api/v1/admin/statistics/users?page=0&size=10
-Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg0MjMyMSwiZXhwIjoxNzgxODQ0MTIxfQ.csUp-P4IBqCCBJe2zoF_-YdiRSNY23TZDtf6W7JFa2Kz_nWwdhbrZbd0o3Nh35AT
+### 3. 특정 유저 상세 및 친구/게시글/댓글 탭 조회 통합 테스트
+# 🌟 기대 결과: 맨 아래 posts와 comments 항목에 커뮤니티 파트의 페이징 데이터(totalElements 등)가 통째로 들어와야 합니다!
+# (주의: 실제 게시글이나 댓글을 작성한 유저 ID를 넣으면 데이터가 더 예쁘게 나옵니다.)
+GET {{baseUrl}}/api/v1/admin/users/1
+Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg1NjIzMSwiZXhwIjoxNzgxODU4MDMxfQ.Th4dwnwi6i5RDKRpkZqzJGW8t_avotFjGj46klJH78QT126BcW9l6VaIeiyzAPWs
 
 
 ### --------------------------------------------------
 
-### 4. 특정 유저 상세 및 친구 목록 탭 조회 테스트
-GET {{baseUrl}}/api/v1/admin/statistics/users/1
-Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg0MjMyMSwiZXhwIjoxNzgxODQ0MTIxfQ.csUp-P4IBqCCBJe2zoF_-YdiRSNY23TZDtf6W7JFa2Kz_nWwdhbrZbd0o3Nh35AT
+### 4. 유저 가입 경로 통계 조회 API 테스트
+# 기대 결과: "검색", "지인추천" 등의 경로별로 가입한 유저 수가 집계되어 나옵니다.
+GET {{baseUrl}}/api/v1/admin/users/statistics/signup-paths
+Cookie: accessToken=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJzdXBlcl9hZG1pbiIsInR5cGUiOiJBRE1JTiIsImlkIjoxLCJyb2xlIjoiUk9MRV9TVVBFUl9BRE1JTiIsImlhdCI6MTc4MTg1NjIzMSwiZXhwIjoxNzgxODU4MDMxfQ.Th4dwnwi6i5RDKRpkZqzJGW8t_avotFjGj46klJH78QT126BcW9l6VaIeiyzAPWs


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
1.  유저 리스트 전체 조회 API 구현

엔드포인트: GET /api/v1/admin/users

관리자 페이지에서 전체 유저 목록을 페이징 처리하여 한눈에 확인할 수 있도록 구현했습니다.

리스트 화면에서 각 유저가 현재 보유한 '친구 수' 데이터를 함께 확인할 수 있습니다.

2.  특정 유저 상세 정보 및 친구 목록 조회 API 구현

엔드포인트: GET /api/v1/admin/users/{userId}

리스트에서 특정 유저를 클릭했을 때 나타나는 상세 기본 정보(가입일, 이메일, 닉네임 등)를 반환합니다.

해당 유저의 실시간 접속 상태(isOnline)를 파악하여 활동 상태를 표시할 수 있도록 구현했습니다.

유저 상세 페이지의 '친구 목록 탭'에 들어갈 실제 친구 리스트(친구 ID, 닉네임, 친구 추가일) 데이터를 함께 반환하도록 구성했습니다.

## 🔗 Issue
Closes #312

---


## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
[x] 관리자(통계 매니저) 권한으로 로그인 후 토큰을 통한 정상 접근 확인

[x] 유저 리스트 페이징 처리 및 각 유저별 친구 수 정상 출력 확인

[x] 특정 유저 상세 조회 시 기본 정보, 실시간 접속 상태, 친구 목록 데이터 JSON 응답 검증 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 관리자용 사용자 목록 조회 및 상세 정보 조회 기능 추가
  * 사용자 온라인 상태 확인 기능 추가
  * 관리자용 사용자별 친구 관계 조회 및 통계 기능 추가

* **Refactor**
  * 관리자 API 경로 구조 개선 (`/api/v1/admin/statistics/users` → `/api/v1/admin/users`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->