### PR TITLE
1대1 채팅방 이름, 유저 프로필 수정

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/chat/application/port/UserPort.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/application/port/UserPort.java
@@ -4,5 +4,6 @@ import java.util.Optional;
 
 public interface UserPort {
     String getNickname(Long userId);
+    String getProfileImageUrl(Long userId);
     Optional<Long> findUserIdById(Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/chat/application/service/ChatService.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/application/service/ChatService.java
@@ -40,11 +40,14 @@ public class ChatService implements ChatUseCase {
         userPort.findUserIdById(command.targetUserId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_USER_NOT_FOUND));
 
+        String partnerNickname = userPort.getNickname(command.targetUserId());
+        String partnerProfile = userPort.getProfileImageUrl(command.targetUserId());
+
         return chatRoomMemberRepository
                 .findDirectRoomIdByUserIds(command.requesterId(), command.targetUserId())
                 .flatMap(chatRoomRepository::findById)
-                .map(room -> ChatRoomResponse.of(room, null, null, 0))
-                .orElseGet(() -> ChatRoomResponse.of(createNewRoom(command), null, null, 0));
+                .map(room -> ChatRoomResponse.of(room, partnerNickname, partnerProfile, null, null, 0))
+                .orElseGet(() -> ChatRoomResponse.of(createNewRoom(command), partnerNickname, partnerProfile, null, null, 0));
     }
 
     @Override
@@ -54,13 +57,32 @@ public class ChatService implements ChatUseCase {
 
         return chatRoomMemberRepository.findByUserId(userId).stream()
                 .map(member -> chatRoomRepository.findById(member.getRoomId()))
-                .filter(java.util.Optional::isPresent)
-                .map(java.util.Optional::get)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .map(room -> {
                     Optional<ChatMessage> lastMsg = chatMessageRepository.findLastByRoomId(room.getId());
                     int unreadCount = (int) chatMessageReadRepository.countUnreadByRoomIdAndUserId(room.getId(), userId);
+
+                    String displayName = room.getRoomName();
+                    String profileImageUrl = null;
+
+                    // 1:1 채팅방은 "나 아닌 상대방"의 닉네임/프로필을 동적으로 표시
+                    if (room.getType() == ChatRoomType.DIRECT) {
+                        Long partnerId = chatRoomMemberRepository.findByRoomId(room.getId()).stream()
+                                .map(ChatRoomMember::getUserId)
+                                .filter(id -> !id.equals(userId))
+                                .findFirst()
+                                .orElse(null);
+                        if (partnerId != null) {
+                            displayName = userPort.getNickname(partnerId);
+                            profileImageUrl = userPort.getProfileImageUrl(partnerId);
+                        }
+                    }
+
                     return ChatRoomResponse.of(
                             room,
+                            displayName,
+                            profileImageUrl,
                             lastMsg.map(ChatMessage::getContent).orElse(null),
                             lastMsg.map(ChatMessage::getCreatedAt).orElse(null),
                             unreadCount
@@ -69,17 +91,9 @@ public class ChatService implements ChatUseCase {
                 .toList();
     }
 
-    private ChatRoom createNewRoom(CreateChatRoomCommand command) {
-        String roomName = userPort.getNickname(command.targetUserId());
-        ChatRoom newRoom = chatRoomRepository.save(ChatRoom.create(ChatRoomType.DIRECT, roomName, 1));
-        chatRoomMemberRepository.save(ChatRoomMember.create(newRoom.getId(), command.requesterId()));
-        chatRoomMemberRepository.save(ChatRoomMember.create(newRoom.getId(), command.targetUserId()));
-        return newRoom;
-    }
-
     @Override
     @Transactional
-    public ChatMessage sendMessage(SendChatMessageCommand command) {
+    public ChatMessageResponse sendMessage(SendChatMessageCommand command) {
         chatRoomMemberRepository.findByRoomIdAndUserId(command.roomId(), command.senderId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_NOT_MEMBER));
 
@@ -94,7 +108,15 @@ public class ChatService implements ChatUseCase {
                 .toList();
         chatMessageReadRepository.saveAll(reads);
 
-        return message;
+        // 방금 생성된 미읽음 레코드 수 = 안 읽은 사람 수 (실시간 브로드캐스트용 정확한 값)
+        int unreadCount = reads.size();
+
+        return ChatMessageResponse.of(
+                message,
+                userPort.getNickname(command.senderId()),
+                userPort.getProfileImageUrl(command.senderId()),
+                unreadCount
+        );
     }
 
     @Override
@@ -114,11 +136,16 @@ public class ChatService implements ChatUseCase {
 
         chatMessageReadRepository.markAllAsRead(roomId, userId);
 
+        java.util.Map<Long, String> nameCache = new java.util.HashMap<>();
+        java.util.Map<Long, String> profileCache = new java.util.HashMap<>();
+
         return chatMessageRepository.findByRoomIdOrderByCreatedAtDesc(roomId).stream()
                 .map(message -> {
-                    int unreadCount = (int) chatMessageReadRepository
-                            .countUnreadByMessageId(message.getId());
-                    return ChatMessageResponse.of(message, unreadCount);
+                    Long sid = message.getSenderId();
+                    String nickname = nameCache.computeIfAbsent(sid, userPort::getNickname);
+                    String profile = profileCache.computeIfAbsent(sid, userPort::getProfileImageUrl);
+                    int unreadCount = (int) chatMessageReadRepository.countUnreadByMessageId(message.getId());
+                    return ChatMessageResponse.of(message, nickname, profile, unreadCount);
                 })
                 .toList();
     }
@@ -142,7 +169,7 @@ public class ChatService implements ChatUseCase {
                 chatRoomMemberRepository.save(ChatRoomMember.create(chatRoom.getId(), targetUserId))
         );
 
-        return ChatRoomResponse.of(chatRoom, null, null, 0);
+        return ChatRoomResponse.of(chatRoom, command.roomName(), null, null, null, 0);
     }
 
     @Override
@@ -159,5 +186,13 @@ public class ChatService implements ChatUseCase {
         if (chatRoomMemberRepository.countByRoomId(roomId) == 0) {
             chatRoomRepository.softDelete(roomId);
         }
+    }
+
+    private ChatRoom createNewRoom(CreateChatRoomCommand command) {
+        String roomName = userPort.getNickname(command.targetUserId());
+        ChatRoom newRoom = chatRoomRepository.save(ChatRoom.create(ChatRoomType.DIRECT, roomName, 1));
+        chatRoomMemberRepository.save(ChatRoomMember.create(newRoom.getId(), command.requesterId()));
+        chatRoomMemberRepository.save(ChatRoomMember.create(newRoom.getId(), command.targetUserId()));
+        return newRoom;
     }
 }

--- a/src/main/java/com/kidmily/algoga_server/chat/application/usecase/ChatUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/application/usecase/ChatUseCase.java
@@ -14,7 +14,7 @@ public interface ChatUseCase {
 
     ChatRoomResponse getOrCreateRoom(CreateChatRoomCommand command);
     List<ChatMessageResponse> getMessages(Long roomId, Long userId);
-    ChatMessage sendMessage(SendChatMessageCommand command);
+    ChatMessageResponse sendMessage(SendChatMessageCommand command);
     void markAsRead(Long roomId, Long userId);
     List<ChatRoomResponse> getRooms(Long userId);
     ChatRoomResponse createGroupRoom(CreateGroupChatRoomCommand command);

--- a/src/main/java/com/kidmily/algoga_server/chat/infrastructure/persistence/adapter/UserPortAdapter.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/infrastructure/persistence/adapter/UserPortAdapter.java
@@ -25,4 +25,11 @@ public class UserPortAdapter implements UserPort {
     public Optional<Long> findUserIdById(Long userId) {
         return userRepository.findById(userId).map(User::getId);
     }
+
+    @Override
+    public String getProfileImageUrl(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::getProfileImageUrl)
+                .orElse(null);
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/chat/presentation/ChatMessageHandler.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/presentation/ChatMessageHandler.java
@@ -2,7 +2,6 @@ package com.kidmily.algoga_server.chat.presentation;
 
 import com.kidmily.algoga_server.chat.application.command.SendChatMessageCommand;
 import com.kidmily.algoga_server.chat.application.usecase.ChatUseCase;
-import com.kidmily.algoga_server.chat.domain.model.ChatMessage;
 import com.kidmily.algoga_server.chat.presentation.api.response.ChatMessageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,16 +27,12 @@ public class ChatMessageHandler {
                             SimpMessageHeaderAccessor headerAccessor) {
         Long senderId = (Long) headerAccessor.getSessionAttributes().get("userId");
 
-        ChatMessage message = chatUseCase.sendMessage(
+        ChatMessageResponse response = chatUseCase.sendMessage(
                 new SendChatMessageCommand(roomId, senderId, payload.content())
         );
 
-        // 해당 방 구독자 전체에게 브로드캐스트
-        // 클라이언트 구독: /topic/chat/rooms/{roomId}
-        messagingTemplate.convertAndSend(
-                "/topic/chat/rooms/" + roomId,
-                ChatMessageResponse.of(message, 0)
-        );
+        // 해당 방 구독자 전체에게 브로드캐스트 (발신자 정보 + unreadCount 포함)
+        messagingTemplate.convertAndSend("/topic/chat/rooms/" + roomId, response);
     }
 
     // 클라이언트: STOMP SEND /app/chat/rooms/{roomId}/read

--- a/src/main/java/com/kidmily/algoga_server/chat/presentation/api/response/ChatMessageResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/presentation/api/response/ChatMessageResponse.java
@@ -17,6 +17,12 @@ public record ChatMessageResponse(
         @Schema(description = "발신자 유저 ID", example = "1")
         Long senderId,
 
+        @Schema(description = "발신자 닉네임", example = "홍길동")
+        String senderNickname,
+
+        @Schema(description = "발신자 프로필 이미지 URL")
+        String senderProfileImageUrl,
+
         @Schema(description = "메시지 내용", example = "안녕하세요!")
         String content,
 
@@ -26,9 +32,11 @@ public record ChatMessageResponse(
         @Schema(description = "메시지 전송 시각")
         LocalDateTime createdAt
 ) {
-    public static ChatMessageResponse of(ChatMessage message, int unreadCount) {
+    public static ChatMessageResponse of(ChatMessage message, String senderNickname,
+                                         String senderProfileImageUrl, int unreadCount) {
         return new ChatMessageResponse(
                 message.getId(), message.getRoomId(), message.getSenderId(),
+                senderNickname, senderProfileImageUrl,
                 message.getContent(), unreadCount, message.getCreatedAt()
         );
     }

--- a/src/main/java/com/kidmily/algoga_server/chat/presentation/api/response/ChatRoomResponse.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/presentation/api/response/ChatRoomResponse.java
@@ -21,6 +21,9 @@ public record ChatRoomResponse(
         @Schema(description = "채팅방 이름")
         String roomName,
 
+        @Schema(description = "채팅방 프로필 이미지 (1:1은 상대방 프로필)")
+        String profileImageUrl,
+
         @Schema(description = "마지막 메시지 내용")
         String lastMessage,
 
@@ -34,21 +37,17 @@ public record ChatRoomResponse(
 ) {
     public static ChatRoomResponse from(ChatRoom chatRoom) {
         return new ChatRoomResponse(
-                chatRoom.getId(),
-                chatRoom.getType(),
-                chatRoom.getCreatedAt(),
-                chatRoom.getRoomName(),
-                null,
-                null,
-                0
+                chatRoom.getId(), chatRoom.getType(), chatRoom.getCreatedAt(),
+                chatRoom.getRoomName(), null, null, null, 0
         );
     }
 
-    public static ChatRoomResponse of(ChatRoom room, String lastMessage,
-                                      LocalDateTime lastMessageAt, int unreadCount) {
+    public static ChatRoomResponse of(ChatRoom room, String roomName, String profileImageUrl,
+                                      String lastMessage, LocalDateTime lastMessageAt, int unreadCount) {
         return new ChatRoomResponse(
                 room.getId(), room.getType(), room.getCreatedAt(),
-                room.getRoomName(), lastMessage, lastMessageAt, unreadCount
+                roomName, profileImageUrl, lastMessage, lastMessageAt, unreadCount
         );
     }
+
 }


### PR DESCRIPTION
채팅 API 응답 개선 — 프론트 연동에 필요한 발신자 정보 및 채팅방 프로필 추가

ChatMessageResponse에 senderNickname, senderProfileImageUrl 필드 추가
ChatRoomResponse에 profileImageUrl 필드 추가
1:1 채팅방 목록 조회 시 roomName을 DB 고정값이 아닌 조회 시점 기준 상대방 닉네임으로 동적 반환
1:1 채팅방 목록 조회 시 상대방 프로필 이미지 반환
그룹 채팅방 메시지 조회 시 각 발신자 닉네임/프로필 반환
WebSocket 실시간 메시지 브로드캐스트에 발신자 정보 및 정확한 unreadCount 포함

🔗 Issue
Closes [#360](https://github.com/kid-mily/Algoga-backend/issues/360)

확인할 사항
- [ ] GET /api/v1/chat/rooms — 1:1 채팅방의 roomName이 상대방 닉네임으로 표시되는지 확인
- [ ] GET /api/v1/chat/rooms — 1:1 채팅방의 profileImageUrl이 상대방 프로필로 반환되는지 확인
- [ ] GET /api/v1/chat/rooms — A가 조회하면 B 닉네임, B가 조회하면 A 닉네임으로 각각 다르게 표시되는지 확인
- [ ] GET /api/v1/chat/rooms/{roomId}/messages — 각 메시지에 senderNickname, senderProfileImageUrl 포함 여부 확인
- [ ] WebSocket 실시간 메시지 수신 시 발신자 정보 및 unreadCount 정상 반환 여부 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 채팅방과 메시지 응답에 상대/발신자 닉네임과 프로필 이미지가 표시되도록 개선되었습니다.
  * 메시지 전송 및 조회 결과에 읽지 않은 메시지 수가 포함됩니다.
  * 채팅방 목록과 1:1 채팅방 생성 시 방 이름과 프로필 정보가 더 정확하게 반영됩니다.

* **Bug Fixes**
  * 메시지 전송 후 브로드캐스트되는 응답 형식이 통일되어, 화면 표시가 더 일관되게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->