### PR TITLE
[Feature] LMS 강의 수강/보상/삭제 강의 접근 정책 개선

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/benefit/application/listener/CourseCompletionRewardEventListener.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/listener/CourseCompletionRewardEventListener.java
@@ -19,8 +19,14 @@ public class CourseCompletionRewardEventListener {
     private final CourseRewardUseCase courseRewardUseCase;
     private final CourseRewardFailureUseCase courseRewardFailureUseCase;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(
+            phase = TransactionPhase.AFTER_COMMIT,
+            fallbackExecution = true
+    )
     public void grantReward(CourseCompletionCompletedEvent event) {
+        log.info("[CourseCompletionReward] Event received. userId={}, courseId={}, completionId={}",
+                event.userId(), event.courseId(), event.completionId());
+
         try {
             courseRewardUseCase.rewardCourseWithDetails(
                     new RewardCourseCommand(event.userId(), event.courseId())

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/service/CourseRewardFailureService.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/service/CourseRewardFailureService.java
@@ -22,6 +22,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CourseRewardFailureService implements CourseRewardFailureUseCase {
 
+    private static final int MAX_RETRY_COUNT = 3;
+
     private final CourseRewardFailureRepository courseRewardFailureRepository;
     private final CourseRewardUseCase courseRewardUseCase;
 
@@ -48,12 +50,21 @@ public class CourseRewardFailureService implements CourseRewardFailureUseCase {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<CourseRewardFailureResult> getRetryableFailures(int maxRetryCount) {
+        return courseRewardFailureRepository.findRetryableFailures(maxRetryCount)
+                .stream()
+                .map(CourseRewardFailureResult::from)
+                .toList();
+    }
+
+    @Override
     @Transactional
     public CourseRewardFailureResult retryFailure(RetryCourseRewardFailureCommand command) {
         CourseRewardFailure failure = courseRewardFailureRepository.findById(command.failureId())
                 .orElseThrow(() -> new BenefitException(BenefitErrorCode.COURSE_REWARD_FAILURE_NOT_FOUND));
 
-        if (failure.getStatus() == CourseRewardFailureStatus.RESOLVED) {
+        if (failure.isResolved()) {
             throw new BenefitException(BenefitErrorCode.COURSE_REWARD_FAILURE_ALREADY_RESOLVED);
         }
 
@@ -71,18 +82,13 @@ public class CourseRewardFailureService implements CourseRewardFailureUseCase {
                     courseRewardFailureRepository.save(retryingFailure.markResolved())
             );
         } catch (Exception exception) {
-            CourseRewardFailure failed = retryingFailure.markFailed(exception.getMessage());
+            CourseRewardFailure failed = retryingFailure.markRetryFailed(
+                    exception.getMessage(),
+                    MAX_RETRY_COUNT
+            );
+
             courseRewardFailureRepository.save(failed);
             throw exception;
         }
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<CourseRewardFailureResult> getRetryableFailures(int maxRetryCount) {
-        return courseRewardFailureRepository.findRetryableFailures(maxRetryCount)
-                .stream()
-                .map(CourseRewardFailureResult::from)
-                .toList();
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/benefit/application/service/CourseRewardService.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/application/service/CourseRewardService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ public class CourseRewardService implements CourseRewardUseCase {
     }
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public CourseRewardResult rewardCourseWithDetails(RewardCourseCommand command) {
         log.info("[Course Reward Command] 강의 보상 지급 요청. userId={}, courseId={}",
                 command.userId(), command.courseId());

--- a/src/main/java/com/kidmily/algoga_server/benefit/domain/model/CourseRewardFailure.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/domain/model/CourseRewardFailure.java
@@ -4,16 +4,16 @@ import java.time.LocalDateTime;
 
 public class CourseRewardFailure {
 
-    private Long id;
-    private Long userId;
-    private Long courseId;
-    private Long completionId;
-    private CourseRewardFailureStatus status;
-    private String failureReason;
-    private int retryCount;
-    private LocalDateTime createdAt;
-    private LocalDateTime lastFailedAt;
-    private LocalDateTime resolvedAt;
+    private final Long id;
+    private final Long userId;
+    private final Long courseId;
+    private final Long completionId;
+    private final CourseRewardFailureStatus status;
+    private final String failureReason;
+    private final int retryCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime lastFailedAt;
+    private final LocalDateTime resolvedAt;
 
     private CourseRewardFailure(
             Long id,
@@ -102,6 +102,25 @@ public class CourseRewardFailure {
         );
     }
 
+    public CourseRewardFailure markRetryFailed(String failureReason, int maxRetryCount) {
+        CourseRewardFailureStatus nextStatus = retryCount >= maxRetryCount
+                ? CourseRewardFailureStatus.FAILED
+                : CourseRewardFailureStatus.PENDING;
+
+        return new CourseRewardFailure(
+                id,
+                userId,
+                courseId,
+                completionId,
+                nextStatus,
+                failureReason,
+                retryCount,
+                createdAt,
+                LocalDateTime.now(),
+                resolvedAt
+        );
+    }
+
     public CourseRewardFailure markResolved() {
         return new CourseRewardFailure(
                 id,
@@ -117,19 +136,8 @@ public class CourseRewardFailure {
         );
     }
 
-    public CourseRewardFailure markFailed(String failureReason) {
-        return new CourseRewardFailure(
-                id,
-                userId,
-                courseId,
-                completionId,
-                CourseRewardFailureStatus.FAILED,
-                failureReason,
-                retryCount,
-                createdAt,
-                LocalDateTime.now(),
-                resolvedAt
-        );
+    public boolean isResolved() {
+        return status == CourseRewardFailureStatus.RESOLVED;
     }
 
     public Long getId() {

--- a/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/lms/LmsCourseAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/lms/LmsCourseAdapter.java
@@ -101,7 +101,7 @@ public class LmsCourseAdapter implements LmsCoursePort {
     private Optional<Object> findCourse(Long courseId) {
         return invoke(
                 bean(COURSE_REPOSITORY),
-                "findByIdAndDeletedFalse",
+                "findById",
                 new Class<?>[]{Long.class},
                 courseId
         );

--- a/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/persistence/repository/SpringDataCourseRewardFailureRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/infrastructure/persistence/repository/SpringDataCourseRewardFailureRepository.java
@@ -15,11 +15,8 @@ public interface SpringDataCourseRewardFailureRepository extends JpaRepository<C
     @Query("""
             select failure
             from CourseRewardFailureJpaEntity failure
-            where failure.status in (
-                com.kidmily.algoga_server.benefit.domain.model.CourseRewardFailureStatus.PENDING,
-                com.kidmily.algoga_server.benefit.domain.model.CourseRewardFailureStatus.FAILED
-            )
-            and failure.retryCount < :maxRetryCount
+            where failure.status = com.kidmily.algoga_server.benefit.domain.model.CourseRewardFailureStatus.PENDING
+              and failure.retryCount < :maxRetryCount
             order by failure.lastFailedAt asc
             """)
     List<CourseRewardFailureJpaEntity> findRetryableFailures(@Param("maxRetryCount") int maxRetryCount);

--- a/src/main/java/com/kidmily/algoga_server/benefit/presentation/api/CourseRewardController.java
+++ b/src/main/java/com/kidmily/algoga_server/benefit/presentation/api/CourseRewardController.java
@@ -1,61 +1,61 @@
-package com.kidmily.algoga_server.benefit.presentation.api;
-
-import com.kidmily.algoga_server.benefit.application.command.RewardCourseCommand;
-import com.kidmily.algoga_server.benefit.application.usecase.CourseRewardUseCase;
-import com.kidmily.algoga_server.benefit.exception.BenefitErrorCode;
-import com.kidmily.algoga_server.benefit.presentation.response.CourseRewardResponse;
-import com.kidmily.algoga_server.benefit.presentation.support.CurrentUserIdResolver;
-import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
-import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@Tag(name = "Course Reward", description = "강의 수료 보상 지급 API")
-@RestController
-@RequestMapping("/api/v1/courses/{courseId}/rewards")
-@RequiredArgsConstructor
-public class CourseRewardController {
-
-    private final CourseRewardUseCase courseRewardUseCase;
-
-    @Operation(
-            summary = "쿠폰 및 마일리지 지급",
-            description = "강의 수료와 퀴즈 제출이 완료된 사용자에게 활성 쿠폰과 마일리지를 지급합니다."
-    )
-    @ApiErrorCodeExample(domain = BenefitErrorCode.class, value = {
-            "COURSE_NOT_FOUND",
-            "COURSE_COMPLETION_NOT_FOUND",
-            "QUIZ_NOT_SUBMITTED",
-            "COURSE_REWARD_ALREADY_GRANTED",
-            "COURSE_REWARD_PERIOD_EXPIRED"
-    })
-    @PreAuthorize("isAuthenticated()")
-    @PostMapping
-    public ResponseEntity<ApiResponse<CourseRewardResponse>> rewardCourse(
-            @Parameter(description = "강의 ID", example = "3")
-            @PathVariable Long courseId,
-
-            @AuthenticationPrincipal Object userDetails
-    ) {
-        Long currentUserId = CurrentUserIdResolver.resolveRequired(userDetails);
-        RewardCourseCommand command = new RewardCourseCommand(currentUserId, courseId);
-        var result = courseRewardUseCase.rewardCourseWithDetails(command);
-
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.created(
-                        "COURSE_REWARD_GRANTED",
-                        "쿠폰 및 마일리지 지급에 성공했습니다.",
-                        CourseRewardResponse.from(result)
-                ));
-    }
-}
+//package com.kidmily.algoga_server.benefit.presentation.api;
+//
+//import com.kidmily.algoga_server.benefit.application.command.RewardCourseCommand;
+//import com.kidmily.algoga_server.benefit.application.usecase.CourseRewardUseCase;
+//import com.kidmily.algoga_server.benefit.exception.BenefitErrorCode;
+//import com.kidmily.algoga_server.benefit.presentation.response.CourseRewardResponse;
+//import com.kidmily.algoga_server.benefit.presentation.support.CurrentUserIdResolver;
+//import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
+//import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.Parameter;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.security.access.prepost.PreAuthorize;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+//import org.springframework.web.bind.annotation.PathVariable;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@Tag(name = "Course Reward", description = "강의 수료 보상 지급 API")
+//@RestController
+//@RequestMapping("/api/v1/courses/{courseId}/rewards")
+//@RequiredArgsConstructor
+//public class CourseRewardController {
+//
+//    private final CourseRewardUseCase courseRewardUseCase;
+//
+//    @Operation(
+//            summary = "쿠폰 및 마일리지 지급",
+//            description = "강의 수료와 퀴즈 제출이 완료된 사용자에게 활성 쿠폰과 마일리지를 지급합니다."
+//    )
+//    @ApiErrorCodeExample(domain = BenefitErrorCode.class, value = {
+//            "COURSE_NOT_FOUND",
+//            "COURSE_COMPLETION_NOT_FOUND",
+//            "QUIZ_NOT_SUBMITTED",
+//            "COURSE_REWARD_ALREADY_GRANTED",
+//            "COURSE_REWARD_PERIOD_EXPIRED"
+//    })
+//    @PreAuthorize("isAuthenticated()")
+//    @PostMapping
+//    public ResponseEntity<ApiResponse<CourseRewardResponse>> rewardCourse(
+//            @Parameter(description = "강의 ID", example = "3")
+//            @PathVariable Long courseId,
+//
+//            @AuthenticationPrincipal Object userDetails
+//    ) {
+//        Long currentUserId = CurrentUserIdResolver.resolveRequired(userDetails);
+//        RewardCourseCommand command = new RewardCourseCommand(currentUserId, courseId);
+//        var result = courseRewardUseCase.rewardCourseWithDetails(command);
+//
+//        return ResponseEntity.status(HttpStatus.CREATED)
+//                .body(ApiResponse.created(
+//                        "COURSE_REWARD_GRANTED",
+//                        "쿠폰 및 마일리지 지급에 성공했습니다.",
+//                        CourseRewardResponse.from(result)
+//                ));
+//    }
+//}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/CourseResult.java
@@ -17,7 +17,8 @@ public record CourseResult(
         List<CourseFileResult> files,
         String level,
         String levelName,
-        String status
+        String status,
+        boolean deleted
 ) {
     public static CourseResult from(Course course) {
         return new CourseResult(
@@ -32,7 +33,8 @@ public record CourseResult(
                 course.getCourseFiles().stream().map(CourseFileResult::from).toList(),
                 course.getLevel(),
                 CourseLevel.find(course.getLevel()).map(CourseLevel::displayName).orElse(""),
-                course.getStatus()
+                course.getStatus(),
+                course.isDeleted()
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/DiagnosisResultSummary.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/DiagnosisResultSummary.java
@@ -1,0 +1,31 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import com.kidmily.algoga_server.lms.domain.model.DiagnosisResult;
+
+import java.time.LocalDateTime;
+
+public record DiagnosisResultSummary(
+        Long resultId,
+        Long countryId,
+        String countryName,
+        LocalDateTime submittedAt,
+        String level,
+        String levelName,
+        Integer score
+) {
+    public static DiagnosisResultSummary from(
+            DiagnosisResult result,
+            String countryName,
+            String levelName
+    ) {
+        return new DiagnosisResultSummary(
+                result.id(),
+                result.countryId(),
+                countryName,
+                result.createdAt(),
+                result.level(),
+                levelName,
+                result.score()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/DiagnosisResultView.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/DiagnosisResultView.java
@@ -6,6 +6,7 @@ import java.util.List;
 public record DiagnosisResultView(
         Long resultId,
         Long countryId,
+        String countryName,
         Integer correctCount,
         Integer totalCount,
         Integer score,

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/LearningProgressResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/LearningProgressResult.java
@@ -10,10 +10,18 @@ public record LearningProgressResult(
         int watchedSeconds,
         int progressRate,
         boolean completed,
+        Long nextChapterId,
+        boolean nextChapterUnlocked,
+        int courseProgressRate,
+        boolean quizAvailable,
         CourseClassroomResult classroom
 ) {
-    public static LearningProgressResult from(
+    public static LearningProgressResult of(
             LearningProgress learningProgress,
+            Long nextChapterId,
+            boolean nextChapterUnlocked,
+            int courseProgressRate,
+            boolean quizAvailable,
             CourseClassroomResult classroom
     ) {
         return new LearningProgressResult(
@@ -24,6 +32,10 @@ public record LearningProgressResult(
                 learningProgress.getWatchedSeconds(),
                 learningProgress.getProgressRate(),
                 learningProgress.isCompleted(),
+                nextChapterId,
+                nextChapterUnlocked,
+                courseProgressRate,
+                quizAvailable,
                 classroom
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/result/QuizSubmissionResult.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/result/QuizSubmissionResult.java
@@ -1,0 +1,27 @@
+package com.kidmily.algoga_server.lms.application.result;
+
+import com.kidmily.algoga_server.lms.domain.model.QuizSubmission;
+
+import java.time.LocalDateTime;
+
+public record QuizSubmissionResult(
+        Long submissionId,
+        Long userId,
+        Long courseId,
+        int totalCount,
+        int correctCount,
+        int score,
+        LocalDateTime submittedAt
+) {
+    public static QuizSubmissionResult from(QuizSubmission submission) {
+        return new QuizSubmissionResult(
+                submission.getId(),
+                submission.getUserId(),
+                submission.getCourseId(),
+                submission.getTotalCount(),
+                submission.getCorrectCount(),
+                submission.getScore(),
+                submission.getSubmittedAt()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CertificatePdfService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CertificatePdfService.java
@@ -56,15 +56,15 @@ public class CertificatePdfService {
                 });
 
         try {
-            byte[] pdfBytes = createPdf(userName, course, courseCompletion);
+            byte[] pdfBytes = createPdf(resolveUserName(userName), course, courseCompletion);
 
             log.info("[Certificate Query] 수료증 PDF 발급 완료. userId={}, courseId={}, certificateCode={}",
                     userId, courseId, courseCompletion.getCertificateCode());
 
             return pdfBytes;
-        } catch (IOException e) {
-            log.error("[Certificate Query] 수료증 PDF 생성 실패. userId={}, courseId={}", userId, courseId, e);
-            throw new IllegalStateException("수료증 PDF 생성에 실패했습니다.", e);
+        } catch (IOException exception) {
+            log.error("[Certificate Query] 수료증 PDF 생성 실패. userId={}, courseId={}", userId, courseId, exception);
+            throw new IllegalStateException("수료증 PDF 생성에 실패했습니다.", exception);
         }
     }
 
@@ -115,8 +115,8 @@ public class CertificatePdfService {
 
         drawLine(contentStream, 244, 585, 351, 585, TEAL, 2.5f);
 
-        drawCenteredText(contentStream, font, 12, "이 수료증은 아래와 같이 증명합니다.", 545, GRAY);
-        drawCenteredText(contentStream, font, 20, safeText(userName), 505, DARK);
+        drawCenteredText(contentStream, font, 12, "본 수료증은 아래와 같이 증명합니다.", 545, GRAY);
+        drawCenteredText(contentStream, font, 20, userName, 505, DARK);
 
         drawCenteredText(contentStream, font, 11, "위 수료자는 알고가(ALGOGA)에서 제공하는", 462, DARK);
         drawCenteredTextWithMaxWidth(contentStream, font, 17, "'" + safeText(course.getTitle()) + "'", 432, TEAL, 380);
@@ -325,6 +325,14 @@ public class CertificatePdfService {
         contentStream.closePath();
     }
 
+    private String resolveUserName(String userName) {
+        if (userName == null || userName.isBlank()) {
+            return "수강생";
+        }
+
+        return userName;
+    }
+
     private String safeText(String text) {
         return text == null ? "" : text;
     }
@@ -332,7 +340,7 @@ public class CertificatePdfService {
     private PDType0Font loadKoreanFont(PDDocument document) throws IOException {
         List<String> fontPaths = List.of(
                 "C:/Windows/Fonts/malgun.ttf",
-                "C:/Windows/Fonts/gulim.ttc",
+                "C:/Windows/Fonts/gulim.ttf",
                 "/System/Library/Fonts/AppleSDGothicNeo.ttc",
                 "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
                 "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseReviewService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseReviewService.java
@@ -197,8 +197,8 @@ public class CourseReviewService implements CourseReviewUseCase {
     }
 
     private void validateCourse(Long courseId) {
-        if (courseRepository.findByIdAndDeletedFalse(courseId).isEmpty()) {
-            log.warn("[Course Review] 리뷰 처리 실패. 존재하지 않거나 삭제된 강의입니다. courseId={}", courseId);
+        if (courseRepository.findById(courseId).isEmpty()) {
+            log.warn("[Course Review] 후기 처리 실패. 존재하지 않는 강의입니다. courseId={}", courseId);
             throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
         }
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/CourseService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kidmily.algoga_server.global.event.CourseCompletionCompletedEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
+import org.springframework.data.domain.PageImpl;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -77,14 +78,56 @@ public class CourseService implements CourseUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<CourseResult> getCourses(Pageable pageable) {
-        return courseRepository.findAllByDeletedFalse(pageable).map(CourseResult::from);
+    public Page<CourseResult> getCourses(Long countryId, String countryName, Pageable pageable) {
+        List<Long> filteredCountryIds = resolveCountryFilter(countryId, countryName);
+
+        if (filteredCountryIds == null) {
+            return courseRepository.findAllByDeletedFalse(pageable)
+                    .map(CourseResult::from);
+        }
+
+        if (filteredCountryIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        return courseRepository.findAllByDeletedFalseAndCountryIdIn(filteredCountryIds, pageable)
+                .map(CourseResult::from);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CourseResult> getDeletedCourses(Long countryId, String countryName, Pageable pageable) {
+        List<Long> filteredCountryIds = resolveCountryFilter(countryId, countryName);
+
+        if (filteredCountryIds == null) {
+            return courseRepository.findAllByDeletedTrue(pageable)
+                    .map(CourseResult::from);
+        }
+
+        if (filteredCountryIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        return courseRepository.findAllByDeletedTrueAndCountryIdIn(filteredCountryIds, pageable)
+                .map(CourseResult::from);
     }
 
     @Override
     @Transactional(readOnly = true)
     public CourseResult getCourse(Long courseId) {
         return CourseResult.from(findCourse(courseId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CourseResult getDeletedCourse(Long courseId) {
+        Course course = findCourseIncludingDeleted(courseId);
+
+        if (!course.isDeleted()) {
+            throw new LmsException(LmsErrorCode.COURSE_NOT_FOUND);
+        }
+
+        return CourseResult.from(course);
     }
 
     @Override
@@ -184,13 +227,22 @@ public class CourseService implements CourseUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public List<MyCourseResult> getMyCourses(Long userId) {
-        return enrollmentRepository.findByUserId(userId).stream()
+    public Page<MyCourseResult> getMyCourses(Long userId, Pageable pageable) {
+        List<MyCourseResult> courses = enrollmentRepository.findByUserId(userId).stream()
                 .map(enrollment -> enrollment.getCourseId())
                 .distinct()
                 .map(courseId -> createMyCourseResult(userId, courseId))
                 .flatMap(Optional::stream)
                 .toList();
+
+        int start = (int) Math.min(pageable.getOffset(), courses.size());
+        int end = Math.min(start + pageable.getPageSize(), courses.size());
+
+        return new PageImpl<>(
+                courses.subList(start, end),
+                pageable,
+                courses.size()
+        );
     }
 
     @Override
@@ -250,7 +302,8 @@ public class CourseService implements CourseUseCase {
 
     @Override
     public CourseQnaResult createQna(CreateCourseQnaCommand command) {
-        findCourse(command.courseId());
+        validateAccessibleEnrollment(command.userId(), command.courseId());
+        findCourseIncludingDeleted(command.courseId());
 
         CourseQna courseQna = CourseQna.create(
                 command.courseId(),
@@ -265,7 +318,8 @@ public class CourseService implements CourseUseCase {
     @Override
     @Transactional(readOnly = true)
     public List<CourseQnaResult> getQnas(Long courseId) {
-        findCourse(courseId);
+        findCourseIncludingDeleted(courseId);
+
         return courseQnaRepository.findByCourseId(courseId).stream()
                 .map(this::toCourseQnaResult)
                 .toList();
@@ -274,7 +328,7 @@ public class CourseService implements CourseUseCase {
     @Override
     @Transactional(readOnly = true)
     public CourseQnaDetailResult getQnaDetail(Long courseId, Long qnaId) {
-        findCourse(courseId);
+        findCourseIncludingDeleted(courseId);
 
         CourseQna qna = findQna(courseId, qnaId);
         List<CourseQnaComment> comments = courseQnaCommentRepository.findByQnaId(qnaId);
@@ -294,13 +348,15 @@ public class CourseService implements CourseUseCase {
                 qna.getStatus(),
                 qna.getCreatedAt(),
                 qna.getAnsweredAt(),
-                comments.stream().map(this::toCourseQnaCommentResult).toList()
+                comments.stream()
+                        .map(this::toCourseQnaCommentResult)
+                        .toList()
         );
     }
 
     @Override
     public CourseQnaResult answerQna(AnswerCourseQnaCommand command) {
-        findCourse(command.courseId());
+        findCourseIncludingDeleted(command.courseId());
 
         CourseQna qna = findQna(command.courseId(), command.qnaId());
 
@@ -309,15 +365,19 @@ public class CourseService implements CourseUseCase {
         }
 
         CourseQna answeredQna = qna.answer(command.managerId(), command.answer());
+
         return toCourseQnaResult(courseQnaRepository.save(answeredQna));
     }
 
     @Override
     public CourseQnaCommentResult createComment(CreateCourseQnaCommentCommand command) {
-        findCourse(command.courseId());
+        findCourseIncludingDeleted(command.courseId());
         findQna(command.courseId(), command.qnaId());
-
         validateParentComment(command.qnaId(), command.parentCommentId());
+
+        if ("USER".equals(command.writerType())) {
+            validateAccessibleEnrollment(command.writerId(), command.courseId());
+        }
 
         CourseQnaComment comment = "MANAGER".equals(command.writerType())
                 ? CourseQnaComment.createManagerComment(
@@ -440,6 +500,40 @@ public class CourseService implements CourseUseCase {
     private void validateCountry(Long countryId) {
         mapRepository.findActiveCountryById(countryId)
                 .orElseThrow(() -> new LmsException(LmsErrorCode.COUNTRY_NOT_FOUND));
+    }
+
+    private List<Long> resolveCountryFilter(Long countryId, String countryName) {
+        boolean hasCountryId = countryId != null;
+        boolean hasCountryName = countryName != null && !countryName.isBlank();
+
+        if (!hasCountryId && !hasCountryName) {
+            return null;
+        }
+
+        if (hasCountryId) {
+            validateCountry(countryId);
+        }
+
+        List<Long> countryIdsByName = hasCountryName
+                ? mapRepository.findActiveCountries()
+                .stream()
+                .filter(country -> country.getName() != null)
+                .filter(country -> country.getName().contains(countryName.trim()))
+                .map(Country::getId)
+                .toList()
+                : null;
+
+        if (hasCountryId && hasCountryName) {
+            return countryIdsByName.stream()
+                    .filter(id -> id.equals(countryId))
+                    .toList();
+        }
+
+        if (hasCountryId) {
+            return List.of(countryId);
+        }
+
+        return countryIdsByName;
     }
 
     private void validateCourseLevel(String level) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/DiagnosisService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/DiagnosisService.java
@@ -23,6 +23,10 @@ import com.kidmily.algoga_server.lms.exception.LmsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.kidmily.algoga_server.lms.application.result.DiagnosisResultSummary;
+import com.kidmily.algoga_server.lms.domain.model.Country;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -178,6 +182,17 @@ public class DiagnosisService implements DiagnosisUseCase {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<DiagnosisResultSummary> getMyResults(Long userId, Pageable pageable) {
+        return diagnosisResultRepository.findByUserId(userId, pageable)
+                .map(result -> DiagnosisResultSummary.from(
+                        result,
+                        findCountryName(result.countryId()),
+                        toLevelName(result.level())
+                ));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<AdminDiagnosisResult> getAdminResults(Long userId, Long countryId) {
         if (countryId != null) {
             validateCountry(countryId);
@@ -228,6 +243,7 @@ public class DiagnosisService implements DiagnosisUseCase {
         return new DiagnosisResultView(
                 result.id(),
                 result.countryId(),
+                findCountryName(result.countryId()),
                 result.correctCount(),
                 result.totalCount(),
                 result.score(),
@@ -243,6 +259,12 @@ public class DiagnosisService implements DiagnosisUseCase {
         if (mapRepository.findActiveCountryById(countryId).isEmpty()) {
             throw new LmsException(LmsErrorCode.COUNTRY_NOT_FOUND);
         }
+    }
+
+    private String findCountryName(Long countryId) {
+        return mapRepository.findActiveCountryById(countryId)
+                .map(Country::getName)
+                .orElse(null);
     }
 
     private void validateDiagnosisQuestion(Integer correctOption, Integer questionOrder) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/LearningProgressService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/LearningProgressService.java
@@ -37,6 +37,9 @@ public class LearningProgressService implements LearningProgressUseCase {
 
     @Override
     public LearningProgressResult updateProgress(UpdateLearningProgressCommand command) {
+        log.info("[Learning Progress Command] 챕터 진도 업데이트 요청. userId={}, courseId={}, chapterId={}, watchedSeconds={}",
+                command.userId(), command.courseId(), command.chapterId(), command.watchedSeconds());
+
         validateWatchedSeconds(command.watchedSeconds());
 
         Course course = courseRepository.findById(command.courseId())
@@ -47,7 +50,11 @@ public class LearningProgressService implements LearningProgressUseCase {
         Chapter chapter = chapterRepository.findByIdAndCourseId(
                 command.chapterId(),
                 command.courseId()
-        ).orElseThrow(() -> new LmsException(LmsErrorCode.CHAPTER_NOT_FOUND));
+        ).orElseThrow(() -> {
+            log.warn("[Learning Progress Command] 진도 업데이트 실패. 존재하지 않거나 삭제된 챕터입니다. courseId={}, chapterId={}",
+                    command.courseId(), command.chapterId());
+            return new LmsException(LmsErrorCode.CHAPTER_NOT_FOUND);
+        });
 
         validatePreviousChapterCompleted(command.userId(), command.courseId(), chapter);
 
@@ -67,12 +74,35 @@ public class LearningProgressService implements LearningProgressUseCase {
 
         LearningProgress savedProgress = learningProgressRepository.save(learningProgress);
 
-        CourseClassroomResult classroom = createClassroomResult(
-                command.userId(),
-                course
-        );
+        List<Chapter> chapters = chapterRepository.findByCourseId(command.courseId())
+                .stream()
+                .sorted(Comparator.comparingInt(Chapter::getChapterOrder))
+                .toList();
 
-        return LearningProgressResult.from(savedProgress, classroom);
+        Long nextChapterId = findNextChapterId(chapters, chapter);
+        boolean nextChapterUnlocked = savedProgress.isCompleted() && nextChapterId != null;
+        int courseProgressRate = calculateCourseProgressRate(command.userId(), chapters);
+        boolean quizAvailable = isQuizAvailable(command.userId(), chapters);
+        CourseClassroomResult classroom = createClassroomResult(command.userId(), course);
+
+        log.info("[Learning Progress Command] 챕터 진도 업데이트 완료. userId={}, courseId={}, chapterId={}, progressRate={}, completed={}, nextChapterId={}, nextChapterUnlocked={}, quizAvailable={}",
+                savedProgress.getUserId(),
+                savedProgress.getCourseId(),
+                savedProgress.getChapterId(),
+                savedProgress.getProgressRate(),
+                savedProgress.isCompleted(),
+                nextChapterId,
+                nextChapterUnlocked,
+                quizAvailable);
+
+        return LearningProgressResult.of(
+                savedProgress,
+                nextChapterId,
+                nextChapterUnlocked,
+                courseProgressRate,
+                quizAvailable,
+                classroom
+        );
     }
 
     private CourseClassroomResult createClassroomResult(Long userId, Course course) {
@@ -132,12 +162,16 @@ public class LearningProgressService implements LearningProgressUseCase {
                 .orElse(false);
 
         if (!accessible) {
+            log.warn("[Learning Progress Command] 진도 업데이트 실패. 수강 등록되지 않은 강의입니다. userId={}, courseId={}",
+                    userId, courseId);
             throw new LmsException(LmsErrorCode.NOT_ENROLLED);
         }
     }
 
     private void validateWatchedSeconds(int watchedSeconds) {
         if (watchedSeconds < 0) {
+            log.warn("[Learning Progress Command] 진도 업데이트 실패. 시청 시간은 음수일 수 없습니다. watchedSeconds={}",
+                    watchedSeconds);
             throw new LmsException(LmsErrorCode.INVALID_PROGRESS);
         }
     }
@@ -160,7 +194,47 @@ public class LearningProgressService implements LearningProgressUseCase {
         );
 
         if (!previousCompleted) {
+            log.warn("[Learning Progress Command] 진도 업데이트 실패. 이전 챕터 미완료 상태입니다. userId={}, courseId={}, currentChapterId={}, previousChapterId={}",
+                    userId, courseId, currentChapter.getId(), previousChapter.getId());
             throw new LmsException(LmsErrorCode.CHAPTER_LOCKED);
         }
+    }
+
+    private Long findNextChapterId(List<Chapter> chapters, Chapter currentChapter) {
+        return chapters.stream()
+                .filter(chapter -> chapter.getChapterOrder() > currentChapter.getChapterOrder())
+                .min(Comparator.comparingInt(Chapter::getChapterOrder))
+                .map(Chapter::getId)
+                .orElse(null);
+    }
+
+    private int calculateCourseProgressRate(Long userId, List<Chapter> chapters) {
+        if (chapters.isEmpty()) {
+            return 0;
+        }
+
+        int totalProgressRate = 0;
+
+        for (Chapter chapter : chapters) {
+            int chapterProgressRate = learningProgressRepository.findByUserIdAndChapterId(userId, chapter.getId())
+                    .map(LearningProgress::getProgressRate)
+                    .orElse(0);
+
+            totalProgressRate += chapterProgressRate;
+        }
+
+        return Math.min(100, (int) Math.floor(totalProgressRate / (double) chapters.size()));
+    }
+
+    private boolean isQuizAvailable(Long userId, List<Chapter> chapters) {
+        if (chapters.isEmpty()) {
+            return false;
+        }
+
+        return chapters.stream()
+                .allMatch(chapter -> learningProgressRepository.existsCompletedByUserIdAndChapterId(
+                        userId,
+                        chapter.getId()
+                ));
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/service/QuizService.java
@@ -7,6 +7,7 @@ import com.kidmily.algoga_server.lms.application.command.SubmitQuizCommand;
 import com.kidmily.algoga_server.lms.application.command.UpdateQuizCommand;
 import com.kidmily.algoga_server.lms.application.result.CourseCompletionResult;
 import com.kidmily.algoga_server.lms.application.result.QuizResult;
+import com.kidmily.algoga_server.lms.application.result.QuizSubmissionResult;
 import com.kidmily.algoga_server.lms.application.result.QuizSubmitResult;
 import com.kidmily.algoga_server.lms.application.result.WrongQuizAnswerResult;
 import com.kidmily.algoga_server.lms.application.usecase.QuizUseCase;
@@ -29,7 +30,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -51,6 +57,7 @@ public class QuizService implements QuizUseCase {
     @Transactional(readOnly = true)
     public List<QuizResult> getQuizzes(Long courseId) {
         validateActiveCourse(courseId);
+
         return quizRepository.findByCourseId(courseId).stream()
                 .map(QuizResult::from)
                 .toList();
@@ -184,6 +191,18 @@ public class QuizService implements QuizUseCase {
                 completion,
                 wrongAnswers
         );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public QuizSubmissionResult getMyQuizSubmission(Long userId, Long courseId) {
+        validateEnrollment(userId, courseId);
+        validateCourseExists(courseId);
+
+        QuizSubmission submission = quizSubmissionRepository.findByUserIdAndCourseId(userId, courseId)
+                .orElseThrow(() -> new LmsException(LmsErrorCode.QUIZ_NOT_SUBMITTED));
+
+        return QuizSubmissionResult.from(submission);
     }
 
     private CourseCompletionResult completeCourseIfNeeded(Long userId, Long courseId) {

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/CourseUseCase.java
@@ -17,9 +17,13 @@ public interface CourseUseCase {
 
     Long createCourse(CreateCourseCommand command);
 
-    Page<CourseResult> getCourses(Pageable pageable);
+    Page<CourseResult> getCourses(Long countryId, String countryName, Pageable pageable);
+
+    Page<CourseResult> getDeletedCourses(Long countryId, String countryName, Pageable pageable);
 
     CourseResult getCourse(Long courseId);
+
+    CourseResult getDeletedCourse(Long courseId);
 
     CourseResult updateCourse(Long courseId, UpdateCourseCommand command);
 
@@ -29,7 +33,7 @@ public interface CourseUseCase {
 
     List<CourseStudentResult> getCourseStudents(Long courseId);
 
-    List<MyCourseResult> getMyCourses(Long userId);
+    Page<MyCourseResult> getMyCourses(Long userId, Pageable pageable);
 
     CourseClassroomResult getCourseClassroom(Long userId, Long courseId);
 

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/DiagnosisUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/DiagnosisUseCase.java
@@ -4,8 +4,11 @@ import com.kidmily.algoga_server.lms.application.command.CreateDiagnosisQuestion
 import com.kidmily.algoga_server.lms.application.command.SubmitDiagnosisCommand;
 import com.kidmily.algoga_server.lms.application.command.UpdateDiagnosisQuestionCommand;
 import com.kidmily.algoga_server.lms.application.result.AdminDiagnosisResult;
-import com.kidmily.algoga_server.lms.application.result.DiagnosisResultView;
 import com.kidmily.algoga_server.lms.application.result.DiagnosisQuestionResult;
+import com.kidmily.algoga_server.lms.application.result.DiagnosisResultSummary;
+import com.kidmily.algoga_server.lms.application.result.DiagnosisResultView;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -22,6 +25,8 @@ public interface DiagnosisUseCase {
     DiagnosisResultView submitResult(SubmitDiagnosisCommand command);
 
     DiagnosisResultView getLatestResult(Long userId);
+
+    Page<DiagnosisResultSummary> getMyResults(Long userId, Pageable pageable);
 
     List<AdminDiagnosisResult> getAdminResults(Long userId, Long countryId);
 

--- a/src/main/java/com/kidmily/algoga_server/lms/application/usecase/QuizUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/application/usecase/QuizUseCase.java
@@ -4,6 +4,7 @@ import com.kidmily.algoga_server.lms.application.command.CreateQuizCommand;
 import com.kidmily.algoga_server.lms.application.command.SubmitQuizCommand;
 import com.kidmily.algoga_server.lms.application.command.UpdateQuizCommand;
 import com.kidmily.algoga_server.lms.application.result.QuizResult;
+import com.kidmily.algoga_server.lms.application.result.QuizSubmissionResult;
 import com.kidmily.algoga_server.lms.application.result.QuizSubmitResult;
 
 import java.util.List;
@@ -21,4 +22,6 @@ public interface QuizUseCase {
     void deleteQuiz(Long courseId, Long quizId);
 
     QuizSubmitResult submitQuiz(SubmitQuizCommand command);
+
+    QuizSubmissionResult getMyQuizSubmission(Long userId, Long courseId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/CourseRepository.java
@@ -19,6 +19,12 @@ public interface CourseRepository {
 
     Page<Course> findAllByDeletedFalse(Pageable pageable);
 
+    Page<Course> findAllByDeletedFalseAndCountryIdIn(List<Long> countryIds, Pageable pageable);
+
+    Page<Course> findAllByDeletedTrue(Pageable pageable);
+
+    Page<Course> findAllByDeletedTrueAndCountryIdIn(List<Long> countryIds, Pageable pageable);
+
     Optional<Course> updateBasicInfo(
             Long courseId,
             String title,

--- a/src/main/java/com/kidmily/algoga_server/lms/domain/repository/DiagnosisResultRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/domain/repository/DiagnosisResultRepository.java
@@ -1,6 +1,8 @@
 package com.kidmily.algoga_server.lms.domain.repository;
 
 import com.kidmily.algoga_server.lms.domain.model.DiagnosisResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +12,8 @@ public interface DiagnosisResultRepository {
     DiagnosisResult save(DiagnosisResult diagnosisResult);
 
     Optional<DiagnosisResult> findLatestByUserId(Long userId);
+
+    Page<DiagnosisResult> findByUserId(Long userId, Pageable pageable);
 
     List<DiagnosisResult> findForAdmin(Long userId, Long countryId);
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/exception/LmsErrorCode.java
@@ -26,7 +26,7 @@ public enum LmsErrorCode implements BaseErrorCode {
     QUIZ_LOCKED(HttpStatus.BAD_REQUEST, "LMS_015", "모든 챕터를 완료해야 퀴즈를 풀 수 있습니다."),
     INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST, "LMS_016", "퀴즈 제출 답안이 올바르지 않습니다."),
     COURSE_ALREADY_COMPLETED(HttpStatus.CONFLICT, "LMS_017", "이미 수강 완료한 강의입니다."),
-    QUIZ_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "LMS_018", "퀴즈 제출 후 강의를 완료할 수 있습니다."),
+    QUIZ_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "LMS_018", "퀴즈 제출 내역을 찾을 수 없습니다."),
     COURSE_COMPLETION_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_019", "강의 이수 내역을 찾을 수 없습니다."),
 
     QNA_NOT_FOUND(HttpStatus.NOT_FOUND, "LMS_023", "해당 Q&A를 찾을 수 없습니다."),

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/CourseRepositoryAdapter.java
@@ -57,6 +57,24 @@ public class CourseRepositoryAdapter implements CourseRepository {
     }
 
     @Override
+    public Page<Course> findAllByDeletedFalseAndCountryIdIn(List<Long> countryIds, Pageable pageable) {
+        return springDataCourseRepository.findByDeletedFalseAndCountryIdInOrderByIdDesc(countryIds, pageable)
+                .map(courseMapper::toDomain);
+    }
+
+    @Override
+    public Page<Course> findAllByDeletedTrue(Pageable pageable) {
+        return springDataCourseRepository.findByDeletedTrueOrderByIdDesc(pageable)
+                .map(courseMapper::toDomain);
+    }
+
+    @Override
+    public Page<Course> findAllByDeletedTrueAndCountryIdIn(List<Long> countryIds, Pageable pageable) {
+        return springDataCourseRepository.findByDeletedTrueAndCountryIdInOrderByIdDesc(countryIds, pageable)
+                .map(courseMapper::toDomain);
+    }
+
+    @Override
     public Optional<Course> updateBasicInfo(
             Long courseId,
             String title,

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/DiagnosisResultRepositoryAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/adapter/DiagnosisResultRepositoryAdapter.java
@@ -5,6 +5,8 @@ import com.kidmily.algoga_server.lms.domain.repository.DiagnosisResultRepository
 import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.DiagnosisResultJpaEntity;
 import com.kidmily.algoga_server.lms.infrastructure.persistence.repository.SpringDataDiagnosisResultRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -33,6 +35,12 @@ public class DiagnosisResultRepositoryAdapter implements DiagnosisResultReposito
     @Override
     public Optional<DiagnosisResult> findLatestByUserId(Long userId) {
         return springDataDiagnosisResultRepository.findFirstByUserIdOrderByCreatedAtDesc(userId)
+                .map(this::toDomain);
+    }
+
+    @Override
+    public Page<DiagnosisResult> findByUserId(Long userId, Pageable pageable) {
+        return springDataDiagnosisResultRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable)
                 .map(this::toDomain);
     }
 

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataCourseRepository.java
@@ -16,6 +16,18 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
 
     Page<CourseJpaEntity> findByDeletedFalseOrderByIdDesc(Pageable pageable);
 
+    Page<CourseJpaEntity> findByDeletedFalseAndCountryIdInOrderByIdDesc(
+            List<Long> countryIds,
+            Pageable pageable
+    );
+
+    Page<CourseJpaEntity> findByDeletedTrueOrderByIdDesc(Pageable pageable);
+
+    Page<CourseJpaEntity> findByDeletedTrueAndCountryIdInOrderByIdDesc(
+            List<Long> countryIds,
+            Pageable pageable
+    );
+
     List<CourseJpaEntity> findByCountryIdAndStatusAndDeletedFalseOrderByIdDesc(
             Long countryId,
             String status

--- a/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataDiagnosisResultRepository.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/infrastructure/persistence/repository/SpringDataDiagnosisResultRepository.java
@@ -1,6 +1,8 @@
 package com.kidmily.algoga_server.lms.infrastructure.persistence.repository;
 
 import com.kidmily.algoga_server.lms.infrastructure.persistence.entity.DiagnosisResultJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,6 +11,8 @@ import java.util.Optional;
 public interface SpringDataDiagnosisResultRepository extends JpaRepository<DiagnosisResultJpaEntity, Long> {
 
     Optional<DiagnosisResultJpaEntity> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Page<DiagnosisResultJpaEntity> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     List<DiagnosisResultJpaEntity> findByUserIdOrderByCreatedAtDesc(Long userId);
 

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CertificateController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CertificateController.java
@@ -6,8 +6,12 @@ import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.presentation.support.CurrentUserIdResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -28,22 +32,31 @@ public class CertificateController {
     @Operation(
             summary = "수료증 PDF 발급",
             description = """
-                    강의 이수 완료 내역이 있는 사용자에게 수료증 PDF를 발급합니다.
-                    PDF에는 사용자명, 강의명, 수료일, 수료 코드가 포함됩니다.
-                    """
+                강의 이수 완료 내역이 있는 사용자에게 수료증 PDF를 발급합니다.
+                PDF에는 사용자명, 강의명, 수료일, 수료 코드가 포함됩니다.
+                """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "수료증 PDF 파일",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_PDF_VALUE,
+                    schema = @Schema(type = "string", format = "binary")
+            )
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "LOGIN_REQUIRED",
             "COURSE_NOT_FOUND",
             "COURSE_COMPLETION_NOT_FOUND"
     })
-    @GetMapping
+    @GetMapping(produces = MediaType.APPLICATION_PDF_VALUE)
     public ResponseEntity<byte[]> downloadCertificate(
-            @Parameter(description = "강의 ID", example = "3")
+            @Parameter(description = "강의 ID", example = "53")
             @PathVariable Long courseId,
 
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
         String userName = CurrentUserIdResolver.resolveNameNullable(userDetails);
 
         byte[] pdfBytes = certificatePdfService.generateCertificatePdf(
@@ -54,12 +67,14 @@ public class CertificateController {
 
         String filename = "certificate-course-" + courseId + ".pdf";
 
-        ContentDisposition contentDisposition = ContentDisposition.attachment()
+        ContentDisposition contentDisposition = ContentDisposition.inline()
                 .filename(filename, StandardCharsets.UTF_8)
                 .build();
 
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
+                .contentLength(pdfBytes.length)
+                .cacheControl(CacheControl.noCache())
                 .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
                 .body(pdfBytes);
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseCompletionController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseCompletionController.java
@@ -44,7 +44,7 @@ public class CourseCompletionController {
 
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
 
         CompleteCourseCommand command = new CompleteCourseCommand(
                 currentUserId,

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseReviewController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/CourseReviewController.java
@@ -51,7 +51,7 @@ public class CourseReviewController {
 
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
 
         CreateCourseReviewCommand command = new CreateCourseReviewCommand(
                 courseId,

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/DiagnosisController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/DiagnosisController.java
@@ -20,6 +20,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import com.kidmily.algoga_server.global.common.api.response.PageResponse;
+import com.kidmily.algoga_server.lms.presentation.response.DiagnosisResultSummaryResponse;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -132,6 +137,29 @@ public class DiagnosisController {
                         "MY_DIAGNOSIS_RESULT_FOUND",
                         "내 최신 진단평가 결과 조회에 성공했습니다.",
                         DiagnosisResultResponse.from(diagnosisUseCase.getLatestResult(currentUserId))
+                )
+        );
+    }
+
+    @Operation(summary = "내 진단평가 결과 목록 조회")
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "DIAGNOSIS_LOGIN_REQUIRED"
+    })
+    @GetMapping("/me/results")
+    public ResponseEntity<ApiResponse<PageResponse<DiagnosisResultSummaryResponse>>> getMyDiagnosisResults(
+            @AuthenticationPrincipal Object userDetails,
+            @ParameterObject Pageable pageable
+    ) {
+        Long currentUserId = CurrentUserIdResolver.resolveRequired(userDetails);
+
+        Page<DiagnosisResultSummaryResponse> response = diagnosisUseCase.getMyResults(currentUserId, pageable)
+                .map(DiagnosisResultSummaryResponse::from);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "MY_DIAGNOSIS_RESULTS_FOUND",
+                        "내 진단평가 결과 목록 조회에 성공했습니다.",
+                        PageResponse.from(response)
                 )
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/LearningProgressController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/LearningProgressController.java
@@ -53,7 +53,7 @@ public class LearningProgressController {
 
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
 
         UpdateLearningProgressCommand command = new UpdateLearningProgressCommand(
                 currentUserId,

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/MyCourseController.java
@@ -1,20 +1,22 @@
 package com.kidmily.algoga_server.lms.presentation.api;
 
+import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.global.common.api.response.ApiResponse;
+import com.kidmily.algoga_server.global.common.api.response.PageResponse;
 import com.kidmily.algoga_server.lms.application.usecase.CourseUseCase;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
-import com.kidmily.algoga_server.global.annotation.swagger.ApiErrorCodeExample;
 import com.kidmily.algoga_server.lms.presentation.response.CourseClassroomResponse;
 import com.kidmily.algoga_server.lms.presentation.response.MyCourseResponse;
 import com.kidmily.algoga_server.lms.presentation.support.CurrentUserIdResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name = "마이페이지 수강 내역", description = "마이페이지 수강 강의 조회 API")
 @RestController
@@ -26,34 +28,30 @@ public class MyCourseController {
 
     @Operation(
             summary = "내 수강 강의 목록 조회",
-            description = """
-                    로그인한 사용자가 진도율을 기록한 강의 목록을 조회합니다.
-                    결제 기능은 제외하고, learning_progresses 기록 기준으로 수강 내역을 구성합니다.
-                    """
+            description = "로그인한 사용자의 수강 강의 목록을 페이지 단위로 조회합니다."
     )
     @GetMapping
-    public ResponseEntity<ApiResponse<List<MyCourseResponse>>> getMyCourses(
-            @AuthenticationPrincipal Object userDetails
+    public ResponseEntity<ApiResponse<PageResponse<MyCourseResponse>>> getMyCourses(
+            @AuthenticationPrincipal Object userDetails,
+            @ParameterObject Pageable pageable
     ) {
         Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
 
-        List<MyCourseResponse> response = courseUseCase.getMyCourses(currentUserId)
-                .stream()
-                .map(MyCourseResponse::from)
-                .toList();
+        Page<MyCourseResponse> response = courseUseCase.getMyCourses(currentUserId, pageable)
+                .map(MyCourseResponse::from);
 
         return ResponseEntity.ok(
                 ApiResponse.success(
                         "MY_COURSES_FOUND",
                         "내 수강 강의 목록 조회에 성공했습니다.",
-                        response
+                        PageResponse.from(response)
                 )
         );
     }
 
     @Operation(
-            summary = "수강생 강의실 상세 조회",
-            description = "수강 중인 강의의 챕터 영상과 진도, 잠금 상태 및 퀴즈 응시 가능 여부를 조회합니다."
+            summary = "수강 중인 강의 상세 조회",
+            description = "수강 중인 강의의 챕터 영상, 진도, 잠금 상태 및 퀴즈 응시 가능 여부를 조회합니다."
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND", "NOT_ENROLLED"})
     @GetMapping("/{courseId}")
@@ -61,13 +59,13 @@ public class MyCourseController {
             @PathVariable Long courseId,
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
         var result = courseUseCase.getCourseClassroom(currentUserId, courseId);
 
         return ResponseEntity.ok(
                 ApiResponse.success(
                         "COURSE_CLASSROOM_FOUND",
-                        "수강생 강의실 조회에 성공했습니다.",
+                        "수강 강의 상세 조회에 성공했습니다.",
                         CourseClassroomResponse.from(result)
                 )
         );

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/UserQuizController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/UserQuizController.java
@@ -9,6 +9,7 @@ import com.kidmily.algoga_server.lms.application.result.QuizSubmitResult;
 import com.kidmily.algoga_server.lms.application.usecase.QuizUseCase;
 import com.kidmily.algoga_server.lms.exception.LmsErrorCode;
 import com.kidmily.algoga_server.lms.presentation.request.SubmitQuizRequest;
+import com.kidmily.algoga_server.lms.presentation.response.QuizSubmissionResponse;
 import com.kidmily.algoga_server.lms.presentation.response.QuizSubmitResponse;
 import com.kidmily.algoga_server.lms.presentation.response.UserQuizResponse;
 import com.kidmily.algoga_server.lms.presentation.support.CurrentUserIdResolver;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "퀴즈 풀이", description = "사용자 퀴즈 조회 및 제출/채점 API")
+@Tag(name = "퀴즈", description = "사용자 퀴즈 조회, 제출, 결과 조회 API")
 @RestController
 @RequestMapping("/api/v1/courses/{courseId}/quiz")
 @RequiredArgsConstructor
@@ -34,23 +35,24 @@ public class UserQuizController {
     @Operation(
             summary = "사용자 퀴즈 조회",
             description = """
-                    사용자가 강의의 모든 챕터를 완료한 뒤 퀴즈 목록을 조회합니다.
+                    사용자가 강의의 모든 챕터를 완료하면 퀴즈 목록을 조회합니다.
                     정답 번호와 해설은 응답에 포함하지 않습니다.
                     """
     )
     @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
             "COURSE_NOT_FOUND",
             "QUIZ_NOT_FOUND",
-            "QUIZ_LOCKED"
+            "QUIZ_LOCKED",
+            "NOT_ENROLLED"
     })
     @GetMapping
     public ResponseEntity<ApiResponse<List<UserQuizResponse>>> getQuizzes(
-            @Parameter(description = "강의 ID", example = "3")
+            @Parameter(description = "강의 ID", example = "53")
             @PathVariable Long courseId,
 
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
 
         List<UserQuizResponse> response = quizUseCase.getQuizzes(
                         currentUserId,
@@ -81,18 +83,19 @@ public class UserQuizController {
             "COURSE_NOT_FOUND",
             "QUIZ_NOT_FOUND",
             "QUIZ_LOCKED",
-            "INVALID_QUIZ_SUBMISSION"
+            "INVALID_QUIZ_SUBMISSION",
+            "NOT_ENROLLED"
     })
     @PostMapping("/submit")
     public ResponseEntity<ApiResponse<QuizSubmitResponse>> submitQuiz(
-            @Parameter(description = "강의 ID", example = "3")
+            @Parameter(description = "강의 ID", example = "53")
             @PathVariable Long courseId,
 
             @Valid @RequestBody SubmitQuizRequest request,
 
             @AuthenticationPrincipal Object userDetails
     ) {
-        Long currentUserId = CurrentUserIdResolver.resolveNullable(userDetails);
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
 
         List<SubmitQuizAnswerCommand> answers = request.answers()
                 .stream()
@@ -115,6 +118,40 @@ public class UserQuizController {
                         "QUIZ_SUBMITTED",
                         "퀴즈 제출 및 채점에 성공했습니다.",
                         QuizSubmitResponse.from(result)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "내 퀴즈 제출 결과 조회",
+            description = """
+                    로그인한 사용자의 해당 강의 퀴즈 제출 결과를 조회합니다.
+                    현재 저장 구조상 전체 문제 수, 정답 수, 점수, 제출 일시를 반환합니다.
+                    """
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {
+            "COURSE_NOT_FOUND",
+            "QUIZ_NOT_SUBMITTED",
+            "NOT_ENROLLED"
+    })
+    @GetMapping("/result")
+    public ResponseEntity<ApiResponse<QuizSubmissionResponse>> getMyQuizSubmission(
+            @Parameter(description = "강의 ID", example = "53")
+            @PathVariable Long courseId,
+
+            @AuthenticationPrincipal Object userDetails
+    ) {
+        Long currentUserId = CurrentUserIdResolver.resolveLoginRequired(userDetails);
+
+        QuizSubmissionResponse response = QuizSubmissionResponse.from(
+                quizUseCase.getMyQuizSubmission(currentUserId, courseId)
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "MY_QUIZ_SUBMISSION_FOUND",
+                        "내 퀴즈 제출 결과 조회에 성공했습니다.",
+                        response
                 )
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/api/admin/AdminCourseController.java
@@ -93,14 +93,23 @@ public class AdminCourseController {
 
     @Operation(
             summary = "어드민 강의 목록 조회",
-            description = "삭제되지 않은 강의 목록을 최신순으로 조회합니다."
+            description = """
+                삭제되지 않은 강의 목록을 최신순으로 조회합니다.
+                countryId 또는 countryName으로 국가 필터링할 수 있습니다.
+                """
     )
     @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<AdminCourseResponse>>> getCourses(
+            @Parameter(description = "국가 ID", example = "1")
+            @RequestParam(required = false) Long countryId,
+
+            @Parameter(description = "국가명 검색어", example = "일본")
+            @RequestParam(required = false) String countryName,
+
             @ParameterObject Pageable pageable
     ) {
-        Page<AdminCourseResponse> response = courseUseCase.getCourses(pageable)
+        Page<AdminCourseResponse> response = courseUseCase.getCourses(countryId, countryName, pageable)
                 .map(AdminCourseResponse::from);
 
         return ResponseEntity.ok(
@@ -108,6 +117,58 @@ public class AdminCourseController {
                         "ADMIN_COURSES_FOUND",
                         "어드민 강의 목록 조회에 성공했습니다.",
                         PageResponse.from(response)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "어드민 삭제 강의 목록 조회",
+            description = """
+                콘텐츠 매니저가 삭제 처리한 강의 목록을 조회합니다.
+                Soft Delete 처리된 강의만 조회하며, countryId 또는 countryName으로 국가 필터링할 수 있습니다.
+                """
+    )
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @GetMapping("/deleted")
+    public ResponseEntity<ApiResponse<PageResponse<AdminCourseResponse>>> getDeletedCourses(
+            @Parameter(description = "국가 ID", example = "1")
+            @RequestParam(required = false) Long countryId,
+
+            @Parameter(description = "국가명 검색어", example = "일본")
+            @RequestParam(required = false) String countryName,
+
+            @ParameterObject Pageable pageable
+    ) {
+        Page<AdminCourseResponse> response = courseUseCase.getDeletedCourses(countryId, countryName, pageable)
+                .map(AdminCourseResponse::from);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_DELETED_COURSES_FOUND",
+                        "어드민 삭제 강의 목록 조회에 성공했습니다.",
+                        PageResponse.from(response)
+                )
+        );
+    }
+
+    @Operation(
+            summary = "어드민 삭제 강의 상세 조회",
+            description = "Soft Delete 처리된 강의의 상세 정보를 조회합니다."
+    )
+    @ApiErrorCodeExample(domain = LmsErrorCode.class, value = {"COURSE_NOT_FOUND"})
+    @PreAuthorize("hasAnyAuthority('CONTENT_MANAGER', 'ROLE_CONTENT_MANAGER', 'SUPER_ADMIN', 'ROLE_SUPER_ADMIN')")
+    @GetMapping("/deleted/{courseId}")
+    public ResponseEntity<ApiResponse<AdminCourseResponse>> getDeletedCourse(
+            @Parameter(description = "강의 ID", example = "1")
+            @PathVariable Long courseId
+    ) {
+        var course = courseUseCase.getDeletedCourse(courseId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        "ADMIN_DELETED_COURSE_FOUND",
+                        "어드민 삭제 강의 상세 조회에 성공했습니다.",
+                        AdminCourseResponse.from(course)
                 )
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/AdminCourseResponse.java
@@ -34,14 +34,17 @@ public record AdminCourseResponse(
         @Schema(description = "원본 파일명을 포함한 강의 자료 목록")
         List<CourseFileResponse> files,
 
-        @Schema(description = "강의 난이도 코드", example = "BEGINNER")
+        @Schema(description = "강의 레벨 코드", example = "BEGINNER")
         String level,
 
-        @Schema(description = "강의 난이도 이름", example = "초급")
+        @Schema(description = "강의 레벨 이름", example = "초급")
         String levelName,
 
         @Schema(description = "강의 상태", example = "PUBLISHED")
-        String status
+        String status,
+
+        @Schema(description = "삭제 여부", example = "true")
+        boolean deleted
 ) {
     public static AdminCourseResponse from(CourseResult course) {
         return new AdminCourseResponse(
@@ -56,7 +59,8 @@ public record AdminCourseResponse(
                 course.files().stream().map(CourseFileResponse::from).toList(),
                 course.level(),
                 course.levelName(),
-                course.status()
+                course.status(),
+                course.deleted()
         );
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/DiagnosisResultResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/DiagnosisResultResponse.java
@@ -15,6 +15,9 @@ public record DiagnosisResultResponse(
         @Schema(description = "사용자가 선택한 국가 ID", example = "1")
         Long countryId,
 
+        @Schema(description = "국가명", example = "일본")
+        String countryName,
+
         @Schema(description = "정답 개수", example = "3")
         Integer correctCount,
 
@@ -43,6 +46,7 @@ public record DiagnosisResultResponse(
         return new DiagnosisResultResponse(
                 result.resultId(),
                 result.countryId(),
+                result.countryName(),
                 result.correctCount(),
                 result.totalCount(),
                 result.score(),

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/DiagnosisResultSummaryResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/DiagnosisResultSummaryResponse.java
@@ -1,0 +1,43 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.DiagnosisResultSummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "마이페이지 진단평가 결과 목록 응답")
+public record DiagnosisResultSummaryResponse(
+
+        @Schema(description = "진단평가 결과 ID", example = "1")
+        Long resultId,
+
+        @Schema(description = "국가 ID", example = "1")
+        Long countryId,
+
+        @Schema(description = "국가명", example = "일본")
+        String countryName,
+
+        @Schema(description = "진단평가 제출 일시", example = "2026-06-24T12:30:00")
+        LocalDateTime submittedAt,
+
+        @Schema(description = "진단 레벨 코드", example = "BEGINNER")
+        String level,
+
+        @Schema(description = "진단 레벨명", example = "초급")
+        String levelName,
+
+        @Schema(description = "진단 점수", example = "60")
+        Integer score
+) {
+    public static DiagnosisResultSummaryResponse from(DiagnosisResultSummary result) {
+        return new DiagnosisResultSummaryResponse(
+                result.resultId(),
+                result.countryId(),
+                result.countryName(),
+                result.submittedAt(),
+                result.level(),
+                result.levelName(),
+                result.score()
+        );
+    }
+}

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/LearningProgressResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/LearningProgressResponse.java
@@ -20,11 +20,23 @@ public record LearningProgressResponse(
         @Schema(description = "시청 시간. 초 단위", example = "600")
         int watchedSeconds,
 
-        @Schema(description = "진도율", example = "100")
+        @Schema(description = "현재 챕터 진도율", example = "100")
         int progressRate,
 
-        @Schema(description = "챕터 학습 완료 여부", example = "true")
+        @Schema(description = "현재 챕터 학습 완료 여부", example = "true")
         boolean completed,
+
+        @Schema(description = "다음 챕터 ID. 마지막 챕터면 null", example = "2")
+        Long nextChapterId,
+
+        @Schema(description = "다음 챕터 잠금 해제 여부", example = "true")
+        boolean nextChapterUnlocked,
+
+        @Schema(description = "강의 전체 진도율", example = "60")
+        int courseProgressRate,
+
+        @Schema(description = "퀴즈 응시 가능 여부", example = "false")
+        boolean quizAvailable,
 
         @Schema(description = "진도율 반영 후 최신 강의장 상태")
         CourseClassroomResponse classroom
@@ -38,6 +50,10 @@ public record LearningProgressResponse(
                 learningProgress.watchedSeconds(),
                 learningProgress.progressRate(),
                 learningProgress.completed(),
+                learningProgress.nextChapterId(),
+                learningProgress.nextChapterUnlocked(),
+                learningProgress.courseProgressRate(),
+                learningProgress.quizAvailable(),
                 CourseClassroomResponse.from(learningProgress.classroom())
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/lms/presentation/response/QuizSubmissionResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/lms/presentation/response/QuizSubmissionResponse.java
@@ -1,0 +1,43 @@
+package com.kidmily.algoga_server.lms.presentation.response;
+
+import com.kidmily.algoga_server.lms.application.result.QuizSubmissionResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "퀴즈 제출 결과 조회 응답")
+public record QuizSubmissionResponse(
+
+        @Schema(description = "퀴즈 제출 결과 ID", example = "1")
+        Long submissionId,
+
+        @Schema(description = "사용자 ID", example = "2")
+        Long userId,
+
+        @Schema(description = "강의 ID", example = "53")
+        Long courseId,
+
+        @Schema(description = "전체 문제 수", example = "5")
+        int totalCount,
+
+        @Schema(description = "정답 개수", example = "4")
+        int correctCount,
+
+        @Schema(description = "점수", example = "80")
+        int score,
+
+        @Schema(description = "제출 일시", example = "2026-06-24T13:30:00")
+        LocalDateTime submittedAt
+) {
+    public static QuizSubmissionResponse from(QuizSubmissionResult result) {
+        return new QuizSubmissionResponse(
+                result.submissionId(),
+                result.userId(),
+                result.courseId(),
+                result.totalCount(),
+                result.correctCount(),
+                result.score(),
+                result.submittedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 설명
<!-- 이번 PR에서 구현한 주요 내용이나 변경 사항을 간략하게 적어주세요. -->
강의 학습/보상/조회 흐름에서 프론트 연동 중 발견된 문제들을 수정했습니다.
삭제된 강의여도 기존 수강자는 유효기간 내 학습 기능을 계속 사용할 수 있도록 처리
강의 학습 진도 저장 후 최신 강의장 상태를 함께 응답하도록 개선
챕터 완료 시 다음 챕터 활성화 상태가 즉시 반영되도록 응답 JSON 확장
퀴즈 조회/제출/결과 조회 API의 로그인 필수 처리를 401로 정리
퀴즈 제출 완료 시 강의 수료 처리 및 보상 자동 지급 이벤트 발행 흐름 연결
수료 후 보상 실패 건은 스케줄러가 재시도하고, 재시도 초과 시 관리자 확인 대상으로 남도록 처리
내 강의 목록, 진단평가 내역 등 마이페이지성 조회 API에 페이지네이션 적용
진단평가 결과 조회 응답에 나라명 포함
관리자 강의 목록에 국가 ID/나라명 필터 추가
삭제된 강의 관리자 조회 API 추가
Q&A/후기 작성자 정보 응답을 사용자/관리자 구분에 맞게 정리
수료증 PDF 응답이 Swagger/프론트에서 파일로 받을 수 있도록 수정
## 🔗 Issue
Closes #362 

---

## 확인할 사항
<!-- 리뷰어가 중점적으로 확인해야 하는 부분이나 테스트 방법을 적어주세요. -->

- [ ] 삭제된 강의를 기존 수강자가 유효기간 내 강의장/진도/퀴즈/수료증/Q&A/후기 기능으로 접근할 수 있는지 확인
- [ ] 챕터 진도율 100% 저장 후 새로고침 없이 다음 챕터 활성화 정보가 응답에 포함되는지 확인
- [ ] 퀴즈 제출 성공 시 수료 처리와 보상 자동 지급이 함께 동작하는지 확인
- [ ] 보상 실패 건이 스케줄러 재시도 후 관리자 실패 목록에서 조회되는지 확인
- [ ] 내 강의 목록/진단평가 내역 페이지네이션 응답 구조 확인
- [ ] 관리자 강의 목록에서 countryId, countryName 필터가 동작하는지 확인
- [ ] 수료증 PDF 다운로드 응답이 정상적으로 내려오는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 진단평가 결과와 퀴즈 제출 결과를 페이지 단위로 조회할 수 있게 되었습니다.
  * 내 수강 목록도 페이지네이션으로 제공되며, 수료증 다운로드가 PDF 형태로 개선되었습니다.
  * 강의 목록에서 국가별 필터와 삭제된 강의 조회가 추가되었습니다.

* **Bug Fixes**
  * 학습 진도, 강의 완료, 리뷰/퀴즈 관련 흐름에서 로그인 필요 처리가 더 일관되게 적용됩니다.
  * 보상 처리와 재시도 실패 관리가 더 안정적으로 동작하도록 개선되었습니다.

* **Refactor**
  * 진단, 학습, 강의, 퀴즈 응답에 진행 상태와 국가 정보가 더 풍부하게 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->