### PR TITLE
코드 테스트 및 코드 오류수정

### DIFF
--- a/src/test/java/com/kidmily/algoga_server/booking/application/service/BookingCommandServiceTest.java
+++ b/src/test/java/com/kidmily/algoga_server/booking/application/service/BookingCommandServiceTest.java
@@ -40,7 +40,7 @@ class BookingCommandServiceTest {
     }
 
     @Test
-    @DisplayName("예약 취소 시 cancel() 호출 확인")
+    @DisplayName("예약 취소 시 리포지토리로 CANCEL_REQUESTED 상태 변경을 요청한다")
     void 예약_취소_성공() {
         // given
         Booking booking = mock(Booking.class);
@@ -50,8 +50,8 @@ class BookingCommandServiceTest {
         // when
         bookingCommandService.cancel(1L, 1L);
 
-        // then : 도메인 cancel() 이 호출되었는지 검증
-        verify(booking).cancel();
+        // then : 현재 구현은 도메인 cancel()이 아니라 리포지토리로 상태를 업데이트한다
+        verify(bookingRepository).updateStatus(1L, BookingStatus.CANCEL_REQUESTED);
     }
 
     @Test
@@ -79,7 +79,7 @@ class BookingCommandServiceTest {
         // when
         bookingCommandService.cancel(1L, 1L);
 
-        // then
-        assertEquals(BookingStatus.CANCEL_REQUESTED, booking.getStatus());
+        // then : 상태 변경은 리포지토리(updateStatus)를 통해 CANCEL_REQUESTED 로 요청된다
+        verify(bookingRepository).updateStatus(1L, BookingStatus.CANCEL_REQUESTED);
     }
 }

--- a/src/test/java/com/kidmily/algoga_server/flight/application/service/FlightSearchServiceTest.java
+++ b/src/test/java/com/kidmily/algoga_server/flight/application/service/FlightSearchServiceTest.java
@@ -57,16 +57,16 @@ class FlightSearchServiceTest {
     }
 
     @Test
-    @DisplayName("항공편 검색 결과 없으면 빈 리스트 반환")
-    void 항공편_검색_결과_없으면_빈리스트_반환() {
-        // given
+    @DisplayName("API 결과가 없으면 Mock 폴백 데이터를 반환한다")
+    void 항공편_검색_결과_없으면_Mock폴백_반환() {
+        // given : 외부 API가 빈 결과를 줌
         when(flightApiClient.getDepartureFlights(anyString(), any(LocalDate.class)))
                 .thenReturn(Collections.emptyList());
 
         // when
         List<FlightInfo> result = flightSearchService.searchFlights("ICN", LocalDate.now());
 
-        // then
-        assertTrue(result.isEmpty());
+        // then : graceful degradation — 빈 리스트가 아니라 Mock 데이터로 채워 반환
+        assertFalse(result.isEmpty());
     }
 }

--- a/src/test/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandServiceTest.java
+++ b/src/test/java/com/kidmily/algoga_server/payment/application/service/PaymentCommandServiceTest.java
@@ -1,0 +1,93 @@
+package com.kidmily.algoga_server.payment.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kidmily.algoga_server.payment.application.command.CreateLecturePaymentCommand;
+import com.kidmily.algoga_server.payment.infrastructure.portone.PortOneClient;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * PaymentCommandService.extractPaymentMethod() 검증.
+ * PortOne 응답(method 노드)에서 실제 결제수단을 뽑아 트랜잭션 서비스로 넘기는지를,
+ * PortOne 호출을 Mock 으로 대체해(실제 호출 없이) handleLecturePayment 경로로 확인한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PaymentCommandServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private PortOneClient portOneClient;
+    @Mock private PaymentTransactionService paymentTransactionService;
+    @Mock private Timer paymentDurationSeconds;
+    @Mock private Counter paymentSuccessTotal;
+    @Mock private Counter paymentFailedTotal;
+    @Mock private Timer portoneApiDurationSeconds;
+
+    @InjectMocks
+    private PaymentCommandService paymentCommandService;
+
+    @Test
+    @DisplayName("간편결제면 method.provider(TOSSPAY)가 결제수단으로 전달된다")
+    void 간편결제_provider_추출() throws Exception {
+        JsonNode fake = objectMapper.readTree(
+                "{\"status\":\"PAID\",\"amount\":{\"total\":100000},\"method\":{\"provider\":\"TOSSPAY\"}}");
+        when(portOneClient.getPayment("pay-1")).thenReturn(fake);
+        when(paymentTransactionService.saveLecturePayment(any(), anyString(), anyInt(), anyString()))
+                .thenReturn(1L);
+
+        CreateLecturePaymentCommand command =
+                new CreateLecturePaymentCommand(10L, 2L, 100000, 0, null, "pay-1");
+
+        Long id = paymentCommandService.handleLecturePayment(command);
+
+        assertEquals(1L, id);
+        verify(paymentTransactionService)
+                .saveLecturePayment(any(), eq("PAID"), eq(100000), eq("TOSSPAY"));
+    }
+
+    @Test
+    @DisplayName("카드 등은 method.type(PaymentMethodCard)이 결제수단으로 전달된다")
+    void 카드_type_추출() throws Exception {
+        JsonNode fake = objectMapper.readTree(
+                "{\"status\":\"PAID\",\"amount\":{\"total\":50000},\"method\":{\"type\":\"PaymentMethodCard\"}}");
+        when(portOneClient.getPayment("pay-2")).thenReturn(fake);
+        when(paymentTransactionService.saveLecturePayment(any(), anyString(), anyInt(), anyString()))
+                .thenReturn(2L);
+
+        CreateLecturePaymentCommand command =
+                new CreateLecturePaymentCommand(11L, 2L, 50000, 0, null, "pay-2");
+
+        paymentCommandService.handleLecturePayment(command);
+
+        verify(paymentTransactionService)
+                .saveLecturePayment(any(), eq("PAID"), eq(50000), eq("PaymentMethodCard"));
+    }
+
+    @Test
+    @DisplayName("method 정보가 없으면 결제수단은 null 로 전달된다")
+    void method_없으면_null() throws Exception {
+        JsonNode fake = objectMapper.readTree(
+                "{\"status\":\"FAILED\",\"amount\":{\"total\":0}}");
+        when(portOneClient.getPayment("pay-3")).thenReturn(fake);
+        when(paymentTransactionService.saveLecturePayment(any(), anyString(), anyInt(), isNull()))
+                .thenReturn(3L);
+
+        CreateLecturePaymentCommand command =
+                new CreateLecturePaymentCommand(12L, 2L, 0, 0, null, "pay-3");
+
+        paymentCommandService.handleLecturePayment(command);
+
+        verify(paymentTransactionService)
+                .saveLecturePayment(any(), eq("FAILED"), eq(0), isNull());
+    }
+}

--- a/src/test/java/com/kidmily/algoga_server/payment/application/service/PaymentTransactionServiceTest.java
+++ b/src/test/java/com/kidmily/algoga_server/payment/application/service/PaymentTransactionServiceTest.java
@@ -1,0 +1,78 @@
+package com.kidmily.algoga_server.payment.application.service;
+
+import com.kidmily.algoga_server.benefit.domain.repository.MileageHistoryRepository;
+import com.kidmily.algoga_server.benefit.domain.repository.UserCouponRepository;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.global.event.LecturePaymentCompletedEvent;
+import com.kidmily.algoga_server.lms.domain.model.Course;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.payment.application.command.CreateLecturePaymentCommand;
+import com.kidmily.algoga_server.payment.domain.model.Payment;
+import com.kidmily.algoga_server.payment.domain.model.PaymentStatus;
+import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * PaymentTransactionService.saveLecturePayment() 검증.
+ * 강의 결제 성공 시 결제수단/사용자명 스냅샷이 저장되고, 수강권 부여용 이벤트가 발행되는지 확인.
+ */
+@ExtendWith(MockitoExtension.class)
+class PaymentTransactionServiceTest {
+
+    @Mock private PaymentRepository paymentRepository;
+    @Mock private BookingRepository bookingRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private CourseRepository courseRepository;
+    @Mock private UserCouponRepository userCouponRepository;
+    @Mock private MileageHistoryRepository mileageHistoryRepository;
+
+    @InjectMocks
+    private PaymentTransactionService paymentTransactionService;
+
+    @Test
+    @DisplayName("강의 결제 성공 시 결제수단·사용자명 스냅샷 저장 + 수강권 이벤트 발행")
+    void 강의결제_성공_스냅샷_저장_및_수강권이벤트() {
+        // given
+        CreateLecturePaymentCommand command =
+                new CreateLecturePaymentCommand(5L, 2L, 50000, 0, null, "pid-1");
+
+        when(courseRepository.findByIdAndDeletedFalse(5L)).thenReturn(Optional.of(mock(Course.class)));
+        when(paymentRepository.findByIdempotencyKey("LECTURE_5_2")).thenReturn(Optional.empty());
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(2L);
+        when(user.getName()).thenReturn("고성민");
+        when(user.getEmail()).thenReturn("test@algoga.kr");
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        paymentTransactionService.saveLecturePayment(command, "PAID", 50000, "TOSSPAY");
+
+        // then : 저장된 Payment 에 결제수단/사용자명 스냅샷이 박혔는지
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).save(captor.capture());
+        Payment saved = captor.getValue();
+        assertEquals("TOSSPAY", saved.getPaymentMethod());
+        assertEquals("고성민", saved.getUserName());
+        assertEquals(PaymentStatus.SUCCESS, saved.getStatus());
+
+        // 수강권 부여용 이벤트 발행
+        verify(eventPublisher).publishEvent(any(LecturePaymentCompletedEvent.class));
+    }
+}

--- a/src/test/java/com/kidmily/algoga_server/refund/application/service/RefundCommandServiceTest.java
+++ b/src/test/java/com/kidmily/algoga_server/refund/application/service/RefundCommandServiceTest.java
@@ -2,10 +2,13 @@ package com.kidmily.algoga_server.refund.application.service;
 
 import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
 import com.kidmily.algoga_server.global.exception.BusinessException;
+import com.kidmily.algoga_server.payment.domain.model.Payment;
 import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
 import com.kidmily.algoga_server.payment.infrastructure.portone.PortOneClient;
 import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
+import com.kidmily.algoga_server.refund.domain.model.RefundStatus;
 import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +26,7 @@ import static org.mockito.Mockito.*;
 /*
  * RefundCommandService 단위 테스트
  * - 환불 승인/거절/없는ID 예외 케이스 검증
- * - verify() 로 도메인 메서드 호출 여부 확인
+ * - 승인은 UNDER_REVIEW 상태에서만, 거절은 REQUESTED/UNDER_REVIEW 에서 가능 (STEP 6 상태흐름 반영)
  */
 @ExtendWith(MockitoExtension.class)
 class RefundCommandServiceTest {
@@ -33,6 +36,9 @@ class RefundCommandServiceTest {
     @Mock private PaymentRepository paymentRepository;
     @Mock private PortOneClient portOneClient;
     @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private Counter refundRequestedTotal;
+    @Mock private Counter refundApprovedTotal;
+    @Mock private Counter refundRejectedTotal;
 
     @InjectMocks
     private RefundCommandService refundCommandService;
@@ -44,10 +50,11 @@ class RefundCommandServiceTest {
     }
 
     @Test
-    @DisplayName("환불 승인 시 approve() 호출 확인")
+    @DisplayName("UNDER_REVIEW 상태 환불 승인 시 approve() 호출 확인")
     void 환불_승인_성공() {
-        // given
+        // given : 승인은 UNDER_REVIEW 상태에서만 가능
         RefundRequest refund = mock(RefundRequest.class);
+        when(refund.getStatus()).thenReturn(RefundStatus.UNDER_REVIEW);
         when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
 
         // when
@@ -58,11 +65,32 @@ class RefundCommandServiceTest {
     }
 
     @Test
-    @DisplayName("환불 거절 시 reject(reason) 호출 확인")
-    void 환불_거절_성공() {
-        // given
+    @DisplayName("UNDER_REVIEW 가 아닌 상태로 승인 시 예외 발생")
+    void 잘못된_상태_승인_시_예외_발생() {
+        // given : REQUESTED 상태(승인 불가)
         RefundRequest refund = mock(RefundRequest.class);
+        when(refund.getStatus()).thenReturn(RefundStatus.REQUESTED);
         when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+
+        // when & then
+        assertThrows(BusinessException.class, () -> refundCommandService.approve(1L));
+        verify(refund, never()).approve();
+    }
+
+    @Test
+    @DisplayName("REQUESTED 상태 환불 거절 시 reject(reason) 호출 확인")
+    void 환불_거절_성공() {
+        // given : 거절은 REQUESTED/UNDER_REVIEW 에서 가능
+        RefundRequest refund = mock(RefundRequest.class);
+        when(refund.getStatus()).thenReturn(RefundStatus.REQUESTED);
+        when(refund.getPaymentId()).thenReturn(10L);
+        when(refund.getUserId()).thenReturn(1L);
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+
+        // 거절 후 강의/패키지 구분용 payment 조회 — courseId 있으면 강의(ofLecture) 분기로 booking 조회 회피
+        Payment payment = mock(Payment.class);
+        when(payment.getCourseId()).thenReturn(5L);
+        when(paymentRepository.findById(10L)).thenReturn(Optional.of(payment));
 
         // when
         refundCommandService.reject(1L, "규정 외 요청");

--- a/src/test/java/com/kidmily/algoga_server/refund/application/service/RefundQueryServiceUserNameTest.java
+++ b/src/test/java/com/kidmily/algoga_server/refund/application/service/RefundQueryServiceUserNameTest.java
@@ -1,0 +1,78 @@
+package com.kidmily.algoga_server.refund.application.service;
+
+import com.kidmily.algoga_server.accommodation.domain.repository.AccommodationRepository;
+import com.kidmily.algoga_server.booking.domain.repository.BookingRepository;
+import com.kidmily.algoga_server.lms.domain.repository.CourseRepository;
+import com.kidmily.algoga_server.payment.domain.repository.PaymentRepository;
+import com.kidmily.algoga_server.refund.domain.model.RefundRequest;
+import com.kidmily.algoga_server.refund.domain.repository.RefundRepository;
+import com.kidmily.algoga_server.refund.presentation.api.response.RefundResponse;
+import com.kidmily.algoga_server.user.domain.User;
+import com.kidmily.algoga_server.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * 환불 단건 조회의 사용자명이 "스냅샷 우선 + 옛 환불건은 live 조회 fallback" 으로 동작하는지 검증.
+ * payment/booking 을 비워(Optional.empty) 상품명 조회 분기를 타지 않게 해 userName 로직만 본다.
+ */
+@ExtendWith(MockitoExtension.class)
+class RefundQueryServiceUserNameTest {
+
+    @Mock private RefundRepository refundRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private BookingRepository bookingRepository;
+    @Mock private PaymentRepository paymentRepository;
+    @Mock private AccommodationRepository accommodationRepository;
+    @Mock private CourseRepository courseRepository;
+
+    @InjectMocks
+    private RefundQueryService refundQueryService;
+
+    @Test
+    @DisplayName("환불에 사용자명 스냅샷이 있으면 그 값을 쓰고 user 테이블을 조회하지 않는다")
+    void 스냅샷_있으면_그대로_사용() {
+        RefundRequest refund = mock(RefundRequest.class);
+        when(refund.getUserName()).thenReturn("고성민");
+        when(refund.getPaymentId()).thenReturn(10L);
+        when(refund.getBookingId()).thenReturn(20L);
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+        when(paymentRepository.findById(10L)).thenReturn(Optional.empty());
+        when(bookingRepository.findById(20L)).thenReturn(Optional.empty());
+
+        RefundResponse result = refundQueryService.getRefund(1L);
+
+        assertEquals("고성민", result.userName());
+        verify(userRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("스냅샷이 없으면(옛 환불건) user 테이블을 live 조회해 채운다")
+    void 스냅샷_없으면_live조회_fallback() {
+        RefundRequest refund = mock(RefundRequest.class);
+        when(refund.getUserName()).thenReturn(null);
+        when(refund.getUserId()).thenReturn(2L);
+        when(refund.getPaymentId()).thenReturn(10L);
+        when(refund.getBookingId()).thenReturn(20L);
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+
+        User user = mock(User.class);
+        when(user.getName()).thenReturn("고성민");
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        when(paymentRepository.findById(10L)).thenReturn(Optional.empty());
+        when(bookingRepository.findById(20L)).thenReturn(Optional.empty());
+
+        RefundResponse result = refundQueryService.getRefund(1L);
+
+        assertEquals("고성민", result.userName());
+    }
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
설명 작성
도메인 캐시 구조를 팀 표준(CacheRegistry 패턴)으로 이전하고, 삭제 정책 대응으로 결제·환불 내역에 사용자명 스냅샷을 추가했습니다. 더불어 깨져있던 단위 테스트를 현행 코드에 맞게 정비하고 변경분 테스트를 보강했습니다.

주요 변경

캐시 이전: global/cache에 CacheRegistry 인터페이스 + 모든 구현체를 모으는 CacheManagerConfig 신설. payment/booking 캐시를 PaymentCacheType/BookingCacheType + Registry로 이전, 어노테이션 문자열 → 상수. RedisConfig의 도메인 캐시 하드코딩 Map 제거
사용자명 스냅샷: Payment/RefundRequest에 userName 필드 추가(컬럼 user_name). 결제·환불 시점 사용자명을 저장하고, 조회 시 스냅샷 우선 + 옛 데이터는 live 조회 fallback → user hard delete 후에도 잔여 내역에서 이름 보존
부수 수정: 환불 조회의 결제수단이 paymentType.name()으로 잘못 나오던 버그 → payment.getPaymentMethod()
테스트: 깨진 단위테스트 3개(booking cancel / refund approve·reject / flight 폴백) 현행화 + 결제수단 추출·스냅샷·수강권 이벤트 신규 테스트 3개

## 🔗 Issue
Closes #

---




## 확인할 사항
캐시: CacheManagerConfig가 모든 CacheRegistry를 모아 TTL 적용 (myPayments 5분 / adminPaymentStats 1시간 / myBookings 5분), RedisConfig에 중복 CacheManager 빈 없는지
미완료
스냅샷: 신규 결제·환불 시 user_name 저장, 조회 시 스냅샷 우선·없으면 live 조회 fallback (payments/refund_requests에 컬럼은 ddl-auto로 자동 생성, 운영 적용 불필요)
미완료
내 도메인(booking/payment/refund/flight) 단위 테스트 전부 통과
미완료
⚠️ CI 전체 실패는 내 도메인 외 기존 깨짐 때문 (LMS 컴파일 깨짐 ChapterRepositoryTest/CourseServiceClassroomTest, RateLimitProvider 빈 누락) — 이번 PR과 무관


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 예약 취소 동작 검증 강화
  * 항공편 검색 폴백 동작 테스트 개선
  * 결제 수단 추출 및 거래 저장 프로세스 검증 추가
  * 환불 승인·거절 상태 흐름 테스트 세분화
  * 환불 조회 시 사용자명 처리 로직 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->