### PR TITLE
[Feature] 강의 수료 보상 자동 지급 및 실패 재시도 기능 구현

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/benefit/application/command/IssueWelcomeCouponCommand.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/command/IssueWelcomeCouponCommand.java
@@ -1,0 +1,6 @@
+package com.kidmily.algoga_server.benefit.application.command;
+
+public record IssueWelcomeCouponCommand(
+        Long userId
+) {
+}

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/listener/WelcomeCouponEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/listener/WelcomeCouponEventListener.java
@@ -1,10 +1,11 @@
 package com.kidmily.algoga_server.benefit.application.listener;
 
-import com.kidmily.algoga_server.benefit.domain.model.UserCoupon;
-import com.kidmily.algoga_server.benefit.domain.repository.UserCouponRepository;
+import com.kidmily.algoga_server.benefit.application.command.IssueWelcomeCouponCommand;
+import com.kidmily.algoga_server.benefit.application.usecase.WelcomeCouponUseCase;
 import com.kidmily.algoga_server.global.event.UserSignedUpEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -14,22 +15,18 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class WelcomeCouponEventListener {
 
-    private static final String WELCOME_COUPON_NAME = "웰컴쿠폰";
+    private final WelcomeCouponUseCase welcomeCouponUseCase;
 
-    private final UserCouponRepository userCouponRepository;
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    @TransactionalEventListener(
+            phase = TransactionPhase.AFTER_COMMIT,
+            fallbackExecution = true
+    )
     public void issueWelcomeCoupon(UserSignedUpEvent event) {
-        try {
-            if (event.userId() == null
-                    || userCouponRepository.existsByUserIdAndCouponName(event.userId(), WELCOME_COUPON_NAME)) {
-                return;
-            }
+        log.info("[WelcomeCoupon] Signup event received. userId={}", event.userId());
 
-            userCouponRepository.save(UserCoupon.issueWelcome(event.userId()));
-            log.info("[WelcomeCoupon] Issued welcome coupon. userId={}", event.userId());
-        } catch (Exception e) {
-            log.error("[WelcomeCoupon] Failed to issue welcome coupon. userId={}", event.userId(), e);
-        }
+        welcomeCouponUseCase.issueWelcomeCoupon(
+                new IssueWelcomeCouponCommand(event.userId())
+        );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/listener/WelcomeCouponEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/listener/WelcomeCouponEventListener.java
@@ -25,8 +25,13 @@ public class WelcomeCouponEventListener {
     public void issueWelcomeCoupon(UserSignedUpEvent event) {
         log.info("[WelcomeCoupon] Signup event received. userId={}", event.userId());
 
-        welcomeCouponUseCase.issueWelcomeCoupon(
-                new IssueWelcomeCouponCommand(event.userId())
-        );
+        try {
+            welcomeCouponUseCase.issueWelcomeCoupon(
+                    new IssueWelcomeCouponCommand(event.userId())
+            );
+        } catch (Exception exception) {
+            log.error("[WelcomeCoupon] Failed to issue welcome coupon. userId={}",
+                    event.userId(), exception);
+        }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/scheduler/CourseRewardFailureRetryScheduler.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/scheduler/CourseRewardFailureRetryScheduler.java
@@ -13,7 +13,8 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CourseRewardFailureRetryScheduler {
+public
+class CourseRewardFailureRetryScheduler {
 
     private static final int MAX_RETRY_COUNT = 3;
 

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/service/WelcomeCouponService.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/service/WelcomeCouponService.java
@@ -1,0 +1,41 @@
+package com.kidmily.algoga_server.benefit.application.service;
+
+import com.kidmily.algoga_server.benefit.application.command.IssueWelcomeCouponCommand;
+import com.kidmily.algoga_server.benefit.application.usecase.WelcomeCouponUseCase;
+import com.kidmily.algoga_server.benefit.domain.model.UserCoupon;
+import com.kidmily.algoga_server.benefit.domain.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WelcomeCouponService implements WelcomeCouponUseCase {
+
+    private static final String WELCOME_COUPON_NAME = "웰컴쿠폰";
+
+    private final UserCouponRepository userCouponRepository;
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void issueWelcomeCoupon(IssueWelcomeCouponCommand command) {
+        if (command.userId() == null) {
+            return;
+        }
+
+        if (userCouponRepository.existsByUserIdAndCouponName(command.userId(), WELCOME_COUPON_NAME)) {
+            return;
+        }
+
+        UserCoupon savedCoupon = userCouponRepository.save(UserCoupon.issueWelcome(command.userId()));
+
+        log.info(
+                "[WelcomeCoupon] Issued welcome coupon. userId={}, userCouponId={}",
+                command.userId(),
+                savedCoupon.getId()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/service/WelcomeCouponService.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/service/WelcomeCouponService.java
@@ -6,6 +6,7 @@ import com.kidmily.algoga_server.benefit.domain.model.UserCoupon;
 import com.kidmily.algoga_server.benefit.domain.repository.UserCouponRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,15 +28,26 @@ public class WelcomeCouponService implements WelcomeCouponUseCase {
         }
 
         if (userCouponRepository.existsByUserIdAndCouponName(command.userId(), WELCOME_COUPON_NAME)) {
+            log.info("[WelcomeCoupon] Welcome coupon already issued. userId={}", command.userId());
             return;
         }
 
-        UserCoupon savedCoupon = userCouponRepository.save(UserCoupon.issueWelcome(command.userId()));
+        try {
+            UserCoupon savedCoupon = userCouponRepository.save(UserCoupon.issueWelcome(command.userId()));
 
-        log.info(
-                "[WelcomeCoupon] Issued welcome coupon. userId={}, userCouponId={}",
-                command.userId(),
-                savedCoupon.getId()
-        );
+            log.info(
+                    "[WelcomeCoupon] Issued welcome coupon. userId={}, userCouponId={}",
+                    command.userId(),
+                    savedCoupon.getId()
+            );
+        } catch (DataIntegrityViolationException exception) {
+            if (userCouponRepository.existsByUserIdAndCouponName(command.userId(), WELCOME_COUPON_NAME)) {
+                log.info("[WelcomeCoupon] Welcome coupon already issued by concurrent request. userId={}",
+                        command.userId());
+                return;
+            }
+
+            throw exception;
+        }
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/usecase/WelcomeCouponUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/usecase/WelcomeCouponUseCase.java
@@ -1,0 +1,8 @@
+package com.kidmily.algoga_server.benefit.application.usecase;
+
+import com.kidmily.algoga_server.benefit.application.command.IssueWelcomeCouponCommand;
+
+public interface WelcomeCouponUseCase {
+
+    void issueWelcomeCoupon(IssueWelcomeCouponCommand command);
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/port/UserProfilePort.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/port/UserProfilePort.java
@@ -11,7 +11,8 @@ public interface UserProfilePort {
     record UserProfile(
             Long userId,
             String name,
-            String email
+            String email,
+            String nickname
     ) {
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminCourseReviewResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/AdminCourseReviewResult.java
@@ -8,6 +8,7 @@ public record AdminCourseReviewResult(
         Long reviewId,
         Long courseId,
         Long userId,
+        String nickname,
         int rating,
         String content,
         boolean hidden,
@@ -16,10 +17,15 @@ public record AdminCourseReviewResult(
         LocalDateTime updatedAt
 ) {
     public static AdminCourseReviewResult from(CourseReview review) {
+        return from(review, null);
+    }
+
+    public static AdminCourseReviewResult from(CourseReview review, String nickname) {
         return new AdminCourseReviewResult(
                 review.getId(),
                 review.getCourseId(),
                 review.getUserId(),
+                nickname,
                 review.getRating(),
                 review.getContent(),
                 review.isDeleted(),

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaCommentResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaCommentResult.java
@@ -10,16 +10,22 @@ public record CourseQnaCommentResult(
         Long userId,
         Long managerId,
         String writerType,
+        String nickname,
         String content,
         LocalDateTime createdAt
 ) {
     public static CourseQnaCommentResult from(CourseQnaComment comment) {
+        return from(comment, null);
+    }
+
+    public static CourseQnaCommentResult from(CourseQnaComment comment, String nickname) {
         return new CourseQnaCommentResult(
                 comment.getId(),
                 comment.getQnaId(),
                 comment.getUserId(),
                 comment.getManagerId(),
                 comment.getWriterType(),
+                nickname,
                 comment.getContent(),
                 comment.getCreatedAt()
         );

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaDetailResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaDetailResult.java
@@ -7,6 +7,7 @@ public record CourseQnaDetailResult(
         Long qnaId,
         Long courseId,
         Long userId,
+        String nickname,
         Long managerId,
         String title,
         String question,

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseQnaResult.java
@@ -8,6 +8,7 @@ public record CourseQnaResult(
         Long qnaId,
         Long courseId,
         Long userId,
+        String nickname,
         Long managerId,
         String title,
         String question,
@@ -17,10 +18,15 @@ public record CourseQnaResult(
         LocalDateTime answeredAt
 ) {
     public static CourseQnaResult from(CourseQna qna) {
+        return from(qna, null);
+    }
+
+    public static CourseQnaResult from(CourseQna qna, String nickname) {
         return new CourseQnaResult(
                 qna.getId(),
                 qna.getCourseId(),
                 qna.getUserId(),
+                nickname,
                 qna.getManagerId(),
                 qna.getTitle(),
                 qna.getQuestion(),

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseReviewResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseReviewResult.java
@@ -8,16 +8,22 @@ public record CourseReviewResult(
         Long reviewId,
         Long courseId,
         Long userId,
+        String nickname,
         int rating,
         String content,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static CourseReviewResult from(CourseReview review) {
+        return from(review, null);
+    }
+
+    public static CourseReviewResult from(CourseReview review, String nickname) {
         return new CourseReviewResult(
                 review.getId(),
                 review.getCourseId(),
                 review.getUserId(),
+                nickname,
                 review.getRating(),
                 review.getContent(),
                 review.getCreatedAt(),

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/MyCourseResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/MyCourseResult.java
@@ -7,6 +7,7 @@ public record MyCourseResult(
         String title,
         String thumbnailUrl,
         Long countryId,
+        String continentCode,
         String countryName,
         int totalDurationSeconds,
         long studentCount,

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseReviewService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseReviewService.java
@@ -2,6 +2,7 @@ package com.kidmily.algoga_server.lms.application.service;
 
 import com.kidmily.algoga_server.lms.application.command.CreateCourseReviewCommand;
 import com.kidmily.algoga_server.lms.application.command.UpdateCourseReviewVisibilityCommand;
+import com.kidmily.algoga_server.lms.application.port.UserProfilePort;
 import com.kidmily.algoga_server.lms.application.result.AdminCourseReviewResult;
 import com.kidmily.algoga_server.lms.application.result.CourseReviewResult;
 import com.kidmily.algoga_server.lms.application.result.CourseReviewSummaryResult;
@@ -28,6 +29,7 @@ public class CourseReviewService implements CourseReviewUseCase {
     private final CourseRepository courseRepository;
     private final CourseCompletionRepository courseCompletionRepository;
     private final CourseReviewRepository courseReviewRepository;
+    private final UserProfilePort userProfilePort;
 
     @Override
     @Transactional
@@ -60,7 +62,7 @@ public class CourseReviewService implements CourseReviewUseCase {
         log.info("[Course Review Command] 리뷰 등록 완료. reviewId={}, courseId={}, userId={}",
                 savedReview.getId(), savedReview.getCourseId(), savedReview.getUserId());
 
-        return CourseReviewResult.from(savedReview);
+        return toCourseReviewResult(savedReview);
     }
 
     @Override
@@ -75,7 +77,7 @@ public class CourseReviewService implements CourseReviewUseCase {
                 courseId, reviews.size());
 
         return reviews.stream()
-                .map(CourseReviewResult::from)
+                .map(this::toCourseReviewResult)
                 .toList();
     }
 
@@ -124,14 +126,14 @@ public class CourseReviewService implements CourseReviewUseCase {
         validateCourse(courseId);
 
         return courseReviewRepository.findAllByCourseId(courseId).stream()
-                .map(AdminCourseReviewResult::from)
+                .map(this::toAdminCourseReviewResult)
                 .toList();
     }
 
     @Override
     public AdminCourseReviewResult getAdminReview(Long courseId, Long reviewId) {
         validateCourse(courseId);
-        return AdminCourseReviewResult.from(findReview(courseId, reviewId));
+        return toAdminCourseReviewResult(findReview(courseId, reviewId));
     }
 
     @Override
@@ -144,7 +146,7 @@ public class CourseReviewService implements CourseReviewUseCase {
                 ? review.hide()
                 : review.show();
 
-        return AdminCourseReviewResult.from(courseReviewRepository.save(updatedReview));
+        return toAdminCourseReviewResult(courseReviewRepository.save(updatedReview));
     }
 
     @Override
@@ -219,6 +221,19 @@ public class CourseReviewService implements CourseReviewUseCase {
         }
     }
 
+    private CourseReviewResult toCourseReviewResult(CourseReview review) {
+        return CourseReviewResult.from(review, findNickname(review.getUserId()));
+    }
+
+    private AdminCourseReviewResult toAdminCourseReviewResult(CourseReview review) {
+        return AdminCourseReviewResult.from(review, findNickname(review.getUserId()));
+    }
+
+    private String findNickname(Long userId) {
+        return userProfilePort.findProfile(userId)
+                .map(UserProfilePort.UserProfile::nickname)
+                .orElse(null);
+    }
     private CourseReview findReview(Long courseId, Long reviewId) {
         return courseReviewRepository.findByIdAndCourseId(reviewId, courseId)
                 .orElseThrow(() -> new LmsException(LmsErrorCode.REVIEW_NOT_FOUND));

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
@@ -566,7 +566,13 @@ public class CourseService implements CourseUseCase {
                 ? "/api/v1/courses/" + course.getId() + "/certificate"
                 : null;
 
-        String countryName = mapRepository.findActiveCountryById(course.getCountryId())
+        Optional<Country> country = mapRepository.findActiveCountryById(course.getCountryId());
+
+        String continentCode = country
+                .map(Country::getContinentCode)
+                .orElse(null);
+
+        String countryName = country
                 .map(Country::getName)
                 .orElse(null);
 
@@ -575,6 +581,7 @@ public class CourseService implements CourseUseCase {
                 course.getTitle(),
                 course.getThumbnailUrl(),
                 course.getCountryId(),
+                continentCode,
                 countryName,
                 totalDurationSeconds,
                 studentCount,

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
@@ -259,7 +259,7 @@ public class CourseService implements CourseUseCase {
                 command.question()
         );
 
-        return CourseQnaResult.from(courseQnaRepository.save(courseQna));
+        return toCourseQnaResult(courseQnaRepository.save(courseQna));
     }
 
     @Override
@@ -267,7 +267,7 @@ public class CourseService implements CourseUseCase {
     public List<CourseQnaResult> getQnas(Long courseId) {
         findCourse(courseId);
         return courseQnaRepository.findByCourseId(courseId).stream()
-                .map(CourseQnaResult::from)
+                .map(this::toCourseQnaResult)
                 .toList();
     }
 
@@ -283,6 +283,7 @@ public class CourseService implements CourseUseCase {
                 qna.getId(),
                 qna.getCourseId(),
                 qna.getUserId(),
+                findNickname(qna.getUserId()),
                 qna.getManagerId(),
                 qna.getTitle(),
                 qna.getQuestion(),
@@ -290,7 +291,7 @@ public class CourseService implements CourseUseCase {
                 qna.getStatus(),
                 qna.getCreatedAt(),
                 qna.getAnsweredAt(),
-                comments.stream().map(CourseQnaCommentResult::from).toList()
+                comments.stream().map(this::toCourseQnaCommentResult).toList()
         );
     }
 
@@ -305,7 +306,7 @@ public class CourseService implements CourseUseCase {
         }
 
         CourseQna answeredQna = qna.answer(command.managerId(), command.answer());
-        return CourseQnaResult.from(courseQnaRepository.save(answeredQna));
+        return toCourseQnaResult(courseQnaRepository.save(answeredQna));
     }
 
     @Override
@@ -325,7 +326,7 @@ public class CourseService implements CourseUseCase {
                 command.content()
         );
 
-        return CourseQnaCommentResult.from(courseQnaCommentRepository.save(comment));
+        return toCourseQnaCommentResult(courseQnaCommentRepository.save(comment));
     }
 
     @Override
@@ -647,6 +648,24 @@ public class CourseService implements CourseUseCase {
                 .orElse(0.0);
 
         return Math.round(average * 10.0) / 10.0;
+    }
+
+    private CourseQnaResult toCourseQnaResult(CourseQna qna) {
+        return CourseQnaResult.from(qna, findNickname(qna.getUserId()));
+    }
+
+    private CourseQnaCommentResult toCourseQnaCommentResult(CourseQnaComment comment) {
+        String nickname = "USER".equals(comment.getWriterType())
+                ? findNickname(comment.getUserId())
+                : null;
+
+        return CourseQnaCommentResult.from(comment, nickname);
+    }
+
+    private String findNickname(Long userId) {
+        return userProfilePort.findProfile(userId)
+                .map(UserProfilePort.UserProfile::nickname)
+                .orElse(null);
     }
 
     private CourseQna findQna(Long courseId, Long qnaId) {

--- a/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
@@ -44,7 +44,8 @@ public enum LmsErrorCode implements BaseErrorCode {
     INVALID_DIAGNOSIS_ANSWER(HttpStatus.BAD_REQUEST, "LMS_037", "진단평가 답안이 올바르지 않습니다."),
     DIAGNOSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_038", "진단평가 결과를 찾을 수 없습니다."),
     DIAGNOSIS_LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "LMS_039", "진단평가 결과를 저장하려면 로그인이 필요합니다."),
-    INVALID_COURSE_REWARD_MILEAGE(HttpStatus.BAD_REQUEST, "LMS_040", "강의 최대 지급 마일리지는 0 이상이어야 합니다.");
+    INVALID_COURSE_REWARD_MILEAGE(HttpStatus.BAD_REQUEST, "LMS_040", "강의 최대 지급 마일리지는 0 이상이어야 합니다."),
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "LMS_041", "로그인이 필요한 서비스입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/user/UserProfileAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/user/UserProfileAdapter.java
@@ -53,7 +53,8 @@ public class UserProfileAdapter implements UserProfilePort {
         return new UserProfile(
                 (Long) invoke(user, "getId"),
                 (String) invoke(user, "getName"),
-                (String) invoke(user, "getEmail")
+                (String) invoke(user, "getEmail"),
+                (String) invoke(user, "getNickname")
         );
     }
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
@@ -35,7 +35,7 @@ public class MyCourseController {
     public ResponseEntity<ApiResponse<List<MyCourseResponse>>> getMyCourses(
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
 
         List<MyCourseResponse> response = courseUseCase.getMyCourses(currentUserId)
                 .stream()

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseReviewResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseReviewResponse.java
@@ -5,16 +5,36 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "Admin course review response")
+@Schema(description = "관리자 강의 후기 응답")
 public record AdminCourseReviewResponse(
+        @Schema(description = "후기 ID", example = "1")
         Long reviewId,
+
+        @Schema(description = "강의 ID", example = "57")
         Long courseId,
+
+        @Schema(description = "사용자 ID", example = "1")
         Long userId,
+
+        @Schema(description = "작성자 닉네임", example = "알고가유저")
+        String nickname,
+
+        @Schema(description = "평점", example = "5")
         int rating,
+
+        @Schema(description = "후기 내용")
         String content,
+
+        @Schema(description = "숨김 여부", example = "false")
         boolean hidden,
+
+        @Schema(description = "삭제 일시", example = "2026-06-11T18:00:00")
         LocalDateTime deletedAt,
+
+        @Schema(description = "작성 일시", example = "2026-06-11T17:30:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "수정 일시", example = "2026-06-11T18:00:00")
         LocalDateTime updatedAt
 ) {
     public static AdminCourseReviewResponse from(AdminCourseReviewResult review) {
@@ -22,6 +42,7 @@ public record AdminCourseReviewResponse(
                 review.reviewId(),
                 review.courseId(),
                 review.userId(),
+                review.nickname(),
                 review.rating(),
                 review.content(),
                 review.hidden(),

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaCommentResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaCommentResponse.java
@@ -22,6 +22,9 @@ public record CourseQnaCommentResponse(
         @Schema(description = "작성자 타입", example = "USER")
         String writerType,
 
+        @Schema(description = "작성자 닉네임", example = "알고가유저")
+        String nickname,
+
         @Schema(description = "댓글 내용")
         String content,
 
@@ -35,6 +38,7 @@ public record CourseQnaCommentResponse(
                 comment.userId(),
                 comment.managerId(),
                 comment.writerType(),
+                comment.nickname(),
                 comment.content(),
                 comment.createdAt()
         );

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaDetailResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaDetailResponse.java
@@ -18,16 +18,19 @@ public record CourseQnaDetailResponse(
         @Schema(description = "질문 작성자 ID", example = "1")
         Long userId,
 
+        @Schema(description = "질문 작성자 닉네임", example = "알고가유저")
+        String nickname,
+
         @Schema(description = "답변 작성 매니저 ID", example = "1")
         Long managerId,
 
-        @Schema(description = "질문 제목", example = "오사카 교통패스 관련 질문입니다.")
+        @Schema(description = "질문 제목", example = "강의 내용 관련 질문입니다.")
         String title,
 
-        @Schema(description = "질문 내용", example = "오사카 주유패스와 간사이 패스 중 어떤 것을 선택해야 하나요?")
+        @Schema(description = "질문 내용", example = "강의에서 설명한 내용 중 어떤 것을 선택해야 하나요?")
         String question,
 
-        @Schema(description = "답변 내용", example = "오사카 시내 관광 위주라면 오사카 주유패스를 추천드립니다.")
+        @Schema(description = "답변 내용", example = "해당 상황에서는 첫 번째 선택지를 추천드립니다.")
         String answer,
 
         @Schema(description = "Q&A 상태", example = "ANSWERED")
@@ -48,6 +51,7 @@ public record CourseQnaDetailResponse(
                 result.qnaId(),
                 result.courseId(),
                 result.userId(),
+                result.nickname(),
                 result.managerId(),
                 result.title(),
                 result.question(),

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseQnaResponse.java
@@ -16,6 +16,9 @@ public record CourseQnaResponse(
         @Schema(description = "질문 작성자 ID", example = "1")
         Long userId,
 
+        @Schema(description = "질문 작성자 닉네임", example = "알고가유저")
+        String nickname,
+
         @Schema(description = "답변 매니저 ID", example = "3")
         Long managerId,
 
@@ -42,6 +45,7 @@ public record CourseQnaResponse(
                 qna.qnaId(),
                 qna.courseId(),
                 qna.userId(),
+                qna.nickname(),
                 qna.managerId(),
                 qna.title(),
                 qna.question(),

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseReviewResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/CourseReviewResponse.java
@@ -16,6 +16,9 @@ public record CourseReviewResponse(
         @Schema(description = "사용자 ID", example = "1")
         Long userId,
 
+        @Schema(description = "작성자 닉네임", example = "알고가유저")
+        String nickname,
+
         @Schema(description = "평점", example = "5")
         int rating,
 
@@ -33,6 +36,7 @@ public record CourseReviewResponse(
                 review.reviewId(),
                 review.courseId(),
                 review.userId(),
+                review.nickname(),
                 review.rating(),
                 review.content(),
                 review.createdAt(),

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyCourseResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/MyCourseResponse.java
@@ -20,6 +20,9 @@ public record MyCourseResponse(
         @Schema(description = "국가 ID", example = "1")
         Long countryId,
 
+        @Schema(description = "대륙 코드", example = "ASIA")
+        String continentCode,
+
         @Schema(description = "국가명", example = "일본")
         String countryName,
 
@@ -72,6 +75,7 @@ public record MyCourseResponse(
                 result.title(),
                 result.thumbnailUrl(),
                 result.countryId(),
+                result.continentCode(),
                 result.countryName(),
                 result.totalDurationSeconds(),
                 result.studentCount(),

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/support/CurrentUserIdResolver.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/support/CurrentUserIdResolver.java
@@ -18,6 +18,14 @@ public final class CurrentUserIdResolver {
         return userId;
     }
 
+    public static Long resolveLoginRequired(Object principal) {
+        Long userId = resolveNullable(principal);
+        if (userId == null) {
+            throw new LmsException(LmsErrorCode.LOGIN_REQUIRED);
+        }
+        return userId;
+    }
+
     public static Long resolveNullable(Object principal) {
         if (principal == null) {
             return null;

--- a/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
+++ b/src/main/java/com/kidmily/algoga_server/user/application/AuthService.java
@@ -136,7 +136,7 @@ public class AuthService implements SocialLoginProcessor {
                 .termsMarketingAgreed(request.termsMarketingAgreed())
                 .build();
         User savedUser = userRepository.save(user);
-        //eventPublisher.publishEvent(new UserSignedUpEvent(savedUser.getId()));
+        eventPublisher.publishEvent(new UserSignedUpEvent(savedUser.getId()));
 
         // 가입이 성공적으로 끝났으니, "인증 완료" 포스트잇도 떼서 버립니다! (청소)
         redisTemplate.delete("AUTH_SUCCESS:" + email);
@@ -319,6 +319,7 @@ public class AuthService implements SocialLoginProcessor {
 
         User savedUser = userRepository.save(user);
         eventPublisher.publishEvent(new UserSignedUpEvent(savedUser.getId()));
+        log.info("[Signup] UserSignedUpEvent published. userId={}", savedUser.getId());
 
         log.info("소셜 신규 회원가입 완료 [아이디(이메일): {}, 소셜: {}]",
                 user.getUsername(), user.getSocialType());


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
강의 수료 후 보상 지급 흐름을 이벤트 기반으로 개선하고, 보상 지급 실패 이력 관리 및 재시도 기능을 추가했습니다.

수료 처리 자체는 확정하고, 보상 지급은 자동으로 시도되도록 분리했습니다. 보상 지급 중 오류가 발생하면 실패 이력을 저장하고, 관리자가 직접 재시도하거나 스케줄러를 통해 자동 재시도할 수 있도록 구성했습니다.

추가로 프론트 요청에 맞춰 내 수강 강의 목록 응답에 `continentCode`를 포함했고, 회원가입 시 웰컴쿠폰이 자동 발급되도록 이벤트 기반 흐름을 정리했습니다.

## 🔗 Issue
Closes #336 

---

## 변경 사항
- 강의 수료 완료 후 보상 지급 이벤트 처리 추가
- 수료 및 보상 지급 응답 구조 정리
- 보상 지급 실패 이력 저장 로직 추가
- 보상 실패 목록 조회 API 추가
- 보상 실패 재시도 API 추가
- 보상 실패 자동 재시도 스케줄러 추가
- 보상 실패 상태 관리 추가
- 내 수강 강의 목록 응답에 `continentCode` 추가
- 회원가입 후 웰컴쿠폰 자동 발급 이벤트 처리 추가
- HTTP 테스트 요청의 로그인 토큰 처리 보완

## 확인할 사항
- [ ] 강의 수료 완료 시 수료 정보와 보상 정보가 함께 응답되는지 확인
- [ ] 보상 지급 실패 시 `course_reward_failures`에 실패 이력이 저장되는지 확인
- [ ] 관리자 보상 실패 목록 조회 API가 정상 동작하는지 확인
- [ ] 관리자 보상 실패 재시도 API가 정상 동작하는지 확인
- [ ] 자동 재시도 스케줄러가 실패 건을 재시도하는지 확인
- [ ] `/api/v1/my/courses` 응답에 `continentCode`가 포함되는지 확인
- [ ] 회원가입 후 웰컴쿠폰이 자동 발급되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원가입 완료 시 웰컴 쿠폰이 자동으로 발급됩니다.
  * 내 강좌 목록에 대륙 코드 정보가 추가됩니다.
  * 강의 Q&A/후기 응답에 작성자 닉네임이 함께 제공됩니다.
* **Bug Fixes**
  * 내 강좌 목록 조회 시 로그인하지 않은 요청은 차단되도록 강화되었습니다(로그인 필요 응답 적용).
  * Q&A/후기 조회에서 닉네임 표시가 일관되게 제공되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->