### PR TITLE
채팅 실시간 개인 알림 채널 추가

### DIFF
--- a/src/main/java/com/kidmily/algoga_server/chat/application/service/ChatService.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/application/service/ChatService.java
@@ -195,4 +195,18 @@ public class ChatService implements ChatUseCase {
         chatRoomMemberRepository.save(ChatRoomMember.create(newRoom.getId(), command.targetUserId()));
         return newRoom;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Long> getRoomMemberIds(Long roomId) {
+        return chatRoomMemberRepository.findByRoomId(roomId).stream()
+                .map(ChatRoomMember::getUserId)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int getUnreadCount(Long roomId, Long userId) {
+        return (int) chatMessageReadRepository.countUnreadByRoomIdAndUserId(roomId, userId);
+    }
 }

--- a/src/main/java/com/kidmily/algoga_server/chat/application/usecase/ChatUseCase.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/application/usecase/ChatUseCase.java
@@ -19,4 +19,6 @@ public interface ChatUseCase {
     List<ChatRoomResponse> getRooms(Long userId);
     ChatRoomResponse createGroupRoom(CreateGroupChatRoomCommand command);
     void leaveRoom(Long roomId, Long userId);
+    List<Long> getRoomMemberIds(Long roomId);
+    int getUnreadCount(Long roomId, Long userId);
 }

--- a/src/main/java/com/kidmily/algoga_server/chat/presentation/ChatMessageHandler.java
+++ b/src/main/java/com/kidmily/algoga_server/chat/presentation/ChatMessageHandler.java
@@ -12,6 +12,8 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Controller
 @RequiredArgsConstructor
@@ -31,8 +33,20 @@ public class ChatMessageHandler {
                 new SendChatMessageCommand(roomId, senderId, payload.content())
         );
 
-        // 해당 방 구독자 전체에게 브로드캐스트 (발신자 정보 + unreadCount 포함)
+        // 1) 방 구독자 전체에게 메시지 브로드캐스트 (기존)
         messagingTemplate.convertAndSend("/topic/chat/rooms/" + roomId, response);
+
+        // 2) 방 멤버 각자의 개인 채널로 목록 갱신 알림 (발신자 제외)
+        chatUseCase.getRoomMemberIds(roomId).stream()
+                .filter(memberId -> !memberId.equals(senderId))
+                .forEach(memberId -> {
+                    int unreadCount = chatUseCase.getUnreadCount(roomId, memberId);
+                    log.info("[ChatHandler] 개인 알림 전송 - userId: {}, roomId: {}", memberId, roomId);
+                    messagingTemplate.convertAndSend(
+                            "/topic/users/" + memberId,
+                            new RoomNotification(roomId, response.content(), response.createdAt(), unreadCount)
+                    );
+                });
     }
 
     // 클라이언트: STOMP SEND /app/chat/rooms/{roomId}/read
@@ -52,4 +66,6 @@ public class ChatMessageHandler {
 
     public record SendMessagePayload(String content) {}
     public record ReadEventPayload(Long roomId, Long readerId) {}
+    public record RoomNotification(Long roomId, String lastMessage,
+                                   LocalDateTime lastMessageAt, int unreadCount) {}
 }


### PR DESCRIPTION
채팅 실시간 개인 알림 채널 추가

메시지 전송 시 방 멤버 개인 채널(/topic/users/{userId})로 목록 갱신 알림 브로드캐스트
RoomNotification(roomId, lastMessage, lastMessageAt, unreadCount) payload 추가
프론트에서 /topic/users/{userId} 구독 시 채팅방 목록 실시간 갱신 가능
🔗 Issue
Closes [#371](https://github.com/kid-mily/Algoga-backend/issues/371)

확인할 사항
미완료
메시지 전송 시 서버 로그에 [ChatHandler] 개인 알림 전송 - userId: {id}, roomId: {id} 가 발신자 제외 멤버 수만큼 찍히는지 확인
미완료
/topic/users/{userId} 구독 후 메시지 수신 시 {"roomId": ..., "lastMessage": ..., "lastMessageAt": ..., "unreadCount": ...} 형태로 수신되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 채팅방에 새 메시지가 오면, 방 전체 알림과 함께 각 멤버에게 개인 알림이 전송됩니다.
  * 개인 알림에 최신 메시지, 전송 시각, 읽지 않은 메시지 수가 포함됩니다.
* **기능 개선**
  * 채팅방 멤버 목록과 사용자별 읽지 않은 메시지 수를 확인할 수 있는 조회 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->