### PR TITLE
커뮤니티 부하테스트 스크립트 및 대시보드 추가

### DIFF
--- a/K6/community/scripts/01-post-detail-baseline.js
+++ b/K6/community/scripts/01-post-detail-baseline.js
@@ -1,0 +1,83 @@
+// K6/community/scripts/01-post-detail-baseline.js
+// ------------------------------------------------------------
+// 목적:
+// - GET /api/v1/posts/{postId} 게시글 단건 조회 성능 측정
+// - 댓글 N+1 쿼리 최적화 전 기준선 확보
+//
+// 관찰할 것:
+// - Grafana: http_req_duration p95, http_req_failed
+//
+// 실행:
+//   k6 run .\K6\community\scripts\01-post-detail-baseline.js
+// ------------------------------------------------------------
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { BASE_URL, randomSleepSeconds } from '../../common/config.js';
+
+const USER_COUNT = Number(__ENV.USER_COUNT || 20);
+
+export const options = {
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+    scenarios: {
+        post_detail_baseline: {
+            executor: 'ramping-vus',
+            startVUs: 0,
+            stages: [
+                { duration: '30s', target: USER_COUNT },
+                { duration: '1m',  target: USER_COUNT },
+                { duration: '30s', target: 0 },
+            ],
+            gracefulRampDown: '10s',
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        // N+1 최적화 전 기준선 — 최적화 후 얼마나 줄어드는지 Grafana에서 비교
+        'http_req_duration{type:post-detail}': ['p(95)<2000'],
+    },
+};
+
+// 테스트 시작 전 실제 존재하는 게시글 ID 수집
+export function setup() {
+    const res = http.get(`${BASE_URL}/api/v1/posts`);
+    const posts = res.json('data.posts');
+
+    if (!posts || posts.length === 0) {
+        console.error('게시글 목록이 비어있습니다. DB 데이터를 확인하세요.');
+        return { postIds: [1] };
+    }
+
+    const postIds = posts.map(p => p.postId);
+    console.log(`수집된 게시글 ID: ${postIds.length}개 (${postIds[0]} ~ ${postIds[postIds.length - 1]})`);
+    return { postIds };
+}
+
+export default function (data) {
+    const postIds = data.postIds;
+    const postId = postIds[Math.floor(Math.random() * postIds.length)];
+
+    const res = http.get(`${BASE_URL}/api/v1/posts/${postId}`, {
+        tags: {
+            type: 'post-detail',
+            api: 'GET /posts/{postId}',
+        },
+        headers: {
+            'Accept': 'application/json',
+        },
+    });
+
+    if (Math.random() < 0.01) {
+        console.log(`[VU: ${__VU}] postId: ${postId} | status: ${res.status} | duration: ${res.timings.duration}ms`);
+    }
+
+    if (res.status !== 200) {
+        console.warn(`⚠️ postId: ${postId} | status: ${res.status} | body: ${res.body}`);
+    }
+
+    check(res, {
+        'post detail: status is 200': (r) => r.status === 200,
+    });
+
+    sleep(randomSleepSeconds());
+}

--- a/monitoring/grafana/dashboards/algoga-community.json
+++ b/monitoring/grafana/dashboards/algoga-community.json
@@ -1,0 +1,192 @@
+{
+  "title": "Algoga Community Post Detail",
+  "uid": "algoga-community-post-detail",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "게시글 단건 조회 API 응답 성능",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 1,
+      "title": "게시글 단건 조회 TPS",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 1, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/posts/{postId}\", status=\"200\"}[1m]))",
+          "legendFormat": "성공 TPS"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/posts/{postId}\", status=~\"4..|5..\"}[1m]))",
+          "legendFormat": "에러 TPS"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 2,
+      "title": "게시글 단건 조회 응답시간 (p50 / p95 / p99)",
+      "type": "timeseries",
+      "description": "N+1 최적화 전/후 p95 변화를 여기서 비교합니다.",
+      "gridPos": { "x": 8, "y": 1, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "histogram_quantile(0.99, rate(http_server_requests_seconds_bucket{uri=\"/api/v1/posts/{postId}\"}[$__rate_interval]))",
+          "legendFormat": "p99"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "histogram_quantile(0.95, rate(http_server_requests_seconds_bucket{uri=\"/api/v1/posts/{postId}\"}[$__rate_interval]))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "histogram_quantile(0.50, rate(http_server_requests_seconds_bucket{uri=\"/api/v1/posts/{postId}\"}[$__rate_interval]))",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 3,
+      "title": "에러율 (%)",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 1, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/posts/{postId}\", status=~\"5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/posts/{postId}\"}[1m])), 0.001) * 100",
+          "legendFormat": "5xx 에러율"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+
+    {
+      "id": 101,
+      "type": "row",
+      "title": "DB 커넥션 풀 (N+1 영향도 관찰)",
+      "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 4,
+      "title": "DB 커넥션 풀 상태",
+      "description": "부하 중 Active 커넥션이 급증하면 N+1 쿼리가 DB를 압박하는 신호입니다.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 10, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "Active"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "hikaricp_connections_idle",
+          "legendFormat": "Idle"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "hikaricp_connections_pending",
+          "legendFormat": "Pending (대기)"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "DB 커넥션 획득 대기시간 (p95)",
+      "description": "Pending이 발생하면 이 값이 올라갑니다. N+1로 커넥션이 고갈되는 상황을 감지합니다.",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 10, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "histogram_quantile(0.95, rate(hikaricp_connections_acquire_seconds_bucket[$__rate_interval]))",
+          "legendFormat": "획득 대기 p95"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+
+    {
+      "id": 102,
+      "type": "row",
+      "title": "인프라",
+      "gridPos": { "x": 0, "y": 18, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 6,
+      "title": "JVM Heap 사용량",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 19, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "legendFormat": "{{id}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "id": 7,
+      "title": "JVM GC Pause 시간",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 19, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus_ds" },
+          "expr": "rate(jvm_gc_pause_seconds_sum[1m])",
+          "legendFormat": "{{gc}} - {{action}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+
+    {
+      "id": 103,
+      "type": "row",
+      "title": "로그",
+      "gridPos": { "x": 0, "y": 27, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 8,
+      "title": "커뮤니티 도메인 실시간 로그 (Loki)",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 28, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki_ds" },
+          "expr": "{job=\"algoga-server\"} |= \"/api/v1/posts/\"",
+          "legendFormat": ""
+        }
+      ],
+      "options": { "showTime": true, "showLabels": false, "sortOrder": "Descending" }
+    }
+  ]
+}


### PR DESCRIPTION
커뮤니티 게시글 단건 조회 API(GET /api/v1/posts/{postId}) 부하테스트 스크립트 및 Grafana 대시보드 추가

k6 부하테스트 스크립트 작성 (K6/community/scripts/01-post-detail-baseline.js)
setup()에서 게시글 목록 API로 실제 존재하는 postId 동적 수집
ramping-vus executor로 0 → 20명 단계적 부하 인가
N+1 최적화 전 기준선 측정 목적 (threshold p95 < 2000ms)
Grafana 대시보드 추가 (monitoring/grafana/dashboards/algoga-community.json)
게시글 단건 조회 TPS, 응답시간(p50/p95/p99), 에러율
DB 커넥션 풀 상태 (N+1 최적화 전/후 비교용)
JVM Heap, GC Pause, Loki 로그 패널

## 🔗 Issue
Closes #346

확인할 사항

-[ ] k6 실행 전 모니터링 스택(docker-compose up -d) 및 Spring Boot 서버가 실행 중인지 확인
-[ ] k6 run ..\K6\community\scripts\01-post-detail-baseline.js 실행 후 Grafana(http://localhost:3000) → Algoga Community Post 
-[ ] Detail 대시보드에서 결과 확인
-[ ] 부하테스트 중 500 에러 발생 시 — 게시글 단건 조회의 view_count UPDATE 동시성 충돌 문제로 확인됨 (별도 이슈로 처리 예정)
