### PR TITLE
캘린더, 커뮤니티, 알림 삭제 정책 적용

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/application/listener/CalendarEventListener.java
@@ -5,6 +5,7 @@ import com.kidmily.algoga_server.calendar.application.policy.CalendarSchedulePol
 import com.kidmily.algoga_server.calendar.domain.model.Calendar;
 import com.kidmily.algoga_server.calendar.domain.model.CalendarType;
 import com.kidmily.algoga_server.calendar.domain.repository.CalendarRepository;
+import com.kidmily.algoga_server.global.event.UserWithdrawnEvent;
 import com.kidmily.algoga_server.payment.domain.event.PackagePaymentCompletedEvent;
 import com.kidmily.algoga_server.payment.domain.event.PaymentCompletedEvent;
 import com.kidmily.algoga_server.refund.domain.event.RefundApprovedEvent;
@@ -156,6 +157,21 @@ public class CalendarEventListener {
         } catch (Exception e) {
             log.error("[CalendarEventListener] 환불 반영 중 캘린더 처리 실패! - userId: {}, error: {}",
                     event.userId(), e.getMessage(), e);
+        }
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserWithdrawnEvent(UserWithdrawnEvent event) {
+        Long withdrawnUserId = event.userId();
+        log.info("[Calendar] 유저 탈퇴 이벤트 수신 - userId: {}", withdrawnUserId);
+
+        try {
+            calendarRepository.deleteAllByUserId(withdrawnUserId);
+            log.info("[Calendar] 유저({}) 캘린더 데이터 삭제 완료", withdrawnUserId);
+        } catch (Exception e) {
+            log.error("[Calendar] 유저 탈퇴 캘린더 삭제 중 오류: {}", e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/domain/repository/CalendarRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/domain/repository/CalendarRepository.java
@@ -13,4 +13,5 @@ public interface CalendarRepository {
     void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type);
     List<Calendar> findByType(CalendarType type);
     Calendar update(Calendar calendar);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/CalendarRepositoryAdapter.java
@@ -56,4 +56,9 @@ public class CalendarRepositoryAdapter implements CalendarRepository {
         entity.updateDDayAlertSent(calendar.getIsDDayAlertSent());
         return calendarMapper.toDomain(springDataRepository.save(entity));
     }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        springDataRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/repository/SpringDataCalendarRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/persistence/repository/SpringDataCalendarRepository.java
@@ -14,4 +14,5 @@ public interface SpringDataCalendarRepository extends JpaRepository<CalendarJpaE
     void deleteByReferenceId(Long referenceId);
     void deleteByUserIdAndReferenceIdAndType(Long userId, Long referenceId, CalendarType type);
     List<CalendarJpaEntity> findByType(CalendarType type);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/application/CommunityCleanupScheduler.java
+++ b/src/main/java/com/kidmily/algoga_server/community/application/CommunityCleanupScheduler.java
@@ -1,0 +1,38 @@
+package com.kidmily.algoga_server.community.application;
+
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataCommentRepository;
+import com.kidmily.algoga_server.community.infrastructure.persistence.repository.SpringDataPostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommunityCleanupScheduler {
+
+    private final SpringDataPostRepository postRepository;
+    private final SpringDataCommentRepository commentRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void cleanUpExpiredPosts() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(14);
+
+        var expiredPosts = postRepository.findByIsDeletedTrueAndDeletedAtBefore(threshold);
+        if (!expiredPosts.isEmpty()) {
+            postRepository.deleteAll(expiredPosts);
+            log.info("[배치 작업] 14일 경과한 삭제 게시글 {}건 영구 삭제 완료", expiredPosts.size());
+        }
+
+        var expiredComments = commentRepository.findByIsDeletedTrueAndDeletedAtBefore(threshold);
+        if (!expiredComments.isEmpty()) {
+            commentRepository.deleteAll(expiredComments);
+            log.info("[배치 작업] 14일 경과한 삭제 댓글 {}건 영구 삭제 완료", expiredComments.size());
+        }
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Comment.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Comment.java
@@ -14,11 +14,12 @@ public class Comment {
     private String content;
     private boolean deleted;
     private final LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
 
     // 신규 생성용
     public static Comment create(Long postId, Long userId, Long parentId, String content) {
         validate(content);
-        return new Comment(null, postId, userId, parentId, content, false, null);
+        return new Comment(null, postId, userId, parentId, content, false, null, null);
     }
 
     public void updateContent(Long requesterId, String newContent) {
@@ -30,6 +31,7 @@ public class Comment {
     public void delete(Long requesterId) {
         validateOwnerForDelete(requesterId);
         this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
     private void validateOwnerForUpdate(Long requesterId) {
@@ -47,8 +49,8 @@ public class Comment {
     // DB 복원용
     public static Comment reconstitute(Long commentId, Long postId, Long userId,
                                        Long parentId, String content,
-                                       boolean deleted, LocalDateTime createdAt) {
-        return new Comment(commentId, postId, userId, parentId, content, deleted, createdAt);
+                                       boolean deleted, LocalDateTime createdAt, LocalDateTime deletedAt) {
+        return new Comment(commentId, postId, userId, parentId, content, deleted, createdAt, deletedAt);
     }
 
     private static void validate(String content) {
@@ -61,7 +63,7 @@ public class Comment {
     }
 
     private Comment(Long commentId, Long postId, Long userId, Long parentId,
-                    String content, boolean deleted, LocalDateTime createdAt) {
+                    String content, boolean deleted, LocalDateTime createdAt, LocalDateTime deletedAt) {
         this.commentId = commentId;
         this.postId = postId;
         this.userId = userId;
@@ -69,6 +71,7 @@ public class Comment {
         this.content = content;
         this.deleted = deleted;
         this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
     }
 
     public Long getCommentId() { return commentId; }
@@ -97,5 +100,6 @@ public class Comment {
     // 관리자에 의한 댓글 삭제 (작성자 권한 검증 없음)
     public void deleteByAdmin() {
         this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/model/Post.java
@@ -28,6 +28,7 @@ public class Post {
     private LocalDateTime createdAt;
     private Boolean isDeleted;
     private Integer viewCount;
+    private LocalDateTime deletedAt;
 
     // 1. 생성 시점의 생성자
     private Post(Long authorId, PostTagType category, String title, String content,
@@ -52,7 +53,7 @@ public class Post {
     // DB 조회 후 재구성용 생성자
     private Post(Long id, Long authorId, PostTagType category, String title, String content,
                  Long countryId, Long lectureId, List<String> freeTags, List<String> imageUrls,
-                 LocalDateTime createdAt, Integer viewCount, Boolean isDeleted) {
+                 LocalDateTime createdAt, Integer viewCount, Boolean isDeleted, LocalDateTime deletedAt) {
         this.id = id;
         this.authorId = authorId;
         this.category = category;
@@ -65,6 +66,7 @@ public class Post {
         this.createdAt = createdAt;
         this.viewCount = viewCount;
         this.isDeleted = isDeleted;
+        this.deletedAt = deletedAt;
     }
 
     // 2. 정적 팩토리 메서드
@@ -119,14 +121,15 @@ public class Post {
     public void delete(Long requesterId) {
         validateOwnerForDelete(requesterId);
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
 
     public static Post reconstitute(Long id, Long authorId, PostTagType category, String title, String content,
                                     Long countryId, Long lectureId, List<String> freeTags, List<String> imageUrls,
-                                    LocalDateTime createdAt, Integer viewCount, Boolean isDeleted) {
+                                    LocalDateTime createdAt, Integer viewCount, Boolean isDeleted, LocalDateTime deletedAt) {
         return new Post(id, authorId, category, title, content, countryId, lectureId,
-                freeTags, imageUrls, createdAt, viewCount, isDeleted);
+                freeTags, imageUrls, createdAt, viewCount, isDeleted, deletedAt);
     }
 
     // 3. 도메인 규칙 검증 메서드 (상단 import에 맞게 BusinessException으로 일관성 유지)
@@ -175,5 +178,6 @@ public class Post {
     // 관리자에 의한 게시글 삭제 (작성자 권한 검증 없음)
     public void deleteByAdmin() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/CommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.community.domain.repository;
 
 import com.kidmily.algoga_server.community.domain.model.Comment;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +17,5 @@ public interface CommentRepository {
     void softDeleteAll(List<Comment> comments);
     List<Comment> findMyCommentsByPage(Long userId, int page, int size);
     long countMyComments(Long userId);
+    List<Comment> findExpiredDeletedComments(LocalDateTime threshold);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/domain/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.kidmily.algoga_server.community.domain.repository;
 import com.kidmily.algoga_server.community.domain.model.Post;
 import com.kidmily.algoga_server.community.domain.model.PostTagType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,4 +24,6 @@ public interface PostRepository {
 
     // 신규: 인기 나라 태그 (게시글 수 상위 N개)
     List<CountryTagCount> findTopCountryTags(int limit);
+
+    List<Post> findExpiredDeletedPosts(LocalDateTime threshold);
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/CommentMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/CommentMapper.java
@@ -31,7 +31,8 @@ public interface CommentMapper {
                 jpaEntity.getParentId(),
                 jpaEntity.getContent(),
                 jpaEntity.getIsDeleted(),
-                jpaEntity.getCreatedAt()
+                jpaEntity.getCreatedAt(),
+                jpaEntity.getDeletedAt()
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/PostMapper.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/mapper/PostMapper.java
@@ -94,7 +94,8 @@ public interface PostMapper {
                 imageUrls,
                 jpaEntity.getCreatedAt(),
                 jpaEntity.getViewCount(),
-                jpaEntity.getIsDeleted()
+                jpaEntity.getIsDeleted(),
+                jpaEntity.getDeletedAt()
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/CommentRepositoryAdapter.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,5 +97,13 @@ public class CommentRepositoryAdapter implements CommentRepository {
     @Override
     public long countMyComments(Long userId) {
         return springDataRepository.countMyComments(userId);
+    }
+
+    @Override
+    public List<Comment> findExpiredDeletedComments(LocalDateTime threshold) {
+        return springDataRepository.findByIsDeletedTrueAndDeletedAtBefore(threshold)
+                .stream()
+                .map(commentMapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/PostRepositoryAdapter.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -157,5 +158,13 @@ public class PostRepositoryAdapter implements PostRepository {
     public long countMyPosts(Long userId, List<PostTagType> categories) {
         List<PostTagType> categoriesParam = (categories == null || categories.isEmpty()) ? null : categories;
         return springDataRepository.countMyPosts(userId, categoriesParam);
+    }
+
+    @Override
+    public List<Post> findExpiredDeletedPosts(LocalDateTime threshold) {
+        return springDataRepository.findByIsDeletedTrueAndDeletedAtBefore(threshold)
+                .stream()
+                .map(postMapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/UserPortAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/UserPortAdapter.java
@@ -15,13 +15,14 @@ public class UserPortAdapter implements UserPort {
     @Override
     public String getNickname(Long userId) {
         return userRepository.findById(userId)
-                .map(User::getNickname)
-                .orElse("알 수 없음");
+                .map(user -> user.isDeleted() ? "탈퇴한 사용자" : user.getNickname())
+                .orElse("탈퇴한 사용자");  // 하드딜리트된 경우도 동일하게
     }
 
     @Override
     public String getProfileImageUrl(Long userId) {
         return userRepository.findById(userId)
+                .filter(user -> !user.isDeleted())
                 .map(User::getProfileImageUrl)
                 .orElse(null);
     }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/CommentJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/CommentJpaEntity.java
@@ -34,6 +34,9 @@ public class CommentJpaEntity {
     @Builder.Default
     private Boolean isDeleted = false;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
@@ -53,6 +56,7 @@ public class CommentJpaEntity {
 
     public void softDelete() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void updateContent(String content) {

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/entity/PostJpaEntity.java
@@ -50,6 +50,9 @@ public class PostJpaEntity {
     @Builder.Default
     private Boolean isDeleted = false;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
@@ -87,6 +90,7 @@ public class PostJpaEntity {
 
     public void softDelete() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataCommentRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataCommentRepository.java
@@ -6,12 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SpringDataCommentRepository extends JpaRepository<CommentJpaEntity, Long> {
     List<CommentJpaEntity> findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId);
     List<CommentJpaEntity> findByParentIdAndIsDeletedFalse(Long parentId);
     List<CommentJpaEntity> findByPostId(Long postId); // 삭제 여부 상관없이 전체 조회
+    List<CommentJpaEntity> findByIsDeletedTrueAndDeletedAtBefore(LocalDateTime threshold);
     @Query("SELECT c FROM CommentJpaEntity c WHERE c.userId = :userId AND c.isDeleted = false ORDER BY c.commentId DESC")
     List<CommentJpaEntity> findMyCommentsByPage(@Param("userId") Long userId, Pageable pageable);
 

--- a/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/community/infrastructure/persistence/repository/SpringDataPostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SpringDataPostRepository extends JpaRepository<PostJpaEntity, Long> {
@@ -71,4 +72,6 @@ public interface SpringDataPostRepository extends JpaRepository<PostJpaEntity, L
     long countMyPosts(
             @Param("authorId") Long authorId,
             @Param("categories") List<PostTagType> categories);
+
+    List<PostJpaEntity> findByIsDeletedTrueAndDeletedAtBefore(LocalDateTime threshold);
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/application/listener/NotificationEventListener.java
@@ -1,6 +1,7 @@
 package com.kidmily.algoga_server.notification.application.listener;
 
 import com.kidmily.algoga_server.calendar.application.port.AccommodationPort;
+import com.kidmily.algoga_server.global.event.UserWithdrawnEvent;
 import com.kidmily.algoga_server.notification.application.port.CoursePort;
 import com.kidmily.algoga_server.notification.domain.event.NotificationEvent;
 import com.kidmily.algoga_server.notification.domain.model.Notification;
@@ -159,6 +160,22 @@ public class NotificationEventListener {
 
         notificationRepository.save(notification);
         log.info("[NotificationEventListener] 환불 거절 알림 저장 완료 - userId: {}", event.userId());
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserWithdrawnEvent(UserWithdrawnEvent event) {
+        Long withdrawnUserId = event.userId();
+        log.info("[Notification] 유저 탈퇴 이벤트 수신 - userId: {}", withdrawnUserId);
+
+        try {
+            notificationRepository.deleteAllByUserId(withdrawnUserId);
+            notificationSettingRepository.deleteByUserId(withdrawnUserId);
+            log.info("[Notification] 유저({}) 알림 데이터 삭제 완료", withdrawnUserId);
+        } catch (Exception e) {
+            log.error("[Notification] 유저 탈퇴 알림 삭제 중 오류: {}", e.getMessage(), e);
+        }
     }
 
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/domain/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/domain/repository/NotificationSettingRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 public interface NotificationSettingRepository {
     NotificationSetting save(NotificationSetting setting);
     Optional<NotificationSetting> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/infrastructure/persistence/NotificationSettingRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/infrastructure/persistence/NotificationSettingRepositoryAdapter.java
@@ -28,4 +28,9 @@ public class NotificationSettingRepositoryAdapter implements NotificationSetting
         return springDataRepository.findById(userId)
                 .map(notificationSettingMapper::toDomain);
     }
+
+    @Override
+    public void deleteByUserId(Long userId) {
+        springDataRepository.deleteByUserId(userId);
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/infrastructure/persistence/SpringDataNotificationRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/infrastructure/persistence/SpringDataNotificationRepository.java
@@ -23,4 +23,6 @@ public interface SpringDataNotificationRepository extends JpaRepository<Notifica
     @Modifying
     @Query("DELETE FROM NotificationJpaEntity n WHERE n.userId = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
+
+
 }

--- a/src/main/java/com/kidmily/algoga_server/notification/infrastructure/persistence/SpringDataNotificationSettingRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/notification/infrastructure/persistence/SpringDataNotificationSettingRepository.java
@@ -4,4 +4,6 @@ import com.kidmily.algoga_server.notification.infrastructure.persistence.entity.
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SpringDataNotificationSettingRepository extends JpaRepository<NotificationSettingJpaEntity, Long> {
+    void deleteByUserId(Long userId);
+
 }


### PR DESCRIPTION
## 설명
유저 탈퇴 및 게시글/댓글 삭제에 대한 데이터 정리 정책을 구현했습니다.

탈퇴 유저 작성 게시글/댓글 닉네임 → "탈퇴한 사용자" 표시, 프로필 이미지 → null 처리
게시글/댓글 삭제 시 소프트딜리트(deletedAt 기록) → 14일 후 스케줄러가 하드딜리트
유저 탈퇴(소프트딜리트) 시점에 캘린더 데이터 즉시 하드딜리트
유저 탈퇴(소프트딜리트) 시점에 알림 내역 및 알림 설정 즉시 하드딜리트

## 🔗 Issue
Closes #329

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 탈퇴한 유저의 게시글/댓글 조회 시 닉네임이 "탈퇴한 사용자"로 표시되는지 확인
- [ ] 탈퇴한 유저의 게시글/댓글 조회 시 프로필 이미지가 비어있는지 확인
- [ ] 게시글/댓글 삭제 후 DB에 is_deleted=true, deleted_at 값이 기록되는지 확인
- [ ] CommunityCleanupScheduler 실행 시 14일 경과한 게시글/댓글이 DB에서 삭제되는지 확인
- [ ] 유저 탈퇴 API 호출 후 해당 유저의 캘린더 데이터가 즉시 삭제되는지 확인
- [ ] 유저 탈퇴 API 호출 후 해당 유저의 알림 내역 및 알림 설정이 즉시 삭제되는지 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 탈퇴 시 관련 캘린더, 알림 데이터가 자동으로 정리됩니다.
  * 14일 이상 전에 삭제된 게시글과 댓글이 자동으로 영구 삭제되는 정리 기능이 추가되었습니다.
  * 탈퇴한 사용자의 닉네임이 "탈퇴한 사용자"로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->