### PR TITLE
[Feature] 강의 진행 상태 갱신 및 퀴즈 제출 후 자동 수료 보상 처리

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/LearningProgressResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/LearningProgressResult.java
@@ -9,9 +9,13 @@ public record LearningProgressResult(
         Long chapterId,
         int watchedSeconds,
         int progressRate,
-        boolean completed
+        boolean completed,
+        CourseClassroomResult classroom
 ) {
-    public static LearningProgressResult from(LearningProgress learningProgress) {
+    public static LearningProgressResult from(
+            LearningProgress learningProgress,
+            CourseClassroomResult classroom
+    ) {
         return new LearningProgressResult(
                 learningProgress.getId(),
                 learningProgress.getUserId(),
@@ -19,7 +23,8 @@ public record LearningProgressResult(
                 learningProgress.getChapterId(),
                 learningProgress.getWatchedSeconds(),
                 learningProgress.getProgressRate(),
-                learningProgress.isCompleted()
+                learningProgress.isCompleted(),
+                classroom
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/QuizSubmitResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/QuizSubmitResult.java
@@ -8,6 +8,8 @@ public record QuizSubmitResult(
         int totalCount,
         int correctCount,
         int score,
+        boolean courseCompleted,
+        CourseCompletionResult completion,
         List<WrongQuizAnswerResult> wrongAnswers
 ) {
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/LearningProgressService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/LearningProgressService.java
@@ -1,9 +1,12 @@
 package com.kidmily.algoga_server.lms.application.service;
 
 import com.kidmily.algoga_server.lms.application.command.UpdateLearningProgressCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseClassroomChapterResult;
+import com.kidmily.algoga_server.lms.application.result.CourseClassroomResult;
 import com.kidmily.algoga_server.lms.application.result.LearningProgressResult;
 import com.kidmily.algoga_server.lms.application.usecase.LearningProgressUseCase;
 import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.domain.model.Course;
 import com.kidmily.algoga_server.lms.domain.model.LearningProgress;
 import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
 import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
@@ -19,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -33,21 +37,17 @@ public class LearningProgressService implements LearningProgressUseCase {
 
     @Override
     public LearningProgressResult updateProgress(UpdateLearningProgressCommand command) {
-        log.info("[Learning Progress Command] 챕터 진도율 업데이트 요청. userId={}, courseId={}, chapterId={}, watchedSeconds={}",
-                command.userId(), command.courseId(), command.chapterId(), command.watchedSeconds());
-
         validateWatchedSeconds(command.watchedSeconds());
-        validateCourse(command.courseId());
+
+        Course course = courseRepository.findById(command.courseId())
+                .orElseThrow(() -> new LmsException(LmsErrorCode.COURSE_NOT_FOUND));
+
         validateEnrollment(command.userId(), command.courseId());
 
         Chapter chapter = chapterRepository.findByIdAndCourseId(
                 command.chapterId(),
                 command.courseId()
-        ).orElseThrow(() -> {
-            log.warn("[Learning Progress Command] 진도율 업데이트 실패. 존재하지 않거나 삭제된 챕터입니다. courseId={}, chapterId={}",
-                    command.courseId(), command.chapterId());
-            return new LmsException(LmsErrorCode.CHAPTER_NOT_FOUND);
-        });
+        ).orElseThrow(() -> new LmsException(LmsErrorCode.CHAPTER_NOT_FOUND));
 
         validatePreviousChapterCompleted(command.userId(), command.courseId(), chapter);
 
@@ -67,14 +67,63 @@ public class LearningProgressService implements LearningProgressUseCase {
 
         LearningProgress savedProgress = learningProgressRepository.save(learningProgress);
 
-        log.info("[Learning Progress Command] 챕터 진도율 업데이트 완료. userId={}, courseId={}, chapterId={}, progressRate={}, completed={}",
-                savedProgress.getUserId(),
-                savedProgress.getCourseId(),
-                savedProgress.getChapterId(),
-                savedProgress.getProgressRate(),
-                savedProgress.isCompleted());
+        CourseClassroomResult classroom = createClassroomResult(
+                command.userId(),
+                course
+        );
 
-        return LearningProgressResult.from(savedProgress);
+        return LearningProgressResult.from(savedProgress, classroom);
+    }
+
+    private CourseClassroomResult createClassroomResult(Long userId, Course course) {
+        var enrollment = enrollmentRepository.findByUserIdAndCourseId(userId, course.getId())
+                .filter(value -> value.isAccessibleAt(LocalDateTime.now()))
+                .orElseThrow(() -> new LmsException(LmsErrorCode.NOT_ENROLLED));
+
+        List<Chapter> chapters = chapterRepository.findByCourseId(course.getId());
+        List<LearningProgress> progresses = learningProgressRepository.findByUserIdAndCourseId(userId, course.getId());
+
+        Map<Long, LearningProgress> progressByChapterId = progresses.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        LearningProgress::getChapterId,
+                        progress -> progress,
+                        (first, second) -> first
+                ));
+
+        boolean previousChaptersCompleted = true;
+        List<CourseClassroomChapterResult> chapterResults = new java.util.ArrayList<>();
+
+        for (Chapter currentChapter : chapters) {
+            LearningProgress progress = progressByChapterId.get(currentChapter.getId());
+            boolean completed = progress != null && progress.isCompleted();
+            boolean locked = !previousChaptersCompleted;
+
+            chapterResults.add(new CourseClassroomChapterResult(
+                    currentChapter.getId(),
+                    currentChapter.getTitle(),
+                    currentChapter.getDescription(),
+                    locked ? null : currentChapter.getVideoUrl(),
+                    currentChapter.getDurationSeconds(),
+                    currentChapter.getChapterOrder(),
+                    progress == null ? 0 : progress.getWatchedSeconds(),
+                    progress == null ? 0 : progress.getProgressRate(),
+                    completed,
+                    locked
+            ));
+
+            previousChaptersCompleted = previousChaptersCompleted && completed;
+        }
+
+        boolean quizAvailable = !chapters.isEmpty()
+                && chapterResults.stream().allMatch(CourseClassroomChapterResult::completed);
+
+        return new CourseClassroomResult(
+                course.getId(),
+                course.getTitle(),
+                enrollment.getAccessExpiresAt(),
+                quizAvailable,
+                chapterResults
+        );
     }
 
     private void validateEnrollment(Long userId, Long courseId) {
@@ -83,24 +132,12 @@ public class LearningProgressService implements LearningProgressUseCase {
                 .orElse(false);
 
         if (!accessible) {
-            log.warn("[Learning Progress Command] 진도율 업데이트 실패. 수강 등록되지 않은 강의입니다. userId={}, courseId={}",
-                    userId, courseId);
             throw new LmsException(LmsErrorCode.NOT_ENROLLED);
-        }
-    }
-
-    private void validateCourse(Long courseId) {
-        if (courseRepository.findById(courseId).isEmpty()) {
-            log.warn("[Learning Progress Command] 진도율 업데이트 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}",
-                    courseId);
-            throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
         }
     }
 
     private void validateWatchedSeconds(int watchedSeconds) {
         if (watchedSeconds < 0) {
-            log.warn("[Learning Progress Command] 진도율 업데이트 실패. 시청 시간이 음수입니다. watchedSeconds={}",
-                    watchedSeconds);
             throw new LmsException(LmsErrorCode.INVALID_PROGRESS);
         }
     }
@@ -123,8 +160,6 @@ public class LearningProgressService implements LearningProgressUseCase {
         );
 
         if (!previousCompleted) {
-            log.warn("[Learning Progress Command] 진도율 업데이트 실패. 이전 챕터 미완료 상태입니다. userId={}, courseId={}, currentChapterId={}, previousChapterId={}",
-                    userId, courseId, currentChapter.getId(), previousChapter.getId());
             throw new LmsException(LmsErrorCode.CHAPTER_LOCKED);
         }
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
@@ -1,17 +1,21 @@
 package com.kidmily.algoga_server.lms.application.service;
 
+import com.kidmily.algoga_server.global.event.CourseCompletionCompletedEvent;
 import com.kidmily.algoga_server.lms.application.command.CreateQuizCommand;
 import com.kidmily.algoga_server.lms.application.command.SubmitQuizAnswerCommand;
 import com.kidmily.algoga_server.lms.application.command.SubmitQuizCommand;
 import com.kidmily.algoga_server.lms.application.command.UpdateQuizCommand;
+import com.kidmily.algoga_server.lms.application.result.CourseCompletionResult;
 import com.kidmily.algoga_server.lms.application.result.QuizResult;
 import com.kidmily.algoga_server.lms.application.result.QuizSubmitResult;
 import com.kidmily.algoga_server.lms.application.result.WrongQuizAnswerResult;
 import com.kidmily.algoga_server.lms.application.usecase.QuizUseCase;
 import com.kidmily.algoga_server.lms.domain.model.Chapter;
+import com.kidmily.algoga_server.lms.domain.model.CourseCompletion;
 import com.kidmily.algoga_server.lms.domain.model.Quiz;
 import com.kidmily.algoga_server.lms.domain.model.QuizSubmission;
 import com.kidmily.algoga_server.lms.domain.repository.ChapterRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseCompletionRepository;
 import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
 import com.kidmily.algoga_server.lms.domain.repository.EnrollmentRepository;
 import com.kidmily.algoga_server.lms.domain.repository.LearningProgressRepository;
@@ -20,15 +24,12 @@ import com.kidmily.algoga_server.lms.domain.repository.QuizSubmissionRepository;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.exception.LmsException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,8 @@ public class QuizService implements QuizUseCase {
     private final EnrollmentRepository enrollmentRepository;
     private final QuizRepository quizRepository;
     private final QuizSubmissionRepository quizSubmissionRepository;
+    private final CourseCompletionRepository courseCompletionRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional(readOnly = true)
@@ -166,14 +169,43 @@ public class QuizService implements QuizUseCase {
                 score
         ));
 
+        CourseCompletionResult completion = completeCourseIfNeeded(
+                command.userId(),
+                command.courseId()
+        );
+
         return new QuizSubmitResult(
                 command.userId(),
                 command.courseId(),
                 quizzes.size(),
                 correctCount,
                 score,
+                completion != null,
+                completion,
                 wrongAnswers
         );
+    }
+
+    private CourseCompletionResult completeCourseIfNeeded(Long userId, Long courseId) {
+        Optional<CourseCompletion> existingCompletion =
+                courseCompletionRepository.findByUserIdAndCourseId(userId, courseId);
+
+        if (existingCompletion.isPresent()) {
+            return CourseCompletionResult.from(existingCompletion.get());
+        }
+
+        CourseCompletion savedCompletion = courseCompletionRepository.save(
+                CourseCompletion.create(userId, courseId)
+        );
+
+        eventPublisher.publishEvent(new CourseCompletionCompletedEvent(
+                savedCompletion.getUserId(),
+                savedCompletion.getCourseId(),
+                savedCompletion.getId(),
+                savedCompletion.getCompletedAt()
+        ));
+
+        return CourseCompletionResult.from(savedCompletion);
     }
 
     private void validateActiveCourse(Long courseId) {

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/LearningProgressResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/LearningProgressResponse.java
@@ -24,7 +24,10 @@ public record LearningProgressResponse(
         int progressRate,
 
         @Schema(description = "챕터 학습 완료 여부", example = "true")
-        boolean completed
+        boolean completed,
+
+        @Schema(description = "진도율 반영 후 최신 강의장 상태")
+        CourseClassroomResponse classroom
 ) {
     public static LearningProgressResponse from(LearningProgressResult learningProgress) {
         return new LearningProgressResponse(
@@ -34,7 +37,8 @@ public record LearningProgressResponse(
                 learningProgress.chapterId(),
                 learningProgress.watchedSeconds(),
                 learningProgress.progressRate(),
-                learningProgress.completed()
+                learningProgress.completed(),
+                CourseClassroomResponse.from(learningProgress.classroom())
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/QuizSubmitResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/QuizSubmitResponse.java
@@ -23,6 +23,12 @@ public record QuizSubmitResponse(
         @Schema(description = "점수", example = "80")
         int score,
 
+        @Schema(description = "강의 수료 처리 여부", example = "true")
+        boolean courseCompleted,
+
+        @Schema(description = "수료 정보")
+        CourseCompletionResponse completion,
+
         @Schema(description = "오답 목록")
         List<WrongQuizAnswerResponse> wrongAnswers
 ) {
@@ -34,6 +40,8 @@ public record QuizSubmitResponse(
                 result.totalCount(),
                 result.correctCount(),
                 result.score(),
+                result.courseCompleted(),
+                result.completion() == null ? null : CourseCompletionResponse.from(result.completion()),
                 result.wrongAnswers()
                         .stream()
                         .map(WrongQuizAnswerResponse::from)


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
챕터 학습 완료 후 다음 챕터/퀴즈 접근 상태가 새로고침 없이 반영되도록 진도율 업데이트 응답을 개선했습니다.

기존에는 진도율 업데이트 API가 현재 챕터의 완료 여부만 반환해 프론트가 최신 강의장 상태를 다시 조회해야 했습니다. 이제 진도율 업데이트 응답에 최신 강의장 상태를 함께 포함하여, 프론트가 응답만으로 챕터 잠금 상태와 퀴즈 활성화 여부를 즉시 갱신할 수 있습니다.

또한 퀴즈 제출 완료 시 백엔드에서 강의 수료 처리를 자동으로 수행하고, 수료 이벤트를 통해 마일리지 및 쿠폰 보상이 지급되도록 흐름을 연결했습니다. 사용자가 별도의 수료 API를 호출하지 않아도 퀴즈 제출 이후 수료 및 보상 지급이 진행됩니다.

삭제된 퀴즈가 제출 검증에 포함되어 답안 개수 검증 오류가 발생하지 않도록, 퀴즈 조회 및 제출 검증 기준을 활성 퀴즈 기준으로 정리했습니다.
## 🔗 Issue
Closes #339 

---

## 변경 사항
- 챕터 진도율 업데이트 응답에 최신 강의장 상태 포함
- 다음 챕터 잠금 상태를 응답 기준으로 즉시 갱신 가능하도록 개선
- 모든 챕터 완료 시 퀴즈 활성화 여부를 응답에 포함
- 퀴즈 제출 완료 후 강의 수료 자동 처리
- 수료 완료 이벤트 발행을 통해 마일리지 및 쿠폰 보상 자동 지급
- 이미 수료된 강의는 중복 수료/중복 보상이 발생하지 않도록 처리
- 퀴즈 조회 및 제출 검증 기준을 활성 퀴즈 기준으로 정리
- Q&A 및 강의 후기 작성자 표시를 닉네임 기준으로 개선

## 확인할 사항
- [ ] 챕터 진도율 100% 저장 시 다음 챕터가 새로고침 없이 활성화되는지 확인
- [ ] 마지막 챕터 완료 시 퀴즈 접근 가능 상태가 응답에 포함되는지 확인
- [ ] 퀴즈 제출 성공 시 수료 이력이 생성되는지 확인
- [ ] 퀴즈 제출 성공 후 마일리지 적립 이력이 생성되는지 확인
- [ ] 강의 쿠폰 정책이 있는 경우 사용자 쿠폰이 발급되는지 확인
- [ ] 보상 지급 실패 시 실패 이력이 저장되는지 확인
- [ ] 삭제된 퀴즈가 퀴즈 제출 검증 대상에서 제외되는지 확인
- [ ] Q&A 목록/상세/댓글 응답에 nickname이 포함되는지 확인
- [ ] 강의 후기 목록/관리자 후기 응답에 nickname이 포함되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 퀴즈 제출 시 과정 완료 여부 및 상세 정보 표시
  * 진도율 조회 시 챕터별 잠금 상태와 강의실 상세 정보 제공

* **Improvements**
  * 학습 진도 업데이트 시 강의실 상태를 함께 반환하여 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->