### PR TITLE
Feature/강의결제 캐시 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ logs/
 # 비밀번호가 포함된 설정 파일은 깃허브에 업로드 금지
 application-secret.yml
 
+# MCP 설정 (DB 접속 비밀번호 포함) — 로컬 전용, 깃 업로드 금지
+.mcp.json
+
 # 모니터링 비밀값 (Slack Webhook 등)
 .env
 monitoring/.env

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentTransactionService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentTransactionService.java
@@ -24,6 +24,8 @@ import com.kidmily.algoga_server.user.domain.UserRepository;
 import com.kidmily.algoga_server.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
@@ -54,6 +56,7 @@ public class PaymentTransactionService {
     private final CourseRepository courseRepository;
     private final UserCouponRepository userCouponRepository;
     private final MileageHistoryRepository mileageHistoryRepository;
+    private final CacheManager cacheManager;
 
     @Caching(evict = {
             @CacheEvict(value = "myPayments", key = "#command.userId()"),
@@ -271,6 +274,21 @@ public class PaymentTransactionService {
                 payment.markSuccess(portonePaymentId);
                 payment.updatePaymentMethod(paymentMethod);
                 paymentRepository.save(payment);
+
+                // 웹훅으로 결제 확정 시에도 결제 목록/통계 캐시를 무효화한다.
+                // 웹훅은 PortOne이 호출하는 경로라 userId 파라미터가 없어 @CacheEvict(key=...)를 쓸 수 없으므로,
+                // 저장된 payment 엔티티의 userId 로 CacheManager 를 통해 직접 evict 한다.
+                Long cacheUserId = payment.getUserId();
+                if (cacheUserId != null) {
+                    Cache myPaymentsCache = cacheManager.getCache("myPayments");
+                    if (myPaymentsCache != null) {
+                        myPaymentsCache.evict(cacheUserId);
+                    }
+                }
+                Cache adminStatsCache = cacheManager.getCache("adminPaymentStats");
+                if (adminStatsCache != null) {
+                    adminStatsCache.evict("all");
+                }
 
                 if (payment.getBookingId() != null) {
                     BookingStatus newBookingStatus = resolveBookingStatus(payment.getPaymentType());

--- a/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentTransactionService.java
+++ b/src/main/java/com/kidmily/algoga_server/payment/application/service/PaymentTransactionService.java
@@ -163,6 +163,10 @@ public class PaymentTransactionService {
         return saved.getId();
     }
 
+    @Caching(evict = {
+            @CacheEvict(value = "myPayments", key = "#command.userId()"),
+            @CacheEvict(value = "adminPaymentStats", key = "'all'")
+    })
     @Transactional
     public Long saveLecturePayment(CreateLecturePaymentCommand command, String portoneStatus, int paidAmount, String paymentMethod) {
         courseRepository.findByIdAndDeletedFalse(command.courseId())


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성

PaymentTransactionService`의 캐시 무효화 누락 버그 2건 수정.

- **강의 단독결제 (`saveLecturePayment`)**: 결제 성공 후 `myPayments`/`adminPaymentStats` 캐시가
  무효화되지 않아, 내 결제 목록에 새 강의 결제가 최대 5분(TTL)간 안 뜨던 버그.
  `savePayment`와 동일한 `@Caching(evict=...)` 추가.
- **웹훅 (`processWebhook`)**: PortOne 웹훅으로 결제 확정 시에도 동일하게 캐시 미갱신.
  웹훅엔 userId 파라미터가 없어 `@CacheEvict(key=)`를 못 써서,
  저장된 payment의 `getUserId()`로 `CacheManager`를 통해 직접 evict.


## 🔗 Issue
Closes #

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
[ ] 강의 단독결제 성공 후 내 결제 목록에 즉시 반영되는지
- [ ] 웹훅 결제 확정 후 myPayments/adminPaymentStats 캐시 갱신되는지
- [x] `./gradlew compileJava` 통과 (확인 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 결제 시스템의 캐시 무효화 로직을 강화하여, 웹훅을 통한 결제 완료 처리 시에도 결제 정보가 실시간으로 정확하게 반영되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->