### PR TITLE
캘린더 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/LecturePortAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/calendar/infrastructure/adapter/LecturePortAdapter.java
@@ -21,11 +21,10 @@ public class LecturePortAdapter implements LecturePort {
 
     @Override
     public String getLectureName(Long lectureId) {
-        return courseRepository.findByIdAndDeletedFalse(lectureId)
+        return courseRepository.findById(lectureId)
                 .map(course -> course.getTitle())
                 .orElse("알 수 없는 강의");
     }
-
     @Override
     public LocalDate getLectureStartDate(Long lectureId, Long userId) {
         return paymentRepository.findByUserId(userId).stream()


### PR DESCRIPTION
## 설명
캘린더 강의 조회 개선 

소프트딜리트된 강의도 캘린더에 강의명이 정상 표시되도록 수정 (findByIdAndDeletedFalse → findById)

## 🔗 Issue
Closes #333

---




## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->
- [x] 소프트딜리트된 강의가 캘린더에 기존 강의명으로 표시되는지 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 강의 제목 조회 시 강의 존재 여부에 기반하여 정보를 반환하도록 개선되었습니다. 이제 존재하는 강의는 제목을, 존재하지 않는 강의는 "알 수 없는 강의"를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->