### PR TITLE
채팅 API 응답 개선 및 WebSocket 쿠키 인증 전환

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/global/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/kidmily/algoga_server/global/websocket/JwtHandshakeInterceptor.java
@@ -1,14 +1,16 @@
 package com.kidmily.algoga_server.global.websocket;
 
 import com.kidmily.algoga_server.global.security.GlobalJwtProvider;
-import com.kidmily.algoga_server.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import jakarta.servlet.http.Cookie;
+
 
 import java.util.Map;
 
@@ -23,13 +25,11 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                    WebSocketHandler wsHandler, Map<String, Object> attributes) {
-        String query = request.getURI().getQuery();
-        if (query == null || !query.contains("token=")) {
+        String token = resolveTokenFromCookie(request);   // 쿼리 → 쿠키로 변경
+        if (token == null) {
             log.warn("[WebSocket] 핸드셰이크 토큰 없음");
             return false;
         }
-
-        String token = query.substring(query.indexOf("token=") + 6);
         try {
             if (!jwtProvider.validateToken(token)) {
                 log.warn("[WebSocket] 핸드셰이크 토큰 유효하지 않음");
@@ -47,6 +47,20 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
             log.warn("[WebSocket] 핸드셰이크 실패: {}", e.getMessage());
             return false;
         }
+    }
+
+    private String resolveTokenFromCookie(ServerHttpRequest request) {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            Cookie[] cookies = servletRequest.getServletRequest().getCookies();
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    if ("accessToken".equals(cookie.getName())) {
+                        return cookie.getValue();
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## 설명
- ChatMessageResponse에 senderNickname, senderProfileImageUrl 추가
- ChatRoomResponse에 profileImageUrl 추가
- 1:1 채팅방 roomName 동적 반환 (조회 시점 상대방 닉네임)
- WebSocket 실시간 메시지에 발신자 정보 및 정확한 unreadCount 포함
- JwtHandshakeInterceptor 쿠키 기반 인증으로 전환 (?token= 제거)

## 🔗 Issue
Closes #

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket 연결 시 인증 토큰을 URL이 아닌 `accessToken` 쿠키에서 읽도록 변경했습니다.
  * 토큰이 없으면 핸드셰이크를 즉시 거부해, 인증되지 않은 연결을 더 명확하게 차단합니다.
  * 기존 토큰 검증, 사용자 식별, 연결 정보 저장 흐름은 유지되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->