### PR TITLE
[FIX] 공지사항 조회 3-> 5개로 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/notice/application/service/NoticeQueryService.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/application/service/NoticeQueryService.java
@@ -36,7 +36,7 @@ public class    NoticeQueryService implements NoticeQueryUseCase {
 
     @Override
     public List<NoticeMainResponse> getNoticeMain() {
-        return noticeRepository.findTop3Notices().stream()
+        return noticeRepository.findTop5Notices().stream()
                 .map(notice -> new NoticeMainResponse(
                         notice.getNoticeId(),
                         notice.getType(),

--- a/src/main/java/com/kidmily/algoga_server/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/domain/repository/NoticeRepository.java
@@ -12,7 +12,7 @@ public interface NoticeRepository {
     Optional<Notice> findById(Long noticeId);
     void deleteById(Long noticeId);
 
-    List<Notice> findTop3Notices();
+    List<Notice> findTop5Notices();
     
     // 🌟 List 대신 Page 반환
     Page<Notice> findAll(int page, int size);

--- a/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/NoticeRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/NoticeRepositoryAdapter.java
@@ -40,8 +40,8 @@ public class NoticeRepositoryAdapter implements NoticeRepository {
     }
 
     @Override
-    public List<Notice> findTop3Notices() {
-        return jpaNoticeRepository.findTop3ByOrderByCreatedAtDesc().stream()
+    public List<Notice> findTop5Notices() {
+        return jpaNoticeRepository.findTop5ByOrderByCreatedAtDesc().stream()
                 .map(noticeMapper::toDomain)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/repository/JpaNoticeRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/infrastructure/persistence/repository/JpaNoticeRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface JpaNoticeRepository extends JpaRepository<NoticeEntity, Long> {
-    List<NoticeEntity> findTop3ByOrderByCreatedAtDesc();
+    List<NoticeEntity> findTop5ByOrderByCreatedAtDesc();
     
     // 🌟 List 대신 Page 로 반환 타입 변경
     Page<NoticeEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/com/kidmily/algoga_server/notice/presentation/api/PublicNoticeController.java
+++ b/src/main/java/com/kidmily/algoga_server/notice/presentation/api/PublicNoticeController.java
@@ -26,7 +26,7 @@ public class PublicNoticeController {
     private final NoticeQueryUseCase noticeQueryUseCase;
 
     @GetMapping("/main")
-    @Operation(summary = "공지사항 메인 조회", description = "메인 페이지에 노출되는 최신 공지사항 3개를 조회합니다.")
+    @Operation(summary = "공지사항 메인 조회", description = "메인 페이지에 노출되는 최신 공지사항 5개를 조회합니다.")
     public ResponseEntity<ApiResponse<List<NoticeMainResponse>>> getNoticeMain() {
         return ResponseEntity.ok(ApiResponse.success(
                 "NOTICE_MAIN_FOUND", "메인 공지사항 조회에 성공했습니다.", noticeQueryUseCase.getNoticeMain()


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
공지사항 조회 3-> 5개로 수정

GET
/api/v1/public/notices/main

## 🔗 Issue
Closes #331 

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [ ] 공지사항 조회 5개로 보이는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 메인 공지사항 목록에서 표시되는 최신 공지 개수가 3개에서 5개로 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->