### PR TITLE
[FIX] 파일 업로드 async event 로 빼고 만약 수정하다 취소하면 업로드 중지 로직 추가 + adminAccesT…

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerAuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/application/service/ManagerAuthService.java
@@ -62,26 +62,23 @@ public class ManagerAuthService implements ManagerAuthUseCase {
         redisTemplate.delete("ADMIN_RT:" + loginId);
     }
 
-    // 🌟 변경: 토큰 재발급 시에도 매니저 정보를 조회해 진짜 권한(Role)을 함께 반환함
     @Override
     public AdminAuthTokenResponse refreshAccessToken(String loginId, String refreshToken) {
-        // Redis 토큰 검증
+        // Redis 검증
         String savedRefreshToken = redisTemplate.opsForValue().get("ADMIN_RT:" + loginId);
 
         if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
             throw new ManagerException(ManagerErrorCode.ACCESS_DENIED);
         }
 
-        // 매니저 권한 조회를 위해 DB 탐색
         Manager manager = managerRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
 
         String roleName = "ROLE_" + manager.getRole().name();
 
-        // 새로운 Access Token 발급
+        // 새 Access Token 발급
         String newAccessToken = globalJwtProvider.createAdminAccessToken(manager.getId(), manager.getLoginId(), roleName);
 
-        // 쿠키용 토큰과 응답 바디용 Role을 세트로 묶어서 반환
         return new AdminAuthTokenResponse(newAccessToken, refreshToken, manager.getRole());
     }
 

--- a/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
+++ b/src/main/java/com/kidmily/algoga_server/admin/presentation/api/ManagerAuthController.java
@@ -32,32 +32,33 @@ public class ManagerAuthController {
     private final ManagerAuthUseCase managerAuthUseCase;
     private final GlobalJwtProvider globalJwtProvider;
 
-    @Operation(summary = "매니저 로그인", description = "어드민 계정으로 로그인하여 토큰 쿠키를 발급받습니다.")
+    @Operation(summary = "매니저 로그인", description = "어드민 계정으로 로그인하여 어드민 전용 토큰 쿠키를 발급받습니다.")
     @ApiErrorCodeExample(domain = ManagerErrorCode.class, value = {"MANAGER_NOT_FOUND", "DELETED_MANAGER", "INVALID_PASSWORD"})
     @PostMapping("/login")
     public ApiResponse<AdminLoginResponse> login(
             @RequestBody @Valid ManagerLoginRequest request,
             HttpServletResponse response
     ) {
-
         log.info("[Manager Login] 관리자 로그인 시도 - ID: {}", request.loginId());
 
         LoginManagerCommand command = new LoginManagerCommand(request.loginId(), request.password());
         AdminAuthTokenResponse tokenResponse = managerAuthUseCase.login(command);
 
-        ResponseCookie accessCookie = ResponseCookie.from("accessToken", tokenResponse.accessToken())
+        // 유저 쿠키와 겹치지 않도록 쿠키 이름 분리 (adminAccessToken)
+        ResponseCookie accessCookie = ResponseCookie.from("adminAccessToken", tokenResponse.accessToken())
                 .httpOnly(true)
-                .secure(true)
+                .secure(true) // HTTPS 적용 시 true
                 .path("/")
-                .maxAge(30 * 60)
+                .maxAge(30 * 60) // 30분
                 .sameSite("None")
                 .build();
 
-        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokenResponse.refreshToken())
+        // 유저 쿠키와 겹치지 않도록 쿠키 이름 분리 (adminRefreshToken)
+        ResponseCookie refreshCookie = ResponseCookie.from("adminRefreshToken", tokenResponse.refreshToken())
                 .httpOnly(true)
-                .secure(true)
+                .secure(true) // HTTPS 적용 시 true
                 .path("/")
-                .maxAge(7 * 24 * 60 * 60)
+                .maxAge(7 * 24 * 60 * 60) // 7일
                 .sameSite("None")
                 .build();
 
@@ -66,11 +67,12 @@ public class ManagerAuthController {
 
         log.info("[Manager Login] 관리자 로그인 성공 - ID: {}", request.loginId());
 
+        // JSON 응답에는 Role만 전달
         AdminLoginResponse responseBody = new AdminLoginResponse(tokenResponse.role());
         return ApiResponse.success("MANAGER_LOGIN_SUCCESS", "관리자 로그인에 성공했습니다.", responseBody);
     }
 
-    @Operation(summary = "매니저 로그아웃", description = "토큰 쿠키를 만료시키고 DB(Redis)의 Refresh Token을 폐기합니다.")
+    @Operation(summary = "매니저 로그아웃", description = "어드민 토큰 쿠키를 만료시키고 DB(Redis)의 Refresh Token을 폐기합니다.")
     @PostMapping("/logout")
     public ApiResponse<Void> logout(
             HttpServletRequest request,
@@ -81,19 +83,21 @@ public class ManagerAuthController {
         String accessToken = null;
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
-                if ("accessToken".equals(cookie.getName())) {
+                if ("adminAccessToken".equals(cookie.getName())) {
                     accessToken = cookie.getValue();
                     break;
                 }
             }
         }
 
+        // Redis 폐기
         if (accessToken != null && globalJwtProvider.validateToken(accessToken)) {
             String loginId = globalJwtProvider.getSubject(accessToken);
             managerAuthUseCase.logout(loginId);
         }
 
-        ResponseCookie accessCookie = ResponseCookie.from("accessToken", "")
+        // 쿠키 만료
+        ResponseCookie accessCookie = ResponseCookie.from("adminAccessToken", "")
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
@@ -101,7 +105,7 @@ public class ManagerAuthController {
                 .sameSite("None")
                 .build();
 
-        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", "")
+        ResponseCookie refreshCookie = ResponseCookie.from("adminRefreshToken", "")
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
@@ -112,20 +116,19 @@ public class ManagerAuthController {
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
-        log.info("[Manager Logout] 관리자 로그아웃 성공 (쿠키 만료 완료)");
+        log.info("[Manager Logout] 관리자 로그아웃 성공 (어드민 쿠키 만료 완료)");
 
         return ApiResponse.success("MANAGER_LOGOUT_SUCCESS", "관리자 로그아웃에 성공했습니다.", null);
     }
 
-    // 🌟 변경: 반환 타입을 ApiResponse<AdminLoginResponse>로 교체하여 로그인과 똑같이 맞춤
-    @Operation(summary = "어드민 토큰 재발급", description = "만료된 Access Token을 수명이 남아있는 Refresh Token 쿠키를 이용해 자동으로 연장하고 최신 Role 정보를 반환합니다.")
+    @Operation(summary = "어드민 토큰 재발급", description = "만료된 adminAccessToken을 수명이 남아있는 adminRefreshToken 쿠키를 이용해 자동으로 연장하고 최신 Role 정보를 반환합니다.")
     @PostMapping("/refresh")
     public ApiResponse<AdminLoginResponse> refreshToken(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = null;
 
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
-                if ("refreshToken".equals(cookie.getName())) {
+                if ("adminRefreshToken".equals(cookie.getName())) {
                     refreshToken = cookie.getValue();
                     break;
                 }
@@ -138,15 +141,15 @@ public class ManagerAuthController {
 
         String loginId = globalJwtProvider.getSubject(refreshToken);
 
-        // 1. 서비스단 호출 (신규 Access Token 및 현재 매니저의 Role 획득)
+        // 서비스단 호출 (신규 Access Token 및 현재 매니저의 Role 획득)
         AdminAuthTokenResponse tokenResponse = managerAuthUseCase.refreshAccessToken(loginId, refreshToken);
 
-        // 2. 새 Access Token을 쿠키에 설정
-        ResponseCookie accessCookie = ResponseCookie.from("accessToken", tokenResponse.accessToken())
+        // 새 Access Token 쿠키 설정
+        ResponseCookie accessCookie = ResponseCookie.from("adminAccessToken", tokenResponse.accessToken())
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(30 * 60) // 30분
+                .maxAge(30 * 60)
                 .sameSite("None")
                 .build();
 
@@ -154,7 +157,7 @@ public class ManagerAuthController {
 
         log.info("[Manager Refresh] 관리자 토큰 및 권한 재발급 완료 - ID: {}", loginId);
 
-        // 3. 로그인 성공 응답과 일치하게 JSON 바디에 최신 role 값을 담아 응답 처리 🌟
+        // 로그인과 동일하게 Role 반환
         AdminLoginResponse responseBody = new AdminLoginResponse(tokenResponse.role());
         return ApiResponse.success("MANAGER_REFRESH_SUCCESS", "관리자 토큰이 성공적으로 재발급되었습니다.", responseBody);
     }

--- a/src/main/java/com/kidmily/algoga_server/global/infrastructure/s3/S3StorageAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/global/infrastructure/s3/S3StorageAdapter.java
@@ -79,4 +79,20 @@ public class S3StorageAdapter implements FileStoragePort {
             log.error("[S3 Delete Error] 파일 삭제 중 오류 발생: {}", e.getMessage());
         }
     }
+
+    @Override
+    public String uploadFileAsync(java.io.File file, String bucketName, String targetS3Key) {
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(targetS3Key)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
+            return endpoint + "/" + bucketName + "/" + targetS3Key;
+        } catch (Exception e) {
+            log.error("[S3 Async Upload Error] 비동기 파일 업로드 실패: {}", e.getMessage(), e);
+            throw new BusinessException(GlobalErrorCode.SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/global/port/out/FileStoragePort.java
+++ b/src/main/java/com/kidmily/algoga_server/global/port/out/FileStoragePort.java
@@ -12,4 +12,5 @@ public interface FileStoragePort {
     String uploadFile(MultipartFile file, String bucketName, String directory);
 
     void deleteFile(String bucketName, String fileUrl);
+    String uploadFileAsync(java.io.File file, String bucketName, String targetS3Key);
 }

--- a/src/main/java/com/kidmily/algoga_server/global/security/GlobalJwtAuthenticationFilter.java
+++ b/src/main/java/com/kidmily/algoga_server/global/security/GlobalJwtAuthenticationFilter.java
@@ -29,13 +29,12 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final GlobalJwtProvider globalJwtProvider;
     private final CustomUserDetailsService customUserDetailsService;
-    private final RedisTemplate<String, String> redisTemplate; // 🌟 블랙리스트 검증용 Redis 추가
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 🌟 여기서부터 try 블록 시작!
         try {
             String token = resolveToken(request);
 
@@ -43,7 +42,6 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
                 String type = globalJwtProvider.getType(token);
 
                 if ("ADMIN".equals(type)) {
-                    // ... 기존 ADMIN 로직 그대로 유지 ...
                     Long id = globalJwtProvider.getAdminId(token);
                     String loginId = globalJwtProvider.getSubject(token);
                     String role = globalJwtProvider.getAdminRole(token);
@@ -56,17 +54,16 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
 
                 } else if ("USER".equals(type)) {
-                    // ... 기존 USER 로직 그대로 유지 ...
                     String email = globalJwtProvider.getSubject(token);
 
-                    // 블랙리스트 등록된 유저인지 Redis 검증 (Access Token 무효화)
+                    // 블랙리스트 검증 로직
                     String isBlacklisted = redisTemplate.opsForValue().get("BLACKLIST:" + email);
                     if ("true".equals(isBlacklisted)) {
                         log.warn("블랙리스트 유저의 비정상적 API 접근 시도 차단: {}", email);
                         response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
                         response.setContentType("application/json;charset=UTF-8");
                         response.getWriter().write("{\"code\":\"AUTH_015\",\"message\":\"블랙리스트에 등록되어 접근이 영구히 제한된 계정입니다. 고객센터에 문의하세요.\"}");
-                        return; // 🌟 중단!
+                        return;
                     }
 
                     CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
@@ -78,41 +75,56 @@ public class GlobalJwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             }
-            // 🌟 여기서부터 에러를 낚아채서 프론트로 예외 응답을 쏴줍니다!
         } catch (ExpiredJwtException e) {
             log.warn("토큰 만료 에러 발생: {}", e.getMessage());
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 에러
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
             response.setContentType("application/json;charset=UTF-8");
             response.getWriter().write("{\"code\":\"AUTH_EXPIRED\",\"message\":\"토큰이 만료되었습니다. 다시 로그인해주세요.\"}");
-            return; // 🌟 필터 통과 못하게 막음
+            return;
 
         } catch (JwtException | IllegalArgumentException e) {
             log.warn("유효하지 않은 토큰 에러 발생: {}", e.getMessage());
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 에러
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
             response.setContentType("application/json;charset=UTF-8");
             response.getWriter().write("{\"code\":\"AUTH_INVALID\",\"message\":\"유효하지 않은 토큰입니다.\"}");
-            return; // 🌟 필터 통과 못하게 막음
+            return;
 
         } catch (Exception e) {
             log.error("JWT 인증 처리 중 서버 에러 발생: {}", e.getMessage(), e);
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR); // 500 에러
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR); // 500
             response.setContentType("application/json;charset=UTF-8");
             response.getWriter().write("{\"code\":\"SYS_ERROR\",\"message\":\"인증 처리 중 서버 에러가 발생했습니다.\"}");
-            return; // 🌟 필터 통과 못하게 막음
+            return;
         }
 
         filterChain.doFilter(request, response);
     }
 
-    // 🌟 헤더 대신 쿠키에서 accessToken을 찾도록 수정
+    // 🌟 핵심 변경 포인트: API 요청 경로에 따라 읽어올 쿠키 이름을 동적으로 결정합니다.
     private String resolveToken(HttpServletRequest request) {
-        if (request.getCookies() != null) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+
+        String requestURI = request.getRequestURI();
+
+        // 1. 관리자(Admin) 전용 API 요청인 경우 -> 'adminAccessToken' 쿠키 탐색
+        if (requestURI.contains("/admin")) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("adminAccessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        // 2. 그 외 일반 유저 API 요청인 경우 -> 'accessToken' 쿠키 탐색
+        else {
             for (Cookie cookie : request.getCookies()) {
                 if ("accessToken".equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }
         }
+
         return null;
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/global/upload/async/AsyncFileEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/global/upload/async/AsyncFileEventListener.java
@@ -1,0 +1,54 @@
+package com.kidmily.algoga_server.global.upload.async;
+
+import com.kidmily.algoga_server.global.port.out.FileStoragePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AsyncFileEventListener {
+
+    private final FileStoragePort fileStoragePort;
+    private final RedisTemplate<String, String> redisTemplate;
+    
+    private static final String CANCEL_PREFIX = "CANCEL_UPLOAD:";
+
+    @Async("taskExecutor")
+    @EventListener
+    public void handlePreUpload(FilePreUploadEvent event) {
+        File tempFile = new File(event.tempFilePath());
+        try {
+            if (isCanceled(event.trackingId())) return;
+
+            String uploadedUrl = fileStoragePort.uploadFileAsync(tempFile, event.bucketName(), event.targetS3Key());
+
+            if (isCanceled(event.trackingId())) {
+                fileStoragePort.deleteFile(event.bucketName(), uploadedUrl);
+            }
+        } finally {
+            if (tempFile.exists()) tempFile.delete();
+        }
+    }
+
+    @Async("taskExecutor")
+    @EventListener
+    public void handleCancel(FileCancelEvent event) {
+        redisTemplate.opsForValue().set(CANCEL_PREFIX + event.trackingId(), "true", Duration.ofHours(1));
+        
+        if (event.fileUrl() != null && !event.fileUrl().isBlank()) {
+            fileStoragePort.deleteFile(event.bucketName(), event.fileUrl());
+        }
+    }
+
+    private boolean isCanceled(String trackingId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(CANCEL_PREFIX + trackingId));
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/global/upload/async/AsyncFilePreUploadService.java
+++ b/src/main/java/com/kidmily/algoga_server/global/upload/async/AsyncFilePreUploadService.java
@@ -1,0 +1,60 @@
+package com.kidmily.algoga_server.global.upload.async;
+
+import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.global.exception.GlobalErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncFilePreUploadService {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Value("${app.file.upload-root:uploads}")
+    private String tempDirPath;
+    
+    @Value("${cloud.aws.s3.endpoint}")
+    private String s3Endpoint;
+
+    public String startPreUpload(MultipartFile multipartFile, String bucketName, String directory, String trackingId) {
+        String extension = getExtension(multipartFile.getOriginalFilename());
+        String targetS3Key = directory + "/" + trackingId + extension;
+        String expectedUrl = s3Endpoint + "/" + bucketName + "/" + targetS3Key;
+
+        File tempFile = saveToLocalTemp(multipartFile, trackingId + extension);
+
+        eventPublisher.publishEvent(new FilePreUploadEvent(
+                tempFile.getAbsolutePath(), bucketName, targetS3Key, trackingId
+        ));
+
+        return expectedUrl;
+    }
+
+    public void cancelPreUpload(String bucketName, String trackingId, String fileUrl) {
+        eventPublisher.publishEvent(new FileCancelEvent(bucketName, trackingId, fileUrl));
+    }
+
+    private File saveToLocalTemp(MultipartFile multipartFile, String fileName) {
+        File dir = new File(tempDirPath);
+        if (!dir.exists()) dir.mkdirs();
+
+        File tempFile = new File(dir, fileName);
+        try {
+            multipartFile.transferTo(tempFile);
+            return tempFile;
+        } catch (IOException e) {
+            throw new BusinessException(GlobalErrorCode.SERVER_ERROR);
+        }
+    }
+
+    private String getExtension(String filename) {
+        return (filename != null && filename.contains(".")) ? filename.substring(filename.lastIndexOf(".")) : "";
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/global/upload/async/FileCancelEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/global/upload/async/FileCancelEvent.java
@@ -1,0 +1,7 @@
+package com.kidmily.algoga_server.global.upload.async;
+
+public record FileCancelEvent(
+        String bucketName,
+        String trackingId,
+        String fileUrl
+) {}

--- a/src/main/java/com/kidmily/algoga_server/global/upload/async/FilePreUploadEvent.java
+++ b/src/main/java/com/kidmily/algoga_server/global/upload/async/FilePreUploadEvent.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.global.upload.async;
+
+public record FilePreUploadEvent(
+        String tempFilePath,
+        String bucketName,
+        String targetS3Key,
+        String trackingId
+) {}


### PR DESCRIPTION
[FIX] 파일 업로드 async event 로 빼고 만약 수정하다 취소하면 업로드 중지 로직 추가 + adminAccesT…

## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->

adminAccessToken 추가
s3 연동 파일 업로드 먼저 실행하다 취소되면 취소 하는 공통 로직 추가 (devops 에 추가예정)
## 🔗 Issue
Closes #316 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] adminAccessToken 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자 인증에 어드민 전용 쿠키 적용 (accessToken과 분리)
  * 토큰 블랙리스트 검증으로 로그아웃 후 기존 토큰 무효화
  * 비동기 파일 업로드 및 취소 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->